### PR TITLE
Include separate module for making site API requests (Closes #77)

### DIFF
--- a/lib/api.php
+++ b/lib/api.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Description: File for accessing and modifying site-related data.
+ */
+
+namespace Seravo;
+
+ // Deny direct access
+ if ( ! defined('ABSPATH') ) {
+   die('Access denied!');
+ }
+
+ if ( ! class_exists('API') ) {
+
+   class API {
+
+     /**
+      * Get various data from the site API for the current site.
+      */
+     public static function get_site_data( $api_query = '' ) {
+       $site = getenv('USER');
+       $ch = curl_init('http://localhost:8888/v1/site/' . $site . $api_query );
+       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+       curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'X-Api-Key: ' . getenv('SERAVO_API_KEY') ));
+       $response = curl_exec($ch);
+       $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+       // Check for errors
+       if ( curl_error($ch) || $httpcode !== 200 ) {
+         error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
+         curl_close($ch);
+         return new WP_Error('seravo-api-get-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+       }
+
+       curl_close($ch);
+       $data = json_decode($response, true);
+       return $data;
+     }
+
+     public static function update_site_data( $data, $api_query = '' ) {
+       $data_json = json_encode($data);
+       $site = getenv('USER');
+       $ch = curl_init('http://localhost:8888/v1/site/' . $site . $api_query);
+
+       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+       curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+       curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+           'X-Api-Key: ' . getenv('SERAVO_API_KEY'),
+           'Content-Type: application/json',
+           'Content-Length: ' . strlen($data_json),
+       ));
+       curl_setopt($ch, CURLOPT_POSTFIELDS, $data_json);
+
+       $response = curl_exec($ch);
+       $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+       // Check for errors
+       if ( curl_error($ch) || $httpcode !== 200 ) {
+         error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
+         curl_close($ch);
+         return new WP_Error('seravo-api-put-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+       }
+
+       return $response;
+     }
+   }
+ }
+ ?>

--- a/lib/domains-dns.php
+++ b/lib/domains-dns.php
@@ -1,4 +1,6 @@
 <?php
+require_once dirname( __FILE__ ) . '/../lib/api.php';
+
 class Seravo_Domains_DNS_Table {
 
   function __construct() {
@@ -38,24 +40,13 @@ class Seravo_Domains_DNS_Table {
   }
 
   function fetch_dns_records( $url ) {
-    $site = getenv('USER');
-
-    $ch = curl_init('http://localhost:8888/v1/site/' . $site . '/domain/' . $url . '/zone');
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'X-Api-Key: ' . getenv('SERAVO_API_KEY') ));
-    $response = curl_exec($ch);
-    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-    if ( curl_error($ch) || $httpcode !== 200 ) {
-      error_log('SWD API (domains) error ' . $httpcode . ': ' . curl_error($ch));
-      echo '<b>' . $url . '</b><br>';
-      die(__('API call failed. Aborting. The error has been logged.', 'seravo'));
+    $api_query = '/domain/' . $url . '/zone';
+    $records = Seravo\API::get_site_data($api_query);
+    if ( is_wp_error($records) ) {
+      die($records->get_error_message());
     }
 
-    curl_close($ch);
-
-    $data = json_decode($response, true);
-    $this->records = $data;
+    $this->records = $records;
   }
 
 }

--- a/lib/domains-page.php
+++ b/lib/domains-page.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once dirname( __FILE__ ) . '/../lib/api.php';
+
 if ( ! current_user_can( 'level_10' ) ) {
   wp_die(
       '<h1>' . __( 'Cheatin&#8217; uh?' ) . '</h1>' .
@@ -126,23 +128,11 @@ class Seravo_Domains_List_Table extends WP_List_Table {
     $this->process_bulk_action();
 
     // Fetch list of domains
-
-    $site = getenv('USER');
-
-    $ch = curl_init('http://localhost:8888/v1/site/' . $site . '/domains');
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'X-Api-Key: ' . getenv('SERAVO_API_KEY') ));
-    $response = curl_exec($ch);
-    $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-    if ( curl_error($ch) || $httpcode !== 200 ) {
-      error_log('SWD API (domains) error ' . $httpcode . ': ' . curl_error($ch));
-      die(__('API call failed. Aborting. The error has been logged.', 'seravo'));
+    $api_query = '/domains';
+    $data = Seravo\API::get_site_data($api_query);
+    if ( is_wp_error($data) ) {
+      die($data->get_error_message());
     }
-
-    curl_close($ch);
-
-    $data = json_decode($response, true);
 
     /**
      * This checks for sorting input and sorts the data in our array accordingly.

--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -63,21 +63,12 @@ if ( ! class_exists('InstanceSwitcher') ) {
       }
 
       if ( ( $shadow_list = get_transient( 'shadow_list' ) ) === false ) {
-        $site = getenv('USER');
-        $ch = curl_init('http://localhost:8888/v1/site/' . $site . '/shadows');
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'X-Api-Key: ' . getenv('SERAVO_API_KEY') ));
-        $response = curl_exec($ch);
-        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-
-        if ( curl_error($ch) || $httpcode !== 200 ) {
-          error_log('SWD API (shadows) error ' . $httpcode . ': ' . curl_error($ch));
+        $api_query = '/shadows';
+        $shadow_list = API::get_site_data($api_query);
+        if ( is_wp_error($shadow_list) ) {
           return false; // Exit with empty result and let later flow handle it
           // Don't break page load here or everything would be broken.
         }
-
-        curl_close($ch);
-        $shadow_list = json_decode($response, true);
         set_transient( 'shadow_list', $shadow_list, 10 * MINUTE_IN_SECONDS );
       }
 

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -47,7 +47,7 @@ if ( ! class_exists('Updates') ) {
     public static function seravo_admin_toggle_seravo_updates() {
       check_admin_referer( 'seravo-updates-nonce' );
 
-      if ( $_POST['seravo_updates'] === 'on' ) {
+      if ( isset($_POST['seravo_updates']) && $_POST['seravo_updates'] === 'on' ) {
         $seravo_updates = 'true';
       } else {
         $seravo_updates = 'false';


### PR DESCRIPTION
Previously, the request implementations were scattered in different modules,
now the code is reusable by invoking the API module.