### PR TITLE
Introduce feature to reset shadows

### DIFF
--- a/js/shadows.js
+++ b/js/shadows.js
@@ -2,16 +2,20 @@
 
 jQuery(document).ready(function($) {
   $('.shadow-reset').click(function(event) {
+    var is_user_sure = confirm(seravo_shadows_loc.confirm);
+    if ( ! is_user_sure) {
+      return;
+    }
     seravo_ajax_reset_shadow($(this).attr("data-shadow-name"),
       function( status ){
-        if( status == 'progress' ) {
+        if ( status == 'progress' ) {
           event.target.disabled = true;
-        }
-        else if( status == 'success' ){
-          event.target.innerHTML = 'DONE';
-        }
-        else {
-          console.log('Unknown status');
+        } else if ( status == 'success' ) {
+          event.target.innerHTML = seravo_shadows_loc.success;
+        } else if ( status == 'failure' ) {
+          event.target.innerHTML = seravo_shadows_loc.failure;
+        } else {
+          event.target.innerHTML = seravo_shadows_loc.error;
         }
       });
   });
@@ -25,10 +29,31 @@ jQuery(document).ready(function($) {
         'resetshadow': shadow },
         function( rawData ) {
           var data = JSON.parse(rawData);
-          console.log(data);
-          animate('success');
-      }
+          // If the last row of rawData does not begin with SUCCESS:
+          if ( data[data.length - 1].search('Success') ) {
+            animate('success');
+          } else {
+            animate('failure');
+          }
+        }
     );
   }
+
+  //Postbox animations
+  jQuery('.ui-sortable-handle').on('click', function () {
+    jQuery(this).parent().toggleClass("closed");
+    if (jQuery(this).parent().hasClass("closed")) {
+      jQuery(this).parents().eq(3).height(60);
+    } else {
+      jQuery(this).parents().eq(3).height('auto');
+    }
+  });
+  jQuery('.toggle-indicator').on('click', function () {
+    jQuery(this).parent().parent().toggleClass("closed");
+    if (jQuery(this).parent().hasClass("closed")) {
+      jQuery(this).parents().eq(4).height(60);
+    } else {
+      jQuery(this).parents().eq(4).height('auto');
+    }
+  });
 });
-    

--- a/js/shadows.js
+++ b/js/shadows.js
@@ -1,0 +1,34 @@
+'use strict';
+
+jQuery(document).ready(function($) {
+  $('.shadow-reset').click(function(event) {
+    seravo_ajax_reset_shadow($(this).attr("data-shadow-name"),
+      function( status ){
+        if( status == 'progress' ) {
+          event.target.disabled = true;
+        }
+        else if( status == 'success' ){
+          event.target.innerHTML = 'DONE';
+        }
+        else {
+          console.log('Unknown status');
+        }
+      });
+  });
+
+  function seravo_ajax_reset_shadow(shadow, animate) {
+    animate('progress');
+    $.post(
+      ajaxurl,
+      { type: 'POST',
+        'action': 'seravo_reset_shadow',
+        'resetshadow': shadow },
+        function( rawData ) {
+          var data = JSON.parse(rawData);
+          console.log(data);
+          animate('success');
+      }
+    );
+  }
+});
+    

--- a/lib/shadows-ajax.php
+++ b/lib/shadows-ajax.php
@@ -4,7 +4,7 @@ function seravo_reset_shadow() {
   if ( isset($_POST['resetshadow']) && ! empty($_POST['resetshadow']) ) {
     $shadow = $_POST['resetshadow'];
     $output = array();
-    exec('. /etc/container_environment.sh; wp-shadow-reset ' . $shadow . ' --force 2>&1', $output);
+    exec('wp-shadow-reset ' . $shadow . ' --force 2>&1', $output);
     echo json_encode($output);
   }
   wp_die();

--- a/lib/shadows-ajax.php
+++ b/lib/shadows-ajax.php
@@ -1,0 +1,11 @@
+<?php
+
+function seravo_reset_shadow() {
+  if ( isset($_POST['resetshadow']) && ! empty($_POST['resetshadow']) ) {
+    $shadow = $_POST['resetshadow'];
+    $output = array();
+    exec('. /etc/container_environment.sh; wp-shadow-reset ' . $shadow . ' --force 2>&1', $output);
+    echo json_encode($output);
+  }
+  wp_die();
+}

--- a/lib/shadows-page.php
+++ b/lib/shadows-page.php
@@ -35,6 +35,7 @@ require_once dirname( __FILE__ ) . '/api.php';
           <th><?php _e('SSH port', 'seravo'); ?></th>
           <th><?php _e('Creation date', 'seravo'); ?></th>
           <th><?php _e('Information', 'seravo'); ?></th>
+          <th><?php _e('Reset Shadow', 'seravo'); ?></th>
         </thead>
 
         <tbody>
@@ -43,9 +44,10 @@ require_once dirname( __FILE__ ) . '/api.php';
               <tr>
                 <?php foreach ( $shadow_data_ordered as $data_key ) : ?>
                   <?php if ( isset($shadow_data[$data_key]) ) : ?>
-                    <th><?php echo $shadow_data[$data_key]; ?></th>
+                    <td><?php echo $shadow_data[$data_key]; ?></td>
                   <?php endif; ?>
                 <?php endforeach; ?>
+                <td><button data-shadow-name="<?php echo $shadow_data['name']; ?>" class="shadow-reset" type="button">Reset Shadow</button></td>
               </tr>
             <?php endforeach; ?>
           <?php else : ?>

--- a/lib/shadows-page.php
+++ b/lib/shadows-page.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Outputs shadows page content.
+ */
+
+// Deny direct access
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+require_once dirname( __FILE__ ) . '/api.php';
+?>
+
+<div id="wpbody" role="main">
+  <div id="wpbody-content" aria-label="Main content" tabindex="0">
+    <div class="wrap">
+      <h1><?php _e('Shadows (beta)', 'seravo'); ?></h1>
+      <p><?php _e('Allow easy access to site shadows.', 'seravo'); ?></p>
+
+      <?php
+      // Get a list of site shadows
+      $api_query = '/shadows';
+      $shadow_list = Seravo\API::get_site_data($api_query);
+      if ( is_wp_error($shadow_list) ) {
+        die($shadow_list->get_error_message());
+      }
+
+      // Order the shadow data so they correspond to the table labels.
+      $shadow_data_ordered = array('name', 'ssh', 'created', 'info');
+      ?>
+
+      <table class="wp-list-table widefat striped" cellspacing="0">
+        <thead>
+          <th><?php _e('Name', 'seravo'); ?></th>
+          <th><?php _e('SSH port', 'seravo'); ?></th>
+          <th><?php _e('Creation date', 'seravo'); ?></th>
+          <th><?php _e('Information', 'seravo'); ?></th>
+        </thead>
+
+        <tbody>
+          <?php if ( ! empty($shadow_list) ) : ?>
+            <?php foreach ( $shadow_list as $shadow_data ) : ?>
+              <tr>
+                <?php foreach ( $shadow_data_ordered as $data_key ) : ?>
+                  <?php if ( isset($shadow_data[$data_key]) ) : ?>
+                    <th><?php echo $shadow_data[$data_key]; ?></th>
+                  <?php endif; ?>
+                <?php endforeach; ?>
+              </tr>
+            <?php endforeach; ?>
+          <?php else : ?>
+            <?php _e('No shadows found. If your plan is WP Pro or higher, you can request a shadow instance from Seravo admins at wordpress@seravo.com.', 'seravo'); ?>
+          <?php endif; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/lib/shadows-page.php
+++ b/lib/shadows-page.php
@@ -14,47 +14,78 @@ require_once dirname( __FILE__ ) . '/api.php';
 <div id="wpbody" role="main">
   <div id="wpbody-content" aria-label="Main content" tabindex="0">
     <div class="wrap">
-      <h1><?php _e('Shadows (beta)', 'seravo'); ?></h1>
-      <p><?php _e('Allow easy access to site shadows.', 'seravo'); ?></p>
+        <div id="dashboard-widgets" class="metabox-holder">
+          <!-- container  -->
+          <div class="postbox-container-max">
+            <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+              <!--First postbox: Shadow Reset-->
+              <div id="dashboard_shadow_reset" class="postbox">
+                <button type="button" class="handlediv button-link" aria-expanded="true">
+                  <span class="screen-reader-text"><?php _e('Toggle panel:', 'seravo'); ?>
+                  <?php _e('Shadows (beta)', 'seravo'); ?>
+                  </span>
+                  <span class="toggle-indicator" aria-hidden="true"></span>
+                </button>
+                <h2 class="hndle ui-sortable-handle">
+                  <span>
+                  <?php _e('Shadows (beta)', 'seravo'); ?>
+                  </span>
+                </h2>
+                <div class="inside" style="padding: 0px">
+                  <div class="seravo-section">
+                    <div style="padding: 0px 15px">
+                      <p><?php _e('Allow easy access to site shadows. Resetting a shadow copies the production state to a shadow by replacing files and importing the production database. For more information, visit our  <a href="https://seravo.com/docs/deployment/shadows/">Developer documentation</a>.', 'seravo'); ?></p>
+                    </div>
+                    <div style="padding: 0px">
+                      <?php
+                      // Get a list of site shadows
+                      $api_query = '/shadows';
+                      $shadow_list = Seravo\API::get_site_data($api_query);
+                      if ( is_wp_error($shadow_list) ) {
+                        die($shadow_list->get_error_message());
+                      }
 
-      <?php
-      // Get a list of site shadows
-      $api_query = '/shadows';
-      $shadow_list = Seravo\API::get_site_data($api_query);
-      if ( is_wp_error($shadow_list) ) {
-        die($shadow_list->get_error_message());
-      }
+                      // Order the shadow data so they correspond to the table labels.
+                      $shadow_data_ordered = array( 'info', 'name', 'ssh', 'created' );
+                      if ( ! empty($shadow_list) ) :
+                        ?>
+                      <table class="widefat striped fixed"
+                        style="width=100%; border:none" cellspacing="0">
+                        <thead>
+                          <th><?php _e('Name', 'seravo'); ?></th>
+                          <th><?php _e('Identifier', 'seravo'); ?></th>
+                          <th><?php _e('SSH port', 'seravo'); ?></th>
+                          <th><?php _e('Creation date', 'seravo'); ?></th>          
+                          <th><?php _e('Reset Shadow', 'seravo'); ?></th>
+                        </thead>
+                        <tbody>
+                            <?php foreach ( $shadow_list as $shadow_data ) : ?>
+                              <tr>
+                                <?php foreach ( $shadow_data_ordered as $data_key ) : ?>
+                                  <?php if ( isset($shadow_data[ $data_key ]) ) : ?>
+                                    <td><?php echo $shadow_data[ $data_key ]; ?></td>
+                                  <?php endif; ?>
+                                <?php endforeach; ?>
+                                <td><button data-shadow-name="<?php echo $shadow_data['name']; ?>" class="shadow-reset button" type="button"><?php _e('Reset Shadow', 'seravo'); ?></button></td>
+                              </tr>
+                            <?php endforeach; ?>
 
-      // Order the shadow data so they correspond to the table labels.
-      $shadow_data_ordered = array('name', 'ssh', 'created', 'info');
-      ?>
-
-      <table class="wp-list-table widefat striped" cellspacing="0">
-        <thead>
-          <th><?php _e('Name', 'seravo'); ?></th>
-          <th><?php _e('SSH port', 'seravo'); ?></th>
-          <th><?php _e('Creation date', 'seravo'); ?></th>
-          <th><?php _e('Information', 'seravo'); ?></th>
-          <th><?php _e('Reset Shadow', 'seravo'); ?></th>
-        </thead>
-
-        <tbody>
-          <?php if ( ! empty($shadow_list) ) : ?>
-            <?php foreach ( $shadow_list as $shadow_data ) : ?>
-              <tr>
-                <?php foreach ( $shadow_data_ordered as $data_key ) : ?>
-                  <?php if ( isset($shadow_data[$data_key]) ) : ?>
-                    <td><?php echo $shadow_data[$data_key]; ?></td>
-                  <?php endif; ?>
-                <?php endforeach; ?>
-                <td><button data-shadow-name="<?php echo $shadow_data['name']; ?>" class="shadow-reset" type="button">Reset Shadow</button></td>
-              </tr>
-            <?php endforeach; ?>
-          <?php else : ?>
-            <?php _e('No shadows found. If your plan is WP Pro or higher, you can request a shadow instance from Seravo admins at wordpress@seravo.com.', 'seravo'); ?>
-          <?php endif; ?>
-        </tbody>
-      </table>
+                        </tbody>
+                      </table>
+                      <?php else : ?>
+                        <p style="padding: 15px">
+                          <?php _e('No shadows found. If your plan is WP Pro or higher, you can request a shadow instance from Seravo admins at wordpress@seravo.com.', 'seravo'); ?>
+                        </p>
+                      <?php endif; ?>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <!--First postbox: end-->
+            </div>
+          </div>
+          <!-- end container -->
+        </div>
     </div>
   </div>
 </div>

--- a/modules/shadows.php
+++ b/modules/shadows.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Plugin name: Shadows
+ * Description: Add a page to list shadows and transfer data between them and
+ * production.
+ * TODO: Should we also prevent the loading of this module in WP Network sites
+ * to prevent disaster?
+ */
+
+namespace Seravo;
+
+require_once dirname( __FILE__ ) . '/../lib/helpers.php';
+
+if ( ! class_exists('Shadows') ) {
+  class Shadows {
+
+    public static function load() {
+      // Load only in production
+      if ( Helpers::is_production() ) {
+        add_action( 'admin_menu', array( __CLASS__, 'register_shadows_page' ) );
+      }
+    }
+
+    public static function register_shadows_page() {
+      add_submenu_page( 'tools.php', __('Shadows', 'seravo'), __('Shadows', 'seravo'), 'manage_options', 'shadows_page', array( __CLASS__, 'load_shadows_page' ) );
+    }
+
+    public static function load_shadows_page() {
+      require_once dirname( __FILE__ ) . '/../lib/shadows-page.php';
+    }
+  }
+
+  Shadows::load();
+}

--- a/modules/shadows.php
+++ b/modules/shadows.php
@@ -10,6 +10,7 @@
 namespace Seravo;
 
 require_once dirname( __FILE__ ) . '/../lib/helpers.php';
+require_once dirname( __FILE__ ) . '/../lib/shadows-ajax.php';
 
 if ( ! class_exists('Shadows') ) {
   class Shadows {
@@ -18,17 +19,19 @@ if ( ! class_exists('Shadows') ) {
       // Load only in production
       if ( Helpers::is_production() ) {
         add_action( 'admin_menu', array( __CLASS__, 'register_shadows_page' ) );
+        wp_register_script( 'seravo_shadows', plugin_dir_url( __DIR__ ) . '/js/shadows.js' );
+        wp_enqueue_script( 'seravo_shadows' );
+        add_action( 'wp_ajax_seravo_reset_shadow' , 'seravo_reset_shadow' );
       }
     }
-
     public static function register_shadows_page() {
-      add_submenu_page( 'tools.php', __('Shadows', 'seravo'), __('Shadows', 'seravo'), 'manage_options', 'shadows_page', array( __CLASS__, 'load_shadows_page' ) );
+      add_submenu_page( 'tools.php', __('Shadows', 'seravo'),
+      __('Shadows', 'seravo'), 'manage_options', 'shadows_page',
+      array( __CLASS__, 'load_shadows_page' ) );
     }
-
     public static function load_shadows_page() {
       require_once dirname( __FILE__ ) . '/../lib/shadows-page.php';
     }
   }
-
   Shadows::load();
 }

--- a/modules/shadows.php
+++ b/modules/shadows.php
@@ -19,15 +19,41 @@ if ( ! class_exists('Shadows') ) {
       // Load only in production
       if ( Helpers::is_production() ) {
         add_action( 'admin_menu', array( __CLASS__, 'register_shadows_page' ) );
-        wp_register_script( 'seravo_shadows', plugin_dir_url( __DIR__ ) . '/js/shadows.js' );
-        wp_enqueue_script( 'seravo_shadows' );
-        add_action( 'wp_ajax_seravo_reset_shadow' , 'seravo_reset_shadow' );
+        add_action('admin_enqueue_scripts', array( __CLASS__, 'register_shadows_scripts' ));
+        add_action( 'wp_ajax_seravo_reset_shadow', 'seravo_reset_shadow' );
+
       }
     }
+
     public static function register_shadows_page() {
-      add_submenu_page( 'tools.php', __('Shadows', 'seravo'),
-      __('Shadows', 'seravo'), 'manage_options', 'shadows_page',
-      array( __CLASS__, 'load_shadows_page' ) );
+      add_submenu_page(
+        'tools.php',
+        __('Shadows', 'seravo'),
+        __('Shadows', 'seravo'),
+        'manage_options',
+        'shadows_page',
+        array( __CLASS__, 'load_shadows_page' )
+      );
+
+    }
+
+    public static function register_shadows_scripts( $page ) {
+      wp_register_style('seravo_shadows', plugin_dir_url( __DIR__ ) . '/css/shadows.css' );
+      wp_register_script( 'seravo_shadows', plugin_dir_url( __DIR__ ) . '/js/shadows.js' );
+
+      if ( $page === 'tools_page_shadows_page' ) {
+        wp_enqueue_style( 'seravo_shadows' );
+        wp_enqueue_script( 'seravo_shadows' );
+
+        $loc_translation = array(
+          'success'  => __('Success', 'seravo'),
+          'failure'  => __('Failure', 'seravo'),
+          'error'    => __('Error', 'seravo'),
+          'confirm'  => __('Are you sure? This replaces all information in the selected environment.', 'seravo'),
+        );
+
+        wp_localize_script( 'seravo_shadows', 'seravo_shadows_loc', $loc_translation );
+      }
     }
     public static function load_shadows_page() {
       require_once dirname( __FILE__ ) . '/../lib/shadows-page.php';

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -257,8 +257,10 @@ class Loader {
     /**
      * Shadows page
      */
-    if ( apply_filters('seravo_show_shadows_page', true) && current_user_can( 'administrator' ) ) {
-      require_once dirname( __FILE__ ) . '/modules/shadows.php';
+    if ( ! is_multisite() || current_user_can( 'manage_network' ) ) {
+      if ( apply_filters('seravo_show_shadows_page', true) && current_user_can( 'administrator' ) ) {
+        require_once dirname( __FILE__ ) . '/modules/shadows.php';
+      }
     }
   }
 }

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -253,6 +253,13 @@ class Loader {
     if ( defined( 'WP_CLI' ) && WP_CLI ) {
       require_once dirname( __FILE__ ) . '/modules/wp-cli.php';
     }
+
+    /**
+     * Shadows page
+     */
+    if ( apply_filters('seravo_show_shadows_page', true) && current_user_can( 'administrator' ) ) {
+      require_once dirname( __FILE__ ) . '/modules/shadows.php';
+    }
   }
 }
 


### PR DESCRIPTION
In this PR the user is given an option of resetting shadow instances from the WordPress user interface. User can track their shadow instances from a new Shadows page in their Tools menu.

![image](https://user-images.githubusercontent.com/16817737/41408158-6ba62c42-6fda-11e8-83f9-1818622299e9.png)

Pressing the ``` Reset Shadow ```-button begins the resetting operation, which is indicated to the user by disabling the button. Successful operation is indicated to the user by changing the text in the button to ```DONE```
