### PR TITLE
Remove the permission check from instance switcher (Closes #55)

### DIFF
--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -83,11 +83,6 @@ if ( ! class_exists('InstanceSwitcher') ) {
         return;
       }
 
-      // check permissions
-      if ( ! current_user_can( 'activate_plugins' ) ) {
-        return;
-      }
-
       $id = 'instance-switcher';
       $menuclass = '';
 


### PR DESCRIPTION
If the permissions are not checked inside instance-switcher, users can run instance-switcher from somewhere else with their own permissions.