### PR TITLE
Show more information on suggested cruft-files

### DIFF
--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -36,7 +36,7 @@ jQuery(document).ready(function($) {
             filecount++;
             //This row needs to print the filesizes
             $( '#cruftfiles_entries' ).append('<tr class="cruftfile"><td class="cruftfile-delete"><input data-file-name="' + file.filename + '" class="cruftfile-check" type="checkbox"></td><td class="cruftfile-path">'
-                                                + file.filename + '</td><td style="float:right;">'+file.size+seravo_cruftfiles_loc.bytes+'</td></tr>');
+                                                + file.filename + '</td><td>'+file.mod_date+'</td><td style="float:right;">'+file.size+seravo_cruftfiles_loc.bytes+'</td></tr>');
           }
         });
         if (filecount == 0) {
@@ -44,8 +44,8 @@ jQuery(document).ready(function($) {
           $( '#cruftfiles_status' ).append('<b>' + seravo_cruftfiles_loc.no_cruftfiles + '</b>');
         } else {
 
-          $( '#cruftfiles_entries' ).parents(':eq(0)').prepend('<thead><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>Select all files</b></td></tr></thead>');
-          $( '#cruftfiles_entries' ).parents(':eq(0)').append('<tfoot class="less-than"><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>Select all files</b></td></tr></tfoot>');
+          $( '#cruftfiles_entries' ).parents(':eq(0)').prepend('<thead><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>'+seravo_cruftfiles_loc.select_all+'</b></td><td>'+seravo_cruftfiles_loc.mod_date+'</td><td>'+seravo_cruftfiles_loc.filesize+'</td></tr></thead>');
+          $( '#cruftfiles_entries' ).parents(':eq(0)').append('<tfoot class="less-than"><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>'+seravo_cruftfiles_loc.select_all+'</b></td><td>'+seravo_cruftfiles_loc.mod_date+'</td><td>'+seravo_cruftfiles_loc.filesize+'</td></tr></tfoot>');
           $( '#cruftfiles_status' ).append('<button class="cruftfile-delete-button button" type="button">' + seravo_cruftfiles_loc.delete + '</b>');
           if ( filecount < 30 ) {
             $( '.less-than' ).hide();

--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -29,12 +29,14 @@ jQuery(document).ready(function($) {
         }
         $('#' + section + '_loading').fadeOut();
         var data = JSON.parse(rawData);
+        console.log(data);
         var filecount = 0;
         $.each( data, function( i, file){
-          if (file != '') {
+          if (file.filename != '') {
             filecount++;
-            $( '#cruftfiles_entries' ).append('<tr class="cruftfile"><td class="cruftfile-delete"><input data-file-name="' + file + '" class="cruftfile-check" type="checkbox"></td><td class="cruftfile-path">'
-                                                + file + '</td></tr>');
+            //This row needs to print the filesizes
+            $( '#cruftfiles_entries' ).append('<tr class="cruftfile"><td class="cruftfile-delete"><input data-file-name="' + file.filename + '" class="cruftfile-check" type="checkbox"></td><td class="cruftfile-path">'
+                                                + file.filename + '</td><td style="float:right;">'+file.size+seravo_cruftfiles_loc.bytes+'</td></tr>');
           }
         });
         if (filecount == 0) {

--- a/js/cruftfiles.js
+++ b/js/cruftfiles.js
@@ -29,14 +29,13 @@ jQuery(document).ready(function($) {
         }
         $('#' + section + '_loading').fadeOut();
         var data = JSON.parse(rawData);
-        console.log(data);
         var filecount = 0;
         $.each( data, function( i, file){
           if (file.filename != '') {
             filecount++;
             //This row needs to print the filesizes
             $( '#cruftfiles_entries' ).append('<tr class="cruftfile"><td class="cruftfile-delete"><input data-file-name="' + file.filename + '" class="cruftfile-check" type="checkbox"></td><td class="cruftfile-path">'
-                                                + file.filename + '</td><td>'+file.mod_date+'</td><td style="float:right;">'+file.size+seravo_cruftfiles_loc.bytes+'</td></tr>');
+                                                + file.filename + '</td><td>' + file.mod_date + '</td><td style="float:right;">' + file.size + seravo_cruftfiles_loc.bytes + '</td></tr>');
           }
         });
         if (filecount == 0) {
@@ -44,8 +43,8 @@ jQuery(document).ready(function($) {
           $( '#cruftfiles_status' ).append('<b>' + seravo_cruftfiles_loc.no_cruftfiles + '</b>');
         } else {
 
-          $( '#cruftfiles_entries' ).parents(':eq(0)').prepend('<thead><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>'+seravo_cruftfiles_loc.select_all+'</b></td><td>'+seravo_cruftfiles_loc.mod_date+'</td><td>'+seravo_cruftfiles_loc.filesize+'</td></tr></thead>');
-          $( '#cruftfiles_entries' ).parents(':eq(0)').append('<tfoot class="less-than"><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>'+seravo_cruftfiles_loc.select_all+'</b></td><td>'+seravo_cruftfiles_loc.mod_date+'</td><td>'+seravo_cruftfiles_loc.filesize+'</td></tr></tfoot>');
+          $( '#cruftfiles_entries' ).parents(':eq(0)').prepend('<thead><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>' + seravo_cruftfiles_loc.select_all + '</b></td><td class="cruft-tool-selector">' + seravo_cruftfiles_loc.mod_date + '</td><td class="cruft-tool-selector">' + seravo_cruftfiles_loc.filesize + '</td></tr></thead>');
+          $( '#cruftfiles_entries' ).parents(':eq(0)').append('<tfoot class="less-than"><tr><td><input class="cruftfile-select-all" type="checkbox" ></td><td class="cruft-tool-selector"><b>' + seravo_cruftfiles_loc.select_all + '</b></td><td class="cruft-tool-selector">' + seravo_cruftfiles_loc.mod_date + '</td><td class="cruft-tool-selector">' + seravo_cruftfiles_loc.filesize + '</td></tr></tfoot>');
           $( '#cruftfiles_status' ).append('<button class="cruftfile-delete-button button" type="button">' + seravo_cruftfiles_loc.delete + '</b>');
           if ( filecount < 30 ) {
             $( '.less-than' ).hide();

--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -5,10 +5,11 @@ if ( ! defined('ABSPATH') ) {
 }
 
 function add_file_information( $file ) {
-  exec( 'du ' . $file . ' -h', $output );
+  exec( 'du ' . $file . ' -h --time', $output );
   $size = explode("\t" ,$output[0]);
 
   $data['size'] = $size[0];
+  $data['mod_date'] = $size[1];
   $data['filename'] = $file;
   return $data;
 

--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -4,6 +4,16 @@ if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 
+function add_file_information( $file ) {
+  exec( 'du ' . $file . ' -h', $output );
+  $size = explode("\t" ,$output[0]);
+
+  $data['size'] = $size[0];
+  $data['filename'] = $file;
+  return $data;
+
+}
+
 function find_cruft_file( $name ) {
   exec('find /data/wordpress -name ' . $name, $output);
   return $output;
@@ -133,6 +143,9 @@ function seravo_ajax_list_cruft_files() {
       }
       $crufts = array_unique($crufts);
       set_transient('cruft_files_found', $crufts, 600);
+      
+      $crufts = array_map("add_file_information", $crufts);
+      error_log(json_encode($crufts));
       echo wp_json_encode($crufts);
       break;
 

--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -6,7 +6,7 @@ if ( ! defined('ABSPATH') ) {
 
 function add_file_information( $file ) {
   exec( 'du ' . $file . ' -h --time', $output );
-  $size = explode("\t" ,$output[0]);
+  $size = explode("\t", $output[0]);
 
   $data['size'] = $size[0];
   $data['mod_date'] = $size[1];
@@ -144,9 +144,8 @@ function seravo_ajax_list_cruft_files() {
       }
       $crufts = array_unique($crufts);
       set_transient('cruft_files_found', $crufts, 600);
-      
-      $crufts = array_map("add_file_information", $crufts);
-      error_log(json_encode($crufts));
+
+      $crufts = array_map('add_file_information', $crufts);
       echo wp_json_encode($crufts);
       break;
 

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -103,6 +103,7 @@ if ( ! class_exists('Cruftfiles') ) {
           'fail'          => __( 'Failed to load. Please try again.', 'seravo' ),
           'no_cruftfiles' => __( 'Congratulations! You have no any cruft around.', 'seravo' ),
           'delete'        => __( 'Delete', 'seravo' ),
+          'bytes'         => __( 'b', 'seravo' ),
         );
         wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation );
       }

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -104,6 +104,9 @@ if ( ! class_exists('Cruftfiles') ) {
           'no_cruftfiles' => __( 'Congratulations! You have no any cruft around.', 'seravo' ),
           'delete'        => __( 'Delete', 'seravo' ),
           'bytes'         => __( 'b', 'seravo' ),
+          'mod_date'      => __( 'Last modified', 'seravo' ),
+          'select_all'    => __( 'Select all files', 'seravo' ),
+          'filesize'      => __( 'Filesize', 'seravo' ),
         );
         wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation );
       }

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -37,6 +37,10 @@
   }
 }
 
+td {
+  padding-right: 15px;
+}
+
 @media only screen and (max-width: 1025px) {
   .label_buttons {
     display: block;


### PR DESCRIPTION
Removing cruft-files reduces clutter from the users' websites reducing disk usage. However, removing files should be done carefully, and this can be achieved by giving the user more information.

In this PR the cruft remover is enhanced by showing the user the last file modification date and file size.

![image](https://user-images.githubusercontent.com/16817737/42088802-85b5d4be-7ba3-11e8-80c2-ae23d1dc7086.png)
