### PR TITLE
Fix database-tools "Learn more about Adminer" link and translation

### DIFF
--- a/lib/database-page.php
+++ b/lib/database-page.php
@@ -50,7 +50,14 @@ if ( ! defined('ABSPATH') ) {
               </h2>
               <div class="inside">
                 <div class="seravo-section">
-                  <p><?php printf( __( 'Adminer is a simple database management tool like phpMyAdmin. <a href="$s">Learn more about Adminer.</a>', 'seravo' ), 'https://www.adminer.org' ); ?></p>
+                  <p>
+                    <?php
+                      /* translators:
+                      * %1$s url to www.adminer.org
+                      */
+                      printf( __( 'Adminer is a simple database management tool like phpMyAdmin. <a href="%1$s">Learn more about Adminer.</a>', 'seravo' ), 'https://www.adminer.org' );
+                    ?>
+                  </p>
                   <p>
                     <?php
                       /* translators:


### PR DESCRIPTION
`<p><?php printf( __( 'Adminer is a simple database management tool like phpMyAdmin. <a href="%1$s">Learn more about Adminer.</a>', 'seravo' ), 'https://www.adminer.org' ); ?></p>`

There was typo at a href (was $s, fixed to %1$s) Attribute so link didnt go anywhere.
