### PR TITLE
Add shadow query string to link if in shadow

### DIFF
--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -91,12 +91,18 @@ if ( ! class_exists('InstanceSwitcher') ) {
       }
 
       $current_title = strtoupper(getenv('WP_ENV'));
+      $current_url = "//{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
+      if (strpos($current_url, '?') > -1) {
+        $current_url .= '&';
+      } else {
+        $current_url .= '?';
+      }
 
       // create the parent menu here
       $wp_admin_bar->add_menu([
           'id' => $id,
           'title' => __('Now in', 'seravo') . ': ' . $current_title,
-          'href' => '#',
+          'href' => !empty($_COOKIE['wpp_shadow']) ? $current_url . 'wpp_shadow=' . $_COOKIE['wpp_shadow'] : '#'
           'meta' => [
           'class' => $menuclass,
           ],

--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -102,7 +102,7 @@ if ( ! class_exists('InstanceSwitcher') ) {
       $wp_admin_bar->add_menu([
           'id' => $id,
           'title' => __('Now in', 'seravo') . ': ' . $current_title,
-          'href' => !empty($_COOKIE['wpp_shadow']) ? $current_url . 'wpp_shadow=' . $_COOKIE['wpp_shadow'] : '#'
+          'href' => !empty($_COOKIE['wpp_shadow']) ? $current_url . 'wpp_shadow=' . $_COOKIE['wpp_shadow'] : '#',
           'meta' => [
           'class' => $menuclass,
           ],


### PR DESCRIPTION
When working in a staging environment, I often have to link to a page inside that environment, but that is surprisingly hard, I have to remember what the query param was, get the instance ID from somewhere, and so on. 

With this, I can just click the big red button, and copy the URL from my browser, or if I'm tech savvy, I can right click the link and copy the address.

Tested and "developed" live @ wp-palvelu.fi instance.