### PR TITLE
Introduce feature for removing unwanted plugins

### DIFF
--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -119,6 +119,7 @@ jQuery(document).ready(function($) {
     // Postbox toggle script
   jQuery('.ui-sortable-handle').on('click', function () {
     jQuery(this).parent().toggleClass("closed");
+
     if (jQuery(this).parent().hasClass("closed")) {
       jQuery(this).parents().eq(3).height(60);
     } else {
@@ -127,10 +128,12 @@ jQuery(document).ready(function($) {
   });
   jQuery('.toggle-indicator').on('click', function () {
     jQuery(this).parent().parent().toggleClass("closed");
+
     if (jQuery(this).parent().hasClass("closed")) {
       jQuery(this).parents().eq(4).height(60);
     } else {
       jQuery(this).parents().eq(4).height('auto');
     }
   });
+
 });

--- a/js/cruftplugins.js
+++ b/js/cruftplugins.js
@@ -1,0 +1,103 @@
+'use strict';
+
+
+
+
+jQuery(document).ready(function($) {
+  function seravo_ajax_delete_plugin(plugin_name, callback) {
+    $.post(
+      ajaxurl,
+      { type: 'POST',
+        'action': 'seravo_remove_plugins',
+        'removeplugin': plugin_name },
+      function( rawData ) {
+        var data = JSON.parse(rawData);
+        if ( data[ data.length - 1 ].indexOf('Success: Deleted 1 of 1 plugins.') != -1 ) {
+          callback();
+        } else {
+          confirm(seravo_cruftplugins_loc.failure);
+        }
+      });
+  }
+
+  // Generic ajax report loader function
+  function seravo_plugin_load_report(section) {
+    $.post(
+      ajaxurl,
+      { 'action': 'seravo_list_cruft_plugins',
+        'section': section },
+      function(rawData) {
+        if (rawData.length == 0) {
+          $('#' + section).html(seravo_cruftplugins_loc.no_data);
+        }
+        $('#' + section + '_loading').fadeOut();
+        var data = JSON.parse(rawData);
+        // title, name, status
+        var titles = new Array();
+        $.each( data, function( i, plugin ){
+          if (plugin.name != '') {
+            titles = seravo_print_plugin_table( titles, plugin );
+          }
+        });
+        if ( titles.length != 0 ) {
+          $( '#cruftplugins_status' ).prepend('<p>' + seravo_cruftplugins_loc.cruftplugins + '</p>');
+        } else {
+          $( '#cruftplugins_status' ).prepend('<b>' + seravo_cruftplugins_loc.no_cruftplugins + '</b>');
+        }
+        $( '#cruftplugins_status_loading img' ).fadeOut
+        $('.cruftplugin-delete-button').click(function(event) {
+          event.preventDefault();
+          var is_user_sure = confirm(seravo_cruftplugins_loc.confirm);
+          if ( ! is_user_sure ) {
+            return;
+          }
+          var parent_row = $(this).parents(':eq(1)');
+          var plugin_name = parent_row.attr('data-plugin-name');
+          seravo_ajax_delete_plugin(plugin_name, function() {
+            parent_row.animate({
+              opacity: 0
+            }, 600, function() {
+              var container = parent_row.parents().eq(0);
+              parent_row.remove();
+              // purge empty lists
+              if ( container.children().length == 0 ) {
+                container.parents(':eq(1)').remove();
+              }
+            });
+          });
+        });
+
+      }
+    ).fail(function() {
+      $('#' + section + '_loading').html(seravo_cruftplugins_loc.fail);
+    });
+  }
+  // titles for the titles that have been printed. plugin for the one which is to be printed.
+  function seravo_print_plugin_table( titles, plugin) {
+    if (titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_status').append('<div class="cruft-plugin-set"><table><tbody class="cruft-plugin-table" id="cruftplugins_' + plugin.status + '"></tbody></table></div>');
+    }
+    if (plugin.status == 'cache_plugins' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.cache_plugins + '</b><p>' + seravo_cruftplugins_loc.cache_plugins_desc + '</p>');
+    } else if (plugin.status == 'security_plugins' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.security_plugins + '</b><p>' + seravo_cruftplugins_loc.security_plugins_desc + '</p>');
+    } else if (plugin.status == 'db_plugins' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.db_plugins + '</b><p>' + seravo_cruftplugins_loc.db_plugins_desc + '</p>');
+    } else if (plugin.status == 'backup_plugins' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.backup_plugins + '</b><p>' + seravo_cruftplugins_loc.backup_plugins_desc + '</p>');
+    } else if (plugin.status == 'poor_security' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.poor_security + '</b><p>' + seravo_cruftplugins_loc.poor_security_desc + '</p>');
+    } else if (plugin.status == 'inactive' && titles.indexOf(plugin.status) == -1) {
+      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.inactive + '</b><p>' + seravo_cruftplugins_loc.inactive_desc + '</p>');
+    }
+    titles.push(plugin.status);
+    $( '#cruftplugins_' + plugin.status ).append('<tr class="cruftplugin" data-plugin-name= "' + plugin.name + '"><td class="cruftplugin-delete">' +
+      '<a href="" class="dashicons dashicons-trash cruftplugin-delete-button" >' +
+      '</td><td class="cruftplugin-path">' + plugin.title + '</td></tr>');
+
+    return titles;
+  }
+
+  // Load on page load
+  seravo_plugin_load_report('cruftplugins_status');
+});

--- a/lib/cruftfiles-page.php
+++ b/lib/cruftfiles-page.php
@@ -47,11 +47,46 @@ if ( ! defined('ABSPATH') ) {
                   </div>
                 </div>
               </div>
-              <!--First postbox: end-->
             </div>
           </div>
-          <!-- end 1 -->
+
+          <!-- container 3 -->
+          <div class="postbox-container-max">
+            <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+              <!-- -->
+              <div id="dashboard_plugins" class="postbox">
+                <button type="button" class="handlediv button-link" aria-expanded="true">
+                  <span class="screen-reader-text">Toggle panel:
+                    <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
+                  </span>
+                  <span class="toggle-indicator" aria-hidden="true"></span>
+                </button>
+                <h2 class="hndle ui-sortable-handle">
+                  <span>
+                    <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
+                  </span>
+                </h2>
+                <div class="inside">
+                  <div class="seravo-section">
+                    <p>
+                      <?php _e( 'Find and remove plugins that are unnecessary or inactive. For more information, read our <a href="https://help.seravo.com/en/knowledgebase/19-teemat-ja-lisaosat/docs/51-wordpress-lisaosat-wp-palvelu-fi-ssa">Helpy-page</a>.', 'seravo' ); ?>
+                    </p>
+                    <p>
+                      <div id="cruftplugins_status">
+                        <div id="cruftplugins_status_loading">
+                          <?php _e( 'Finding plugins...', 'seravo' ); ?>
+                          <img src="/wp-admin/images/spinner.gif">
+                        </div>
+                      </div>
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <!-- -->
+            </div>
+
+          </div>
+          <!-- end 3 -->
         </div>
       </div>
     </div>
-  </div>

--- a/lib/cruftplugins-ajax.php
+++ b/lib/cruftplugins-ajax.php
@@ -1,0 +1,107 @@
+<?php
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+// [plugin, reason, size]
+function seravo_ajax_list_cruft_plugins() {
+  exec('wp plugin list --fields=name,title,status --format=json --skip-plugins --skip-themes', $output);
+    //https://help.seravo.com/en/knowledgebase/19-themes-and-plugins/docs/51-wordpress-plugins-in-seravo-com
+    $plugins_list = array(
+      'cache_plugins' => array(                               //Unneeded cache plugins
+        'w3-total-cache',
+        'wp-super-cache',
+        'wp-file-cache',
+        'wp-fastest-cache',
+        'litespeed-cache',
+        'comet-cache',
+	  ),
+      'security_plugins' => array(                            //False sense of security
+        'better-wp-security',                                 //iThemes Security aka Better WP Security
+        'wordfence',
+        'limit-login-attempts-reloaded',
+        'wp-limit-login-attempts',
+        'wordfence-assistant',
+      ),
+      'db_plugins' => array(                                  //Known to mess up your DB
+        'broken-link-checker',                               //Broken Link Checker
+        'tweet-blender',                                     //Tweet Blender
+      ),
+      'backup_plugins' => array(                             //A list of most used backup-plugins
+        'updraftplus',
+        'backwpup',
+        'jetpack',
+        'duplicator',
+        'backup',
+        'all-in-one-wp-migration',
+        'dropbox-backup',
+        'wp-db-backup',
+        'really-simple-ssl',
+        'xcloner-backup-and-restore',
+      ),
+      'poor_security' => array(                             //Known for poor security
+        'wp-phpmyadmin-extension',                          //phpMyAdmin
+        'ari-adminer',                                      //Adminer
+        'sweetcaptcha-revolutionary-free-captcha-service',  //Sweet Captcha
+        'wp-cerber',
+        'sucuri-scanner',
+        'wp-simple-firewall',
+      ),
+      'bad_code' => array(                                  //Hard to differentiate from actual malicious
+        'wp-client',
+        'wp-filebase-pro',
+        'miniorange-oauth-client-premium',
+      ),
+      'foolish_plugins' => array(                            //Not malicious but do unwanted things
+        'all-in-one-wp-migration',
+        'video-capture',
+        'simple-subscribe',
+      ),
+    );
+    $remove_from_list = array();
+    $output = json_decode($output[0]);
+  foreach ( $output  as $plugin ) {
+    //as default, we want to keep plugins - ie, remove them from the suggestions
+    $rm_tag = true;
+    foreach ( $plugins_list as $plugin_set_title => $plugins_set ) {
+      if ( in_array($plugin->name, $plugins_set) ) {
+        $plugin->status = $plugin_set_title;
+        $rm_tag = false;
+      }
+    }
+    if ( $plugin->status != 'inactive' && $rm_tag ) {
+      $remove_from_list[] = $plugin;
+    }
+  }
+    $output = array_udiff($output, $remove_from_list,
+      function ( $obj_a, $obj_b ) {
+        return $obj_a->name <=> $obj_b->name;
+      }
+    );
+  //to check if the system has these
+  set_transient('cruft_plugins_found', $output, 600);
+  echo json_encode($output);
+  wp_die();
+}
+
+function seravo_ajax_remove_plugins() {
+  if ( isset($_POST['removeplugin']) && ! empty($_POST['removeplugin']) ) {
+    $plugins = $_POST['removeplugin'];
+    if ( is_string($plugins) ) {
+      $plugins = array( $plugins );
+    }
+    if ( ! empty($plugins) ) {
+      $result = array();
+      foreach ( $plugins as $plugin ) {
+        $legit_removeable_plugins = get_transient('cruft_plugins_found');
+        foreach ( $legit_removeable_plugins as $legit_plugin ) {
+          if ( $legit_plugin->name == $plugin ) {
+            exec( 'wp plugin deactivate ' . $plugin . ' --skip-plugins --skip-themes && wp plugin delete ' . $plugin . ' --skip-plugins --skip-themes', $output );
+          }
+        }
+      }
+    }
+  }
+  echo json_encode($output);
+  wp_die();
+}

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -13,6 +13,7 @@ if ( ! defined('ABSPATH') ) {
 }
 
 require_once dirname( __FILE__ ) . '/../lib/cruftfiles-ajax.php';
+require_once dirname( __FILE__ ) . '/../lib/cruftplugins-ajax.php';
 
 if ( ! class_exists('Cruftfiles') ) {
   class Cruftfiles {
@@ -24,6 +25,10 @@ if ( ! class_exists('Cruftfiles') ) {
       // AJAX functionality for listing and deleting files
       add_action( 'wp_ajax_seravo_cruftfiles', 'seravo_ajax_list_cruft_files' );
       add_action( 'wp_ajax_seravo_delete_file', 'seravo_ajax_delete_cruft_files' );
+
+      // AJAX functionality for listing ... plugins
+      add_action( 'wp_ajax_seravo_list_cruft_plugins', 'seravo_ajax_list_cruft_plugins' );
+      add_action( 'wp_ajax_seravo_remove_plugins', 'seravo_ajax_remove_plugins' );
     }
 
     public static function register_cruftfiles_page() {
@@ -91,13 +96,15 @@ if ( ! class_exists('Cruftfiles') ) {
     public static function enqueue_cruftfiles_scripts( $hook ) {
       wp_register_style( 'seravo_cruftfiles', plugin_dir_url( __DIR__ ) . '/style/cruftfiles.css' );
       wp_register_script( 'seravo_cruftfiles', plugin_dir_url( __DIR__ ) . '/js/cruftfiles.js' );
+      wp_register_script( 'seravo_cruftplugins', plugin_dir_url( __DIR__ ) . '/js/cruftplugins.js' );
 
       if ( $hook === 'tools_page_cruftfiles_page' ) {
         wp_enqueue_style( 'seravo_cruftfiles' );
         wp_enqueue_script( 'seravo_cruftfiles' );
+        wp_enqueue_script( 'seravo_cruftplugins' );
 
         // Localize the javascript file.
-        $loc_translation = array(
+        $loc_translation_files = array(
           'no_data'       => __( 'No data returned for section.', 'seravo' ),
           'confirm'       => __( 'Are you sure you want to proceed? Deleted files can not be recovered.', 'seravo' ),
           'fail'          => __( 'Failed to load. Please try again.', 'seravo' ),
@@ -108,7 +115,26 @@ if ( ! class_exists('Cruftfiles') ) {
           'select_all'    => __( 'Select all files', 'seravo' ),
           'filesize'      => __( 'Filesize', 'seravo' ),
         );
-        wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation );
+        $loc_translation_plugins = array(
+          'inactive'                => __( 'Inactive plugins:', 'seravo' ),
+          'inactive_desc'           => __( 'These plugins are currently not in use. They can be removed to save disk storage.' ),
+          'cache_plugins'           => __( 'Unnecessary cache plugins:', 'seravo' ),
+          'cache_plugins_desc'      => __( 'Your website runs on a server which has serverside caching. Any plugins that provide caching can not improve upon the provided service.', 'seravo' ),
+          'security_plugins'        => __( 'Unnecessary security plugins:', 'seravo' ),
+          'security_plugins_desc'   => __( 'Your website runs on a server which has been configured to a high level of security. Any plugins providing security services only slow your website down.', 'seravo' ),
+          'db_plugins'              => __( 'Unnecessary database manipulating plugins:', 'seravo' ),
+          'db_plugins_desc'         => __( 'These plugins may cause issues with your database.', 'seravo' ),
+          'backup_plugins'          => __( 'Unnecessary backup plugins:', 'seravo' ),
+          'backup_plugins_desc'     => __( 'Backups of your website are taken automatically on the server daily. Any plugins creating backups are redundant and unnecessesarily fill up data storage.', 'seravo' ),
+          'poor_security'           => __( 'Plugins that are not very secure:', 'seravo' ),
+          'poor_security_desc'      => __( 'These plugins are known to have issues with security.', 'seravo' ),
+          'no_cruftplugins'         => __( 'All plugins are currently active and approved.', 'seravo' ),
+          'cruftplugins'            => __( 'The following plugins have been found and are suggested for removal', 'seravo' ),
+          'confirm'                 => __( 'Are you sure you want to remove this plugin?', 'seravo' ),
+          'failure'                 => __( 'Failed to remove plugin', 'seravo' ),
+        );
+        wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation_files );
+        wp_localize_script( 'seravo_cruftplugins', 'seravo_cruftplugins_loc', $loc_translation_plugins );
       }
     }
   }

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -15,7 +15,9 @@
   outline: none;
   box-shadow: none;
 }
-
+.cruft-plugin-set {
+  padding-top: 15px;
+}
 .inside {
   padding: 10px 15px 0px 15px!important;
 }
@@ -31,6 +33,7 @@
 .cruft-tool-selector {
   background-color: antiquewhite;
 }
+
 @media only screen and (min-width: 1500px) {
   #wpbody-content #dashboard-widgets .postbox-container {
     width: 50%;


### PR DESCRIPTION
This PR introduces a feature which allows the user to remove inactive plugins. The feature also suggests pre-selected plugins that are known to be for some reason unnecessary or cause issues for some users.

When the user has no such plugins:
![image](https://user-images.githubusercontent.com/16817737/41915726-121b340e-795f-11e8-84eb-0404e243d606.png)

When the user has plugins that are considered removeable:
![image](https://user-images.githubusercontent.com/16817737/41915817-4bc6030a-795f-11e8-8865-94ad1abfb140.png)

When the user clicks one of the trashcans, a notification will appear:

Confirm-notification:
![image](https://user-images.githubusercontent.com/16817737/41915867-677d8ec4-795f-11e8-8522-52f754652d19.png)

After confirmation and successful removal, the item is removed from the list.
If the removal fails, a similar notification is to be shown.