### PR TITLE
Fix the error when opening docs link 

### DIFF
--- a/js/instance-switcher.js
+++ b/js/instance-switcher.js
@@ -1,12 +1,13 @@
 document.addEventListener('DOMContentLoaded', function() {
     var links = document.querySelectorAll('#wp-admin-bar-instance-switcher li > a');
     var listener = function(e){
-    e.preventDefault();
     var instance = e.target.getAttribute('href').substr(1);
     if (instance === 'exit') {
+      e.preventDefault();
       document.cookie = "wpp_shadow=;path=/";
       document.cookie = "seravo_shadow=;path=/";
-    } else {
+    } else if (instance.length === 6){
+      e.preventDefault();
       document.cookie = "wpp_shadow=" + instance + ";path=/";
       document.cookie = "seravo_shadow=" + instance + ";path=/";
     }


### PR DESCRIPTION
Fixes #47 .

As it is documented in instance-switcher.php:140, the last item in the admin bar's instance switcher menu is always the docs link. The loop can be stopped before the link. 