### PR TITLE
Update Cruft Remover layout to WordPress layout

### DIFF
--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -67,4 +67,21 @@ jQuery(document).ready(function($) {
 
   // Load on page load
   seravo_load_report('cruftfiles_status');
+    // Postbox toggle script
+  jQuery('.ui-sortable-handle').on('click', function () {
+    jQuery(this).parent().toggleClass("closed");
+    if (jQuery(this).parent().hasClass("closed")) {
+      jQuery(this).parents().eq(3).height(60);
+    } else {
+      jQuery(this).parents().eq(3).height('auto');
+    }
+  });
+  jQuery('.toggle-indicator').on('click', function () {
+    jQuery(this).parent().parent().toggleClass("closed");
+    if (jQuery(this).parent().hasClass("closed")) {
+      jQuery(this).parents().eq(4).height(60);
+    } else {
+      jQuery(this).parents().eq(4).height('auto');
+    }
+  });
 });

--- a/lib/cruftfiles-page.php
+++ b/lib/cruftfiles-page.php
@@ -5,22 +5,53 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<div class="wrap">
 
-<h1><?php _e( 'Cruft Files (beta)', 'seravo' ); ?></h1>
 
-<h2><?php _e( 'Find and delete unnecessary files in the filesystem', 'seravo' ); ?></h2>
-<p>
-<div id="cruftfiles_status">
-  <table>
-    <tbody id="cruftfiles_entries">
-    </tbody>
-  </table>
-  <div id="cruftfiles_status_loading">
-    <?php _e( 'Finding files...', 'seravo' ); ?>
-    <img src="/wp-admin/images/spinner.gif">
+  <div id="wpbody" role="main">
+    <div id="wpbody-content" aria-label="Main content" tabindex="0">
+      <div class="wrap">
+        <div id="dashboard-widgets" class="metabox-holder">
+          <!-- container 1 -->
+          <div class="postbox-container-max">
+            <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+              <!--First postbox: Cruft remover-->
+              <div id="dashboard_cruft_files" class="postbox">
+                <button type="button" class="handlediv button-link" aria-expanded="true">
+                  <span class="screen-reader-text">Toggle panel:
+                    <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
+                  </span>
+                  <span class="toggle-indicator" aria-hidden="true"></span>
+                </button>
+                <h2 class="hndle ui-sortable-handle">
+                  <span>
+                    <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
+                  </span>
+                </h2>
+                <div class="inside">
+                  <div class="seravo-section">
+                    <p>
+                      <?php _e( 'Find and delete unnecessary files in the filesystem', 'seravo' ); ?>
+                    </p>
+                    <p>
+                      <div id="cruftfiles_status">
+                        <table>
+                          <tbody id="cruftfiles_entries">
+                          </tbody>
+                        </table>
+                        <div id="cruftfiles_status_loading">
+                          <?php _e( 'Finding files...', 'seravo' ); ?>
+                          <img src="/wp-admin/images/spinner.gif">
+                        </div>
+                      </div>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <!--First postbox: end-->
+            </div>
+          </div>
+          <!-- end 1 -->
+        </div>
+      </div>
+    </div>
   </div>
-</div>
-</p>
-
-</div>

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -1,15 +1,53 @@
 .cruftfile-delete-button {
   color: #a00;
 }
+
 .cruftfile-delete-button:hover {
   color: #EA6161 !important;
   outline: none;
   box-shadow: none;
 }
+
 .cruftfile-delete-button:active,
 .cruftfile-delete-button:focus,
 .cruftfile-delete-button:visited {
   color: #a00;
   outline: none;
   box-shadow: none;
+}
+
+.inside {
+  padding: 10px 15px 0px 15px!important;
+}
+.seravo-section {
+  margin-bottom: 2.5rem;
+}
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+.postbox-container-max {
+  width: 100%
+}
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+
+@media only screen and (max-width: 1025px) {
+  .label_buttons {
+    display: block;
+  }
+  .to_button, .adminer_button {
+    padding-top: 15px;
+  }
+  .optionboxes {
+    padding-left: 10%;
+  }
+  .to_label {
+    padding-right: 15%;
+  }
+  .from_label {
+    padding-right: 10%;
+  }
 }


### PR DESCRIPTION
As stated by @nasusa the postbox-style of layout is better than what was used before. For consistency and usability, in this PR cruft remover uses the same style as most other features in seravo-plugin.
![image](https://user-images.githubusercontent.com/16817737/40907978-25221dc4-67ee-11e8-82f5-c7f346552ea7.png)
![image](https://user-images.githubusercontent.com/16817737/40908015-43d2dc4a-67ee-11e8-84f3-e7a63b9c8711.png)

