### PR TITLE
Add undefined variable

### DIFF
--- a/modules/check-https.php
+++ b/modules/check-https.php
@@ -25,7 +25,7 @@ if ( ! class_exists('CheckHttps') ) {
         }
 
         public static  function _seravo_show_https_warning() {
-?>
+            $siteurl = get_option('siteurl'); ?>
             <div class="notice notice-error"><p>
 <?php
 printf(


### PR DESCRIPTION
Fixes Undefined variable: siteurl in some cases. 

Ran into this on a multisite that doesn't require HTTPS using Seravo/wordpress.