### PR TITLE
Fix bug of grouping files with same file extension onto same line

### DIFF
--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -9,9 +9,11 @@ jQuery(document).ready(function($) {
         'deletefile': filepath },
       function( rawData ) {
         var data = JSON.parse(rawData);
-        if ( data.success ) {
-          callback();
-        }
+        data.forEach(fileinfo => {
+          if ( fileinfo.success ) {
+            callback();
+          }
+        });
       });
   }
 

--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -39,30 +39,29 @@ switch ( $_REQUEST['section'] ) {
     $crufts = array();
     foreach ( $list_files as $filename ) {
       $cruft_found = find_cruft_file($filename);
-      if ( $cruft_found != '' ) {
-        array_push($crufts, $cruft_found);
+      if ( !empty($cruft_found) ) {
+        $crufts = array_merge($crufts, $cruft_found);
       }
     }
     foreach ( $list_dirs as $dirname ) {
       $cruft_found = find_cruft_dir($dirname);
-      if ( $cruft_found != '' ) {
-        array_push($crufts, $cruft_found);
+      if ( !empty($cruft_found) ) {
+        $crufts = array_merge($crufts, $cruft_found);
       }
     }
     foreach ( $list_known_files as $dirname ) {
       $cruft_found = list_known_cruft_file($dirname);
-      if ( $cruft_found != '' ) {
-        array_push($crufts, $cruft_found);
+      if ( !empty($cruft_found) ) {
+        $crufts = array_merge($crufts, $cruft_found);
       }
     }
     foreach ( $list_known_dirs as $dirname ) {
       $cruft_found = list_known_cruft_dir($dirname);
-      if ( $cruft_found != '' ) {
-        array_push($crufts, $cruft_found);
+      if ( !empty($cruft_found) ) {
+        $crufts = array_merge($crufts, $cruft_found);
       }
     }
     set_transient('cruft_files_found', $crufts, 600);
-
     echo wp_json_encode($crufts);
     break;
 


### PR DESCRIPTION
Previously the Cruft Files -page did not list multiple files with the same file extension correctly. This lead to situations, where such files could not be deleted.

In this PR files with the same file extension are not stored in an array which is `array_push()`:ed to another array. Rather, each array is merged into one, which also requires changes to `cruftfiles.php`
