### PR TITLE
Add nonce to the form on Seravo update setting page

### DIFF
--- a/lib/updates-page.php
+++ b/lib/updates-page.php
@@ -46,6 +46,7 @@ if ($site_data['seravo_updates'] == true) {
   <p>Seravo's upkeep service includes that your WordPress site is kept up-to-date with quick security updates and regular tested updates of both WordPress core and plugins. If you want full control of updates yourself, you can opt-out from Seravo updates.</p>
 
   <form name="toggle_seravo_updates" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" method="post">
+    <?php wp_nonce_field( 'toggle-seravo-updates-on-or-off' ); ?>
     <input type="hidden" name="action" value="toggle_seravo_updates">
     <input id="seravo_updates" name="seravo_updates" type="checkbox" <?php echo $checked; ?>> Seravo updates enabled<br><br>
     <input type="submit" value="Save settings">

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -33,6 +33,8 @@ if (!class_exists('Updates')) {
     }
 
     public static function seravo_admin_toggle_seravo_updates() {
+      check_admin_referer( 'toggle-seravo-updates-on-or-off' );
+
       $site = getenv('USER');
       $ch = curl_init('http://localhost:8888/v1/site/' . $site);
 


### PR DESCRIPTION
This is a standard security procedure to reduce risk of url abuse.
The form now has a nonce field which is checked by the backend.