### PR TITLE
Disable Seravo image optimisation by default

### DIFF
--- a/modules/optimize-images.php
+++ b/modules/optimize-images.php
@@ -56,7 +56,7 @@ if ( ! class_exists('Optimize_images') ) {
                 update_option( 'seravo-image-max-resolution-height', self::$max_height_default );
             }
             if ( get_option( 'seravo-enable-optimize-images' ) === false ) {
-                update_option( 'seravo-enable-optimize-images', 'on' );
+                update_option( 'seravo-enable-optimize-images', '' );
             }
         }
 


### PR DESCRIPTION
For the optimize-images page to work properly, the option `seravo-enable-optimize-images` must exist in the database. However, it is not advisable to enable Seravo image optimisation as a default for customers when creating the option.