### PR TITLE
Use vanilla DOMContentLoaded

### DIFF
--- a/js/instance-switcher.js
+++ b/js/instance-switcher.js
@@ -1,4 +1,4 @@
-jQuery(document).ready(function($){
+document.addEventListener('DOMContentLoaded', function() {
     var links = document.querySelectorAll('#wp-admin-bar-instance-switcher li > a');
     var listener = function(e){
     e.preventDefault();


### PR DESCRIPTION
You're not even using jQuery, might as well remove the dependency for it?

We remove jQuery from the client side of themes when we're not using it, which is most of the time nowadays, since it's not 2006 anymore. 