### PR TITLE
Update backups-tool layout to WordPress layout

### DIFF
--- a/js/backups.js
+++ b/js/backups.js
@@ -1,0 +1,45 @@
+'use strict';
+
+jQuery(document).ready(function($) {
+  // Reports load
+  // Generic ajax report loader function
+  function seravo_load_report(section) {
+    jQuery.post(
+      ajaxurl, {
+        'action': 'seravo_backups',
+        'section': section
+      },
+      function (rawData) {
+        if (rawData.length == 0) {
+          jQuery('#' + section).html('No data returned for section.');
+        }
+
+        jQuery('#' + section + '_loading').fadeOut();
+        var data = JSON.parse(rawData);
+        jQuery('#' + section).append(data.join("\n"));
+      }
+    ).fail(function () {
+      jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
+    });
+  }
+
+  // Load on page load
+  seravo_load_report('backup_status');
+  seravo_load_report('backup_exclude');
+
+  // Load when clicked
+  jQuery('#create_backup_button').click(function () {
+    jQuery('#create_backup_loading img').show();
+    jQuery('#create_backup_button').hide();
+    seravo_load_report('create_backup');
+  });
+
+  // Postbox toggle-script
+  jQuery('.ui-sortable-handle').on('click', function () {
+    jQuery(this).parent().toggleClass("closed");
+  });
+  jQuery('.toggle-indicator').on('click', function () {
+    jQuery(this).parent().parent().toggleClass("closed");
+  });
+
+});

--- a/lib/backups-page.php
+++ b/lib/backups-page.php
@@ -1,65 +1,90 @@
-<div class="wrap">
+<div id="wpbody" role="main">
+  <div id="wpbody-content" aria-label="Main content" tabindex="0">
+    <div class="wrap">
+      <div id="dashboard-widgets" class="metabox-holder">
+        <div class="postbox-container">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!-- first -->
+            <div id="dashboard_right_now" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Backups', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e('Backups', 'seravo'); ?></span>
+              </h2>
+              <div class="inside">
+                <p><?php _e('Backups are made automatically every night and preserved for 30 days. The data can be accessed on the server at <code>/data/backups</code>.', 'seravo') ?></p>
+              </div>
+          </div>
+          <!-- first ends -->
 
-<h1><?php _e('Backups', 'seravo') ?></h1>
+          <!-- second -->
+          <div id="dashboard_activity" class="postbox">
+            <button type="button" class="handlediv button-link" aria-expanded="true">
+              <span class="screen-reader-text">Toggle panel: <?php _e('Create a new backup', 'seravo'); ?></span>
+              <span class="toggle-indicator" aria-hidden="true"></span>
+            </button>
+            <h2 class="hndle ui-sortable-handle">
+              <span><?php _e('Create a new backup', 'seravo'); ?></span>
+            </h2>
+            <div class="inside">
+              <p><?php _e('You can also create backups using the command line tool <code>wp-backup</code>. We recommend getting familiar with the command line option accessible via SSH so that recovering a backup is not dependant on if WP-admin works or not.', 'seravo') ?></p>       
+              <p class="create_backup">
+                <button id="create_backup_button" class="button"><?php _e('Make a new backup', 'seravo') ?> </button>
+                <div id="create_backup_loading"><img class="hidden" src="/wp-admin/images/spinner.gif"></div>
+                <pre><div id="create_backup"></div></pre>
+              </p>
+            </div>
+          </div>
+          <!-- second ends -->
 
-<p><?php _e('Backups are made automatically every night and preserved for 30 days. The data can be accessed on the server at <code>/data/backups</code>.', 'seravo') ?></p>
+          <!-- third -->
+          <div id="dashboard_quick_press" class="postbox">
+            <button type="button" class="handlediv button-link" aria-expanded="true">
+              <span class="screen-reader-text">Toggle panel: <?php _e('Files excluded from backups', 'seravo'); ?></span>
+              <span class="toggle-indicator" aria-hidden="true"></span>
+            </button>
+            <h2 class="hndle ui-sortable-handle">
+              <span><?php _e('Files excluded from backups', 'seravo'); ?></span>
+            </h2>
+            <div class="inside">
+              <?php echo wp_sprintf( __('Below is the content of the file %s.', 'seravo'), '<code>/data/backups/exclude.filelist</code>' ); ?>
+              <p>
+                <div id="backup_exclude_loading">
+                  <img src="/wp-admin/images/spinner.gif">
+                </div>
+                <pre id="backup_exclude"></pre>
+              </p>
+            </div>
+          </div>
+          <!-- third ends -->
+        </div>
+      </div>
 
-<h2><?php _e('Create a new backup', 'seravo') ?></h2>
-
-<p><?php _e('You can also create backups using the command line tool <code>wp-backup</code>. We recommend getting familiar with the command line option accessible via SSH so that recovering a backup is not dependant on if WP-admin works or not.', 'seravo') ?></p>
-
-<p>
-<button id="create_backup_button" class="button"><?php _e('Make a new backup', 'seravo') ?> </button>
-<div id="create_backup_loading"><img class="hidden" src="/wp-admin/images/spinner.gif"></div>
-<pre><div id="create_backup"></div></pre>
-</p>
-
-<h2><?php _e('Current backups', 'seravo') ?></h2>
-<?php echo wp_sprintf( __('This listing is produced by command %s.', 'seravo'), '<code>wp-backup-status</code>' ); ?>
-<p>
-<div id="backup_status_loading"><img src="/wp-admin/images/spinner.gif"></div>
-<pre id="backup_status"></pre>
-</p>
-
-<h2><?php _e('Files excluded from backups', 'seravo') ?></h2>
-<?php echo wp_sprintf( __('Below is the content of the file %s.', 'seravo'), '<code>/data/backups/exclude.filelist</code>' ); ?>
-<p>
-<div id="backup_exclude_loading"><img src="/wp-admin/images/spinner.gif"></div>
-<pre id="backup_exclude"></pre>
-</p>
-
-<script>
-// Generic ajax report loader function
-function seravo_load_report(section) {
-  jQuery.post(
-    ajaxurl,
-    { 'action': 'seravo_backups',
-      'section': section },
-    function(rawData) {
-      if (rawData.length == 0) {
-        jQuery('#' + section).html('No data returned for section.');
-      }
-
-      jQuery('#' + section + '_loading').fadeOut();
-      var data = JSON.parse(rawData);
-      jQuery('#' + section).append(data.join("\n"));
-    }
-  ).fail(function() {
-    jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
-  });
-}
-
-// Load on page load
-seravo_load_report('backup_status');
-seravo_load_report('backup_exclude');
-
-// Load when clicked
-jQuery('#create_backup_button').click(function(){
-  jQuery('#create_backup_loading img').show();
-  jQuery('#create_backup_button').hide();
-  seravo_load_report('create_backup');
-});
-
-</script>
-
+      <div class="postbox-container">
+        <div id="side-sortables" class="meta-box-sortables ui-sortable">
+          <!-- fourth -->
+          <div id="dashboard_primary" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e( 'Current backups', 'seravo' ); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e( 'Current backups', 'seravo' ); ?></span>
+              </h2>
+              <div class="inside">
+                <?php echo wp_sprintf( __('This listing is produced by command %s.', 'seravo'), '<code>wp-backup-status</code>' ); ?>
+                <p>
+                  <div id="backup_status_loading"><img src="/wp-admin/images/spinner.gif"></div>
+                  <pre id="backup_status"></pre>
+                </p>
+                <!-- fourth ends -->
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/modules/backups.php
+++ b/modules/backups.php
@@ -17,6 +17,8 @@ if ( ! class_exists('Backups') ) {
           wp_die();
       });
 
+      add_action('admin_enqueue_scripts', array( __CLASS__, 'register_backups_scripts' ));
+
       // Only show the menu item on systems where wp-backup is available
       if ( exec('which wp-backup-status') ) {
         add_action( 'admin_menu', array( __CLASS__, 'register_backups_page' ) );
@@ -24,6 +26,22 @@ if ( ! class_exists('Backups') ) {
 
       // TODO: check if this hook actually ever fires for mu-plugins
       register_activation_hook( __FILE__, array( __CLASS__, 'register_view_backups_capability' ) );
+    }
+
+    /**
+     * Register scripts
+     *
+     * @param string $page hook name
+     */
+    public static function register_backups_scripts( $page ) {
+
+      wp_register_style('seravo_backups', plugin_dir_url(__DIR__) . '/style/backups.css');
+
+      if ( $page === 'tools_page_backups_page' ) {
+        wp_enqueue_script( 'backups', plugins_url( '../js/backups.js' , __FILE__), 'jquery', null, false );
+        wp_enqueue_style('seravo_backups');
+      }
+
     }
 
     public static function register_backups_page() {

--- a/style/backups.css
+++ b/style/backups.css
@@ -1,0 +1,43 @@
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+.inside {
+  padding: 20px!important;
+}
+p {
+  margin: 0;
+}
+.postbox .inside {
+  margin: 0!important;
+}
+.inside {
+  padding: 20px!important;
+}
+.create_backup {
+  margin-top: 20px;
+}
+pre {
+  overflow: auto;
+  padding-bottom: 15px;
+}
+/* Scrollbar on mobile*/
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+}
+::-webkit-scrollbar:horizontal {
+  height: 12px;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, .5);
+  border-radius: 10px;
+  border: 2px solid #dddede;
+}
+::-webkit-scrollbar-track {
+  border-radius: 10px;  
+  background-color: #dddede; 
+}


### PR DESCRIPTION
- Make backups-tools content responsive

- Fix code indentation

- Make backups.js file and move JavaScript there

- Make function register_scripts to backups.php

- Make backups.css-file and move css there

I updated backups-tool layout to wordpress layout.

When content are on postboxes it is easier to find what you are looking for. Different tools are more separated and when you go first time to look at the tool, you will see immediately what data and features tool contains.

![backups_tool](https://user-images.githubusercontent.com/15683849/40534960-5b2f6ea2-6010-11e8-8de0-3073bf351207.png)