### PR TITLE
Update updates-tool layout to WordPress layout

### DIFF
--- a/js/updates.js
+++ b/js/updates.js
@@ -1,0 +1,74 @@
+'use strict';
+//Email script
+function generateButtons (emails) {
+  var html = [];
+
+  emails.forEach(function (email) {
+    if (email) {
+      html.push('<button type="button" class="button button-primary email-button"><span class="email-button-content">' + email + '</span><span class="delete-icon dashicons dashicons-no"></span></button>')
+    }
+  });
+  jQuery('[name="technical_contacts"]').val(emails.join(', '))
+  return html.join(' ');
+}
+
+function validateEmail ($emailInput) {
+  var $form = jQuery('[name="seravo_updates_form"]');
+  var regex = /^([ÆØÅæøåõäöüa-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})$/;
+  var result = regex.test($emailInput.val());
+  if ( ! result ) {
+    $form.addClass('has-errors');
+  } else {
+		$form.removeClass('has-errors');
+  }
+  return result;
+}
+
+jQuery(document).ready(function($) {
+  var $emailInput = jQuery('.technical_contacts_input');
+  var emails = $emailInput.data('emails');
+  var $buttonsDiv = jQuery('.technical_contacts_buttons');
+  $buttonsDiv.html(generateButtons(emails));
+
+  // Disable form submit using enter
+  jQuery('[name="seravo_updates_form"]').on('keyup keypress', function(event) {
+    var keyCode = event.keyCode || event.which;
+    if (keyCode === 13) {
+      event.preventDefault();
+      return false;
+    }
+  });
+
+  function insertEmail() {
+    if (validateEmail($emailInput)) {
+      emails.push($emailInput.val())
+      $buttonsDiv.html(generateButtons(emails));
+    }
+  }
+
+  $emailInput.keypress(function (event) {
+    if (event.which == 13) {
+      insertEmail();
+      event.preventDefault();
+      return false;
+    }
+  });
+
+  jQuery('.technical_contacts_add').click(function() {
+    insertEmail();
+  });
+
+  jQuery('.technical_contacts_buttons').on('click', '.email-button', function () {
+    var text = jQuery(this).find('.email-button-content').html();
+    emails.splice(jQuery.inArray(text, emails), 1);
+    $buttonsDiv.html(generateButtons(emails));
+  });
+
+  // Accordion script
+  jQuery('.ui-sortable-handle').on('click', function () {
+    jQuery(this).parent().toggleClass("closed");
+  });
+  jQuery('.toggle-indicator').on('click', function () {
+    jQuery(this).parent().parent().toggleClass("closed");
+  });
+});

--- a/lib/updates-page.php
+++ b/lib/updates-page.php
@@ -4,119 +4,101 @@ if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 ?>
-
-<div class="wrap">
-
-  <h1><?php _e('Seravo updates', 'seravo'); ?></h1>
-
-<?php
-
-$site_info = Seravo\Updates::seravo_admin_get_site_info();
-
-?>
-
-<?php if ( isset($_GET['settings-updated']) && $_GET['settings-updated'] ) { ?>
-<div id="updates-settings_updated" class="updated settings-error notice is-dismissible">
-  <p>
-    <strong>
-      <?php _e('Settings saved.'); ?>
-    </strong>
-  </p>
-  <button type="button" class="notice-dismiss">
-    <span class="screen-reader-text">
-      <?php _e('Dismiss this notice.'); ?>
-    </span>
-  </button>
-</div>
-<?php } ?>
-
-<h2><?php _e('Site status', 'seravo'); ?></h2>
-<ul>
-  <li>
-    <?php _e('Site created', 'seravo'); ?>:
-    <?php echo $site_info['created']; ?>
-  </li>
-  <li>
-    <?php _e('Latest update attempt', 'seravo'); ?>:
-    <?php echo $site_info['update_attempt']; ?>
-  </li>
-  <li>
-    <?php _e('Latest successful update', 'seravo'); ?>:
-    <?php echo $site_info['update_success']; ?>
-  </li>
-</ul>
-
-<h2><?php _e('Opt-out form updates by Seravo', 'seravo'); ?></h2>
-
-<?php
-if ( $site_info['seravo_updates'] === true ) {
-  $checked = 'checked="checked"';
-} else {
-  $checked = '';
-}
-
-$contact_emails = array();
-if ( isset($site_info['contact_emails']) ) {
-  $contact_emails = $site_info['contact_emails'];
-}
-
-?>
-
-  <p>
-    <?php
-      _e('Seravo\'s upkeep service includes that your WordPress
-      site is kept up-to-date with quick security updates and regular
-      tested updates of both WordPress core and plugins. If you want
-      full control of updates yourself, you can opt-out from Seravo
-      updates.', 'seravo');
+<div id="wpbody" role="main">
+  <div id="wpbody-content" aria-label="Main content" tabindex="0">
+    <div class="wrap">
+      <?php
+      $site_info = Seravo\Updates::seravo_admin_get_site_info();
       ?>
-  </p>
+      <?php if ( isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] ) { ?>
+      <div id="updates-settings_updated" class="updated settings-error notice is-dismissible">
+        <p>
+          <strong><?php _e('Settings saved.'); ?></strong>
+        </p>
+        <button type="button" class="notice-dismiss">
+          <span class="screen-reader-text"><?php _e('Dismiss this notice.'); ?></span>
+        </button>
+      </div>
+      <?php } ?>
+      <div id="dashboard-widgets" class="metabox-holder">
+        <div class="postbox-container">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <div id="dashboard_right_now" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Seravo updates', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e('Seravo updates', 'seravo'); ?></span>
+              </h2>
+              <div class="inside seravo-updates-postbox">
+                <h2><?php _e('Opt-out form updates by Seravo', 'seravo'); ?></h2>
 
-  <form name="seravo_updates_form" action=
-    "
-    <?php
-      echo esc_url( admin_url('admin-post.php') );
-    ?>
-    "
-    method="post">
-    <?php wp_nonce_field( 'seravo-updates-nonce' ); ?>
-    <input type="hidden" name="action" value="toggle_seravo_updates">
-    <input id="seravo_updates" name="seravo_updates" type="checkbox"
-      <?php echo $checked; ?>> <?php _e('Seravo updates enabled', 'seravo'); ?><br>
+                <?php
+                if ( $site_info['seravo_updates'] === true ) {
+                  $checked = 'checked="checked"';
+                } else {
+                  $checked = '';
+                }
 
-    <h2><?php _e('Technical contact email addresses', 'seravo'); ?></h2>
-    <p>
-      <?php
-        _e('Seravo may send automatic notifications about site errors
-        and failed updates to these addresses. Please separate multiple email
-        addresses with commas.', 'seravo');
-        ?>
-    </p>
-    <input name="technical_contacts" type="email" multiple size="30"
-      placeholder="<?php _e('example@example.com', 'seravo'); ?>" value="
-      <?php
-      if ( ! empty($contact_emails) ) {
-        echo implode(', ', $contact_emails);
-      }
-      ?>
-    ">
+                $contact_emails = array();
+                if ( isset($site_info['contact_emails']) ) {
+                  $contact_emails = $site_info['contact_emails'];
+                }
 
-    <p>
-      <small class="seravo-developer-letter-hint">
-      <?php
-        /* translators:
-        * %1$s first part of an <a> -tag
-        * %2$s last part of an <a> -tag
-        */
-        echo sprintf( __('P.S. Subscribe to Seravo\'s %1$sNewsletter for
-        WordPress Developers%2$s to get up-to-date information about our newest
-        features.', 'seravo'), '<a href="https://seravo.com/newsletter-for-
-        wordpress-developers/">', '</a>');
-        ?>
-      </small>
-    </p>
+                ?>
 
-    <input type="submit" id="save_settings_button" class="button button-primary"
-      value="<?php _e('Save settings', 'seravo'); ?>">
-  </form>
+                <p><?php _e('Seravo\'s upkeep service includes that your WordPress site is kept up-to-date with quick security updates and regular tested updates of both WordPress core and plugins. If you want full control of updates yourself, you can opt-out from Seravo updates.', 'seravo'); ?></p>
+
+                <form name="seravo_updates_form" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" method="post">
+                  <?php wp_nonce_field( 'seravo-updates-nonce' ); ?>
+                  <input type="hidden" name="action" value="toggle_seravo_updates">
+                  <div class="checkbox allow_updates_checkbox">
+                    <input id="seravo_updates" name="seravo_updates" type="checkbox" <?php echo $checked; ?>> <?php _e('Seravo updates enabled', 'seravo'); ?><br>
+                  </div>
+                  <hr class="seravo-updates-hr">
+                  <h2><?php _e('Technical contact email addresses', 'seravo'); ?></h2>
+                  <p><?php _e('Seravo may send automatic notifications about site errors and failed updates to these addresses. Remember to add @-character to email.', 'seravo'); ?></p>
+                  <input class="technical_contacts_input" type="email" multiple size="30" placeholder="<?php _e('example@example.com', 'seravo'); ?>" value="" data-emails="<?php echo htmlspecialchars(json_encode($contact_emails)); ?>">
+                  <button type="button" class="technical_contacts_add button"><?php _e('Add', 'seravo'); ?></button>
+                  <span class="technical_contacts_error"><?php _e('Email must be formatted as name@domain.com', 'seravo'); ?></span>
+                  <input name="technical_contacts" type="hidden">
+                  <div class="technical_contacts_buttons"></div>
+                  <p><small class="seravo-developer-letter-hint">
+                    <?php
+                      // translators: %1$s link to Newsletter for WordPress developers
+                      echo wp_sprintf( __('P.S. Subscribe to Seravo\'s %1$sNewsletter for WordPress Developers%2$s to get up-to-date information about our newest features.', 'seravo'), '<a href="https://seravo.com/newsletter-for-wordpress-developers/">', '</a>');
+                    ?>
+                  </small></p>
+                  <input type="submit" id="save_settings_button" class="button button-primary" value="<?php _e('Save settings', 'seravo'); ?>">
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="postbox-container">
+          <div id="side-sortables" class="meta-box-sortables ui-sortable">
+            <div id="dashboard_quick_press" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Site status', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span>
+                  <span class="hide-if-no-js"><?php _e('Site status', 'seravo'); ?></span>
+                </span>
+              </h2>
+              <div class="inside">
+                <ul>
+                  <li><?php _e('Site created', 'seravo'); ?>: <?php echo $site_info['created']; ?></li>
+                  <li><?php _e('Latest update attempt', 'seravo'); ?>: <?php echo $site_info['update_attempt']; ?></li>
+                  <li><?php _e('Latest successful update', 'seravo'); ?>: <?php echo $site_info['update_success']; ?></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -18,6 +18,7 @@ if ( ! class_exists('Updates') ) {
     public static function load() {
       add_action( 'admin_menu', array( __CLASS__, 'register_updates_page' ) );
 
+      add_action('admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ));
       /*
       * This will use the SWD api to toggle Seravo updates on/off and add
       * technical contact emails for this site.
@@ -26,6 +27,22 @@ if ( ! class_exists('Updates') ) {
 
       // TODO: check if this hook actually ever fires for mu-plugins
       register_activation_hook( __FILE__, array( __CLASS__, 'register_view_updates_capability' ) );
+    }
+
+    /**
+     * Register scripts
+     *
+     * @param string $page hook name
+     */
+    public static function register_scripts( $page ) {
+
+      wp_register_style('seravo_updates', plugin_dir_url(__DIR__) . '/style/updates.css');
+
+      if ( $page === 'tools_page_updates_page' ) {
+          wp_enqueue_style('seravo_updates');
+          wp_enqueue_script( 'seravo_updates', plugins_url( '../js/updates.js', __FILE__), 'jquery', null, false );
+      }
+
     }
 
     public static function register_updates_page() {

--- a/style/updates.css
+++ b/style/updates.css
@@ -1,0 +1,82 @@
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+
+.inside {
+  padding: 30px 60px 60px 60px!important;
+  text-align: center;
+}
+
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+
+@media only screen and (max-width:1445px) {
+  .inside {
+    padding: 10px 20px 20px 20px!important;
+    text-align: center;
+  }
+}
+
+.allow_updates_checkbox {
+  padding-bottom: 10px;
+}
+
+.technical_contacts_buttons {
+  padding-top: 10px;
+}
+
+.email-button {
+  margin-bottom: 5px!important;
+}
+.dashicons {
+  line-height: 1.4;
+}
+
+@media screen and (max-width: 425px) {
+  .technical_contacts_input {
+    max-width: 200px;
+  }
+}
+
+form[name="seravo_updates_form"] > .technical_contacts_error {
+  display: none;
+}
+
+form[name="seravo_updates_form"].has-errors > .technical_contacts_error {
+  background: #c51244 !important;
+  padding: 10px !important;
+  border-radius: 0 !important;
+  position: relative;
+  display: block;
+  max-width: 280px;
+  margin: auto;
+  box-shadow: 1px 1px 1px #aaaaaa;
+  margin-top: 10px;
+  color: white;
+}
+
+form[name="seravo_updates_form"].has-errors > .technical_contacts_error::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid #c51244;
+  position: absolute;
+  top: -10px;
+}
+
+form[name="seravo_updates_form"].has-errors > .technical_contacts_error::after {
+  background: #fff0f4;
+  color: #c51244;
+}
+
+form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
+  box-shadow: 0!important;
+  border: 1px solid #c51244 !important;
+  background: #fff0f4;
+  color: #eb819f;
+}


### PR DESCRIPTION
- Update updates-tool layout to WordPress layout (postboxes)
- Show technical contact emails in buttons
- Add updates.css -file
- Make layout mobile responsive

I did accidentally delete my latest pr, but luckily I had these files saved to my computer.

![image](https://user-images.githubusercontent.com/15683849/41089297-2ffc7f92-6a4a-11e8-8b1a-3db804c20011.png)
