### PR TITLE
Update Database-tool layout to wordpress layout

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -1,0 +1,111 @@
+// Search-replace-tool script
+var dryrun_ran = 0;
+// Modified from the original seravo_load_report to handle tables and tsv's
+function seravo_load_sr_report(section, from, to, options) {
+  jQuery.post(
+    ajaxurl, {
+      'action': 'seravo_search_replace',
+      'section': section,
+      'from': from,
+      'to': to,
+      'options': options
+    },
+    function (rawData) {
+      if (rawData.length === 0) {
+        jQuery('#' + section).html('No data returned for section.');
+      }
+      var data = JSON.parse(rawData);
+
+      // Loops through the data array row by row
+      jQuery.each(data, function (i, row) {
+        var tr = jQuery('<tr>');
+        // Loops through the row column by column
+        jQuery.each(row.split('\t'), function (j, col) {
+          if (i === 0) {
+            jQuery('#search_replace_command').append('<code>' + col + '</code>');
+          } else {
+            jQuery('<td>').html(col).appendTo(tr);
+          }
+        })
+        jQuery('#search_replace_loading img').fadeOut();
+        jQuery('#search_replace').append(tr);
+      });
+      jQuery('#sr-button').prop('disabled', false);
+    }
+  ).fail(function () {
+    jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
+  });
+}
+
+// Load when clicked.
+jQuery('.sr-button').click(function () {
+  jQuery('#search_replace_loading img').fadeIn();
+  jQuery('#search_replace').empty();
+  jQuery('#search_replace_command').empty();
+
+  var options = {};
+  if (jQuery(this).attr('id') === "sr-button") {
+    options['dry_run'] = false;
+  } else {
+    options['dry_run'] = true;
+  }
+  jQuery.each(jQuery('.optionbox'), function (i, option) {
+    options[jQuery(option).attr('id')] = jQuery(option).is(':checked');
+  });
+  seravo_load_sr_report('search_replace', jQuery('#sr-from').val(), jQuery('#sr-to').val(), options);
+});
+
+jQuery('#all_tables').click(function () {
+  if (jQuery(this).is(':checked')) {
+    jQuery('#sr-button').prop('disabled', true);
+    jQuery('#skip_backup').prop('checked', false);
+  }
+});
+
+jQuery('#sr-from').keyup(function (event) {
+  jQuery('#sr-button').prop('disabled', true);
+  dryrun_ran = 0;
+});
+
+jQuery(document).ready(function () {
+  jQuery('#sr-button').prop('disabled', true);
+  jQuery('#skip_backup').prop('checked', false);
+})
+
+// Database table sizes script
+// Load db info with ajax because it might take a little while
+function seravo_load_db_info(section) {
+  jQuery.post(
+    ajaxurl, {
+      'action': 'seravo_wp_db_info',
+      'section': section
+    },
+    function (rawData) {
+      if (rawData.length == 0) {
+        jQuery('#' + section).html('No data returned for section.');
+      }
+      var data = JSON.parse(rawData);
+      if (section === 'seravo_wp_db_info') {
+        console.log(data);
+        jQuery('#seravo_wp_db_info').append(data.totals);
+        generateChart(data.tables.dataFolders);
+      } else {
+        console.log(section, data);
+        jQuery('#' + section).text(data.join("\n"));
+      }
+      jQuery('#' + section + '_loading').fadeOut();
+    }).fail(function () {
+    jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
+  });
+}
+
+// Postbox toggle script
+// Load on page load
+seravo_load_db_info('seravo_wp_db_info');
+
+jQuery('.ui-sortable-handle').on('click', function () {
+  jQuery(this).parent().toggleClass("closed");
+});
+jQuery('.toggle-indicator').on('click', function () {
+  jQuery(this).parent().parent().toggleClass("closed");
+});

--- a/js/reports-chart.js
+++ b/js/reports-chart.js
@@ -23,6 +23,8 @@ function generateChart(JSONdata) {
       ]
     },
     options: {
+      maintainAspectRatio: true,
+      resposive: true,
       tooltips: {
         callbacks: {
           label: function (tooltipItem, data) {

--- a/lib/database-page.php
+++ b/lib/database-page.php
@@ -1,206 +1,161 @@
-<div class="wrap">
+<div id="wpbody" role="main">
+  <div id="wpbody-content" aria-label="Main content" tabindex="0">
+    <div class="wrap">
+      <div id="dashboard-widgets" class="metabox-holder">
+        <div class="postbox-container">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!--First postbox: Database access-->
+            <div id="dashboard_right_now" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Database access', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e('Database access', 'seravo'); ?></span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p><?php printf( __( 'You can find the database credentials by connecting with SSH and running command %s. These credentials can be used to connect to server with SSH tunnel. You can also use web-based Adminer below.', 'seravo' ), '<code>wp-list-env</code>' ); ?></p>
+                  <p><?php printf( __( 'When you have SSH connection you can use WP-CLI that has powerful database tools for example exports and imports. <a href="%s">Read wp db docs.</a>', 'seravo' ), 'https://developer.wordpress.org/cli/commands/db/' ); ?></p>
+                </div>
+              </div>
+            </div>
+          <!--First postbox: end-->
 
-<h1><?php _e('Database', 'seravo'); ?> (beta)</h1>
+          <!--Second postbox: Manage database with Adminer-->
+            <div id="dashboard_activity" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Manage database with Adminer', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e('Manage database with Adminer', 'seravo'); ?></span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p><?php printf( __( 'Adminer is a simple database management tool like phpMyAdmin. <a href="$s">Learn more about Adminer.</a>', 'seravo' ), 'https://www.adminer.org' ); ?></p>
+                  <p><?php printf( __( 'Find Adminer in production at %1$s and in local development at %2$s.', 'seravo' ), '<code>sitename.com/.seravo/adminer</code>', '<code>adminer.sitename.local</code>' ); ?></p>
 
-<div class="seravo-section">
-<h2><?php _e('Database access', 'seravo'); ?></h2>
-  <p><?php printf( __( 'You can find the database credentials by connecting with SSH and running command %s. These credentials can be used to connect to server with SSH tunnel. You can also use web-based Adminer below.', 'seravo' ), '<code>wp-list-env</code>' ); ?></p>
-  <p><?php printf( __( 'When you have SSH connection you can use WP-CLI that has powerful database tools for example exports and imports. <a href="%s">Read wp db docs.</a>', 'seravo' ), 'https://developer.wordpress.org/cli/commands/db/' ); ?></p>
-</div>
+                  <?php
 
-<div class="seravo-section">
-<h2><?php _e('Manage database with Adminer', 'seravo'); ?></h2>
-<p><?php printf( __( 'Adminer is a simple database management tool like phpMyAdmin. <a href="$s">Learn more about Adminer.</a>', 'seravo' ), 'https://www.adminer.org' ); ?></p>
-<p><?php printf( __( 'Find Adminer in production at %1$s and in local development at %2$s.', 'seravo' ), '<code>sitename.com/.seravo/adminer</code>', '<code>adminer.sitename.local</code>' ); ?></p>
+                    $adminer_url = '';
+
+                    // TODO: test for multisite
+                    $siteurl = get_site_url();
 
 
-<?php
+                    if ( 'production' === getenv('WP_ENV') ) {
 
-  $adminer_url = '';
+                      // Add trailing slash if missing
+                      if ( substr($siteurl, -1) !== '/' ) {
+                        $siteurl .= '/';
+                      }
 
-  // TODO: test for multisite
-  $siteurl = get_site_url();
+                      $adminer_url = $siteurl . '.seravo/adminer';
 
+                    } else {
 
-  if ( 'production' === getenv('WP_ENV') ) {
+                      // Add trailing slash if missing
+                      if ( substr($siteurl, -1) !== '/' ) {
+                        $siteurl .= '/';
+                      }
 
-    // Add trailing slash if missing
-    if ( substr($siteurl, -1) !== '/' ) {
-      $siteurl .= '/';
-    }
+                      // Inject subdomain
+                      $adminer_url = str_replace('//', '//adminer.', $siteurl);
 
-    $adminer_url = $siteurl . '.seravo/adminer';
+                    }
 
-  } else {
+                  ?>
 
-    // Add trailing slash if missing
-    if ( substr($siteurl, -1) !== '/' ) {
-      $siteurl .= '/';
-    }
+                  <p class="adminer_button"><a href="<?php echo esc_url($adminer_url); ?>" class="button" target="_blank"><?php _e( 'Open Adminer', 'seravo' ); ?><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>
+                </div>
+              </div>
+            </div>
+          <!--Second postbox: end-->
+          </div>
+        </div>
 
-    // Inject subdomain
-    $adminer_url = str_replace('//', '//adminer.', $siteurl);
+        <div class="postbox-container">
+          <div id="side-sortables" class="meta-box-sortables ui-sortable">
+            <!--Third postbox: Search-replace tool--> 
+            <div id="dashboard_quick_press" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Search-replace tool','seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span>
+                  <span class="hide-if-no-js"><?php _e('Search-replace tool','seravo'); ?></span>
+                </span>
+              </h2>
+              <div class="inside">
+                <?php if ( exec( 'which wp' ) && apply_filters('seravo_search_replace', true) ) : ?>
+                <div class="seravo-section">
+                  <p> <?php _e('With this tool you can run wp search-replace. For your own safety, dry-run has to be ran before the actual search-replace', 'seravo'); ?></p>
+                  <div class="sr-navbar">
+                    <span class="label_buttons"><label class="from_label" for="sr-from"><?php _e('From:', 'seravo'); ?></label> <input type="text" id="sr-from" value=""></span>
+                    <span class="label_buttons to_button"><label class="to_label" for="sr-to"><?php _e('To:', 'seravo'); ?></label> <input type="text" id="sr-to" value=""></span>            
+                    <!-- To add new arbitrary option put it below. Use class optionbox
+                        Custom options will be overriden upon update -->
+                    <ul class="optionboxes">
+                        <li class="sr_option">
+                          <input type="checkbox" id="skip_backup" class="optionbox">
+                          <label for="skip_backup"><?php _e('Skip backups', 'seravo'); ?></label>
+                        </li>
+                      <?php if ( $GLOBALS['sr_alltables'] ) : ?>
+                        <li class="sr_option">
+                          <input type="checkbox" id="all_tables" class="optionbox">
+                          <label for="all_tables"><?php _e('All tables', 'seravo'); ?></label>
+                        </li>
+                      <?php endif; ?>
+                      <?php if ( $GLOBALS['sr_networkvisibility'] ) : ?>
+                        <li class="sr_option">
+                          <input type="checkbox" id="network" class="optionbox">
+                          <label for="network"><?php _e('Network', 'seravo'); ?></label>
+                        </li>
+                      <?php endif; ?>
+                    </ul>
+                    <div class="datab_buttons">
+                      <button id="sr-drybutton" class="button sr-button"> <?php _e('Run dry-run', 'seravo'); ?> </button>
+                      <button id="sr-button" class="button sr-button" disabled> <?php _e('Run wp search-replace', 'seravo'); ?> </button>
+                    </div>
+                  </div>
+                  <div id="search_replace_loading"><img class="hidden" src="/wp-admin/images/spinner.gif"></div>
+                  <div id="search_replace_command"></div>
+                  <table id="search_replace"></table>
+                </div>
+                <?php endif; // end search & replace ?>
+              </div>
+            </div>
+            <!--Third postbox: end-->
 
-  }
-
- ?>
-
-<p><a href="<?php echo esc_url($adminer_url); ?>" class="button" target="_blank"><?php _e( 'Open Adminer', 'seravo' ); ?><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>
-</div>
-
-<?php if ( exec( 'which wp' ) && apply_filters('seravo_search_replace', true) ) : ?>
-<div class="seravo-section">
-<h2><?php _e('Search-replace tool','seravo'); ?></h2>
-<p> <?php _e('With this tool you can run wp search-replace. For your own safety, dry-run has to be ran before the actual search-replace', 'seravo'); ?></p>
-
- <div class="sr-navbar">
-    <label for="sr-from"><?php _e('From:', 'seravo'); ?></label> <input type="text" id="sr-from" value="">
-    <label for="sr-to"><?php _e('To:', 'seravo'); ?></label> <input type="text" id="sr-to" value="">
-
-    <!-- To add new arbitrary option put it below. Use class optionbox
-         Custom options will be overriden upon update -->
-  <ul class="optionboxes">
-      <li class="sr_option">
-        <input type="checkbox" id="skip_backup" class="optionbox">
-        <label for="skip_backup"><?php _e('Skip backups', 'seravo'); ?></label>
-      </li>
-    <?php if ( $GLOBALS['sr_alltables'] ) : ?>
-      <li class="sr_option">
-         <input type="checkbox" id="all_tables" class="optionbox">
-         <label for="all_tables"><?php _e('All tables', 'seravo'); ?></label>
-      </li>
-    <?php endif; ?>
-    <?php if ( $GLOBALS['sr_networkvisibility'] ) : ?>
-      <li class="sr_option">
-        <input type="checkbox" id="network" class="optionbox">
-        <label for="network"><?php _e('Network', 'seravo'); ?></label>
-      </li>
-    <?php endif; ?>
-  </ul>
-
-    <button id="sr-drybutton" class="button sr-button"> <?php _e('Run dry-run', 'seravo'); ?> </button>
-    <button id="sr-button" class="button sr-button" disabled> <?php _e('Run wp search-replace', 'seravo'); ?> </button>
-
- </div>
- <div id="search_replace_loading"><img class="hidden" src="/wp-admin/images/spinner.gif"></div>
- <div id="search_replace_command"></div>
- <table id="search_replace"></table>
-
-<script>
-
-var dryrun_ran=0;
-// Modified from the original seravo_load_report to handle tables and tsv's
-function seravo_load_sr_report( section, from, to, options ) {
-  jQuery.post(
-    ajaxurl,
-    { 'action': 'seravo_search_replace',
-      'section': section,
-      'from': from,
-      'to': to,
-      'options': options },
-    function( rawData ) {
-      if ( rawData.length === 0 ) {
-        jQuery('#' + section).html( 'No data returned for section.' );
-      }
-      //jQuery('#' + section + '_loading').fadeOut();
-      var data = JSON.parse(rawData);
-
-      // Loops through the data array row by row
-      jQuery.each( data, function( i, row ){
-        var tr = jQuery( '<tr>' );
-        // Loops through the row column by column
-        jQuery.each( row.split( '\t' ), function( j, col ){
-          if (i === 0){
-            jQuery( '#search_replace_command' ).append('<code>' + col + '</code>');
-          } else {
-            jQuery( '<td>' ).html(col).appendTo(tr);
-          }
-        })
-        jQuery( '#search_replace_loading img' ).fadeOut();
-        jQuery( '#search_replace' ).append(tr);
-      });
-    jQuery('#sr-button').prop('disabled', false);
-  }
-  ).fail(function() {
-    jQuery( '#' + section + '_loading' ).html( 'Failed to load. Please try again.' );
-  });
-}
-
-// Load when clicked.
-jQuery( '.sr-button' ).click(function(){
-  jQuery( '#search_replace_loading img' ).fadeIn();
-  jQuery( '#search_replace' ).empty();
-  jQuery( '#search_replace_command' ).empty();
-
-  var options = {};
-  if(jQuery(this).attr('id') === "sr-button"){
-    options['dry_run'] = false;
-  } else{
-    options['dry_run'] = true;
-  }
-  jQuery.each(jQuery( '.optionbox' ), function( i, option ){
-    options[jQuery(option).attr( 'id' )] = jQuery(option).is( ':checked' );
-  });
-  seravo_load_sr_report( 'search_replace', jQuery( '#sr-from' ).val() , jQuery( '#sr-to' ).val() , options);
-});
-
-jQuery( '#all_tables' ).click(function(){
-  if( jQuery(this).is( ':checked' ) ){
-    jQuery( '#sr-button').prop('disabled', true);
-    jQuery( '#skip_backup').prop('checked', false);
-  }
-});
-
-jQuery( '#sr-from' ).keyup(function( event ){
-  jQuery('#sr-button').prop('disabled', true);
-  dryrun_ran = 0;
-});
-
-jQuery( document ).ready( function(){
-  jQuery( '#sr-button').prop('disabled', true);
-  jQuery( '#skip_backup').prop('checked', false);
-})
-</script>
-</div>
-<?php endif; // end search & replace ?>
-
-<?php if ( exec( 'which wp' ) ) : ?>
-
-<div class="seravo-seciton">
-<h2><?php _e( 'Database size', 'seravo' ); ?></h2>
-<p>
-<div id="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
-<pre><div id="seravo_wp_db_info"></div></pre>
-
-</p>
-
-<script>
-// Load db info with ajax because it might take a little while
-function seravo_load_db_info(section) {
-  jQuery.post(
-    ajaxurl,
-    { 'action': 'seravo_wp_db_info',
-      'section': section },
-    function(rawData) {
-      if (rawData.length == 0) {
-        jQuery('#' + section).html('No data returned for section.');
-      }
-
-      jQuery('#' + section + '_loading').fadeOut();
-      var data = JSON.parse(rawData);
-      jQuery('#' + section).append(data);
-    }
-  ).fail(function() {
-    jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
-  });
-}
-
-// Load on page load
-seravo_load_db_info('seravo_wp_db_info');
-
-</script>
-</div>
-
-<?php endif; // end database info ?>
-
+            <!--Fourth postbox: Database size-->
+            <div id="dashboard_primary" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e( 'Database size', 'seravo' ); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e( 'Database size', 'seravo' ); ?></span>
+              </h2>
+              <div class="inside">
+                <?php if ( exec( 'which wp' ) ) : ?>
+                <div class="seravo-section section_chart_mobile">
+                  <p>
+                    <div id="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
+                    <pre><div id="seravo_wp_db_info"></div></pre>
+                    <div class="pie_container">
+                      <canvas id="pie_chart" style="width: 10%; height: 4vh;"></canvas>
+                    </div>
+                  </p>
+                </div>
+                <?php endif; // end database info ?>
+              </div>
+            </div>
+            <!--Fourth postbox: end-->
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/modules/database.php
+++ b/modules/database.php
@@ -50,9 +50,14 @@ if ( ! class_exists('Database') ) {
     public static function register_scripts( $page ) {
 
         wp_register_style('seravo_database', plugin_dir_url(__DIR__) . '/style/database.css');
+        wp_register_script( 'chart-js', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js', null, null, true );
 
         if ( $page === 'tools_page_database_page' ) {
             wp_enqueue_style('seravo_database');
+            wp_enqueue_script('chart-js');
+            wp_enqueue_script( 'color-hash', plugins_url( '../js/color-hash.js' , __FILE__), 'jquery', null, false );
+            wp_enqueue_script( 'reports-chart', plugins_url( '../js/reports-chart.js' , __FILE__), 'jquery', null, false );
+            wp_enqueue_script( 'database', plugins_url( '../js/database.js' , __FILE__), 'jquery', null, false );
         }
 
     }

--- a/style/database.css
+++ b/style/database.css
@@ -30,3 +30,52 @@ span.dashicons-external {
   line-height: unset;
   padding-left: 3px;
 }
+
+.inside {
+  padding: 10px 15px 0px 15px!important;
+}
+
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+
+@media only screen and (max-width: 1025px) {
+  .label_buttons {
+    display: block;
+  }
+  .to_button, .adminer_button {
+    padding-top: 15px;
+  }
+  .optionboxes {
+    padding-left: 10%;
+  }
+  .to_label {
+    padding-right: 15%;
+  }
+  .from_label {
+    padding-right: 10%;
+  }
+}
+
+@media only screen and (max-width: 376px) {
+  .pie_container {
+    margin: -90px;
+    padding-top: 90px;
+    white-space: pre-line;
+    overflow-wrap: break-word;
+  }
+  .section_chart_mobile {
+    padding-bottom: 25%;
+  }
+  canvas {
+    width: 253px!important;
+    height: 198px!important;
+    margin: auto;
+  }
+}


### PR DESCRIPTION
- Add database-tool contents in postboxes

- Make postboxes content responsive

- Show database data in pie chart

- Make pie chart responsive

This layout is same as in reports-tool. Also same pie chart from reports-tool, is used showing database table sizes.

I think that pie chart is much more informative and it is faster to see which table takes the most space on database. Also when site content is on postboxes, it is easier to find wanted information from there.

![database_layout](https://user-images.githubusercontent.com/15683849/40415179-0363cf94-5e83-11e8-8a95-a81bbae5f1bd.png)
