### PR TITLE
Refactor existing Tests and Reports -pages to current architecture

### DIFF
--- a/js/reports.js
+++ b/js/reports.js
@@ -1,0 +1,87 @@
+'use strict';
+// Generic ajax report loader function
+jQuery(document).ready(function($) {
+
+  function seravo_load_http_request_reports(){
+    $.post(
+      ajaxurl,
+      {'action': 'seravo_report_http_requests'},
+      function(rawData) {
+        var data = JSON.parse(rawData);
+        //test if this is still valid
+        if (data.length == 0) {
+          //echo '<tr><td colspan=3>' . seravo_reports.no_reports . '</td></tr>';
+          jQuery('#http-requests_info').html(seravo_reports_loc.no_reports);
+        } else {
+          // take months separately
+
+          //max value is in it's own little container
+          var result = data.filter(function( obj ) {
+            return obj.hasOwnProperty('max_requests');
+          });
+          var max_requests = result[0].max_requests;
+
+          data.forEach( function(month) {
+            if (month.hasOwnProperty('date')) {
+              var bar_size = month.requests / max_requests;
+              if ( bar_size <= 10 ) {
+                var bar_css = 'auto';
+              } else {
+                var bar_css = bar_size + '%';
+              }
+              jQuery( '#http-reports_table' ).prepend('<tr><td><a href="?report=' +
+              month.date +
+              '.html" target="_blank"> ' +
+              month.date +
+              ' </a> </td> <td><div style="background: #44A1CB; color: #fff; padding: 3px; width: ' +
+              bar_css +
+              '; display: inline-block;">' +
+              month.requests +
+              '</div></td> <td><a href="?report=-' +
+              month.date +
+              '.html" target="_blank" class="button hideMobile">' +
+              seravo_reports_loc.view_report +
+              '<span aria-hidden="true" class="dashicons dashicons-external" style="line-height: unset; padding-left: 3px;"></span></a></td></tr>'
+              );
+            }
+
+          });
+        }
+      }
+    );
+  }
+
+  function seravo_load_report(section) {
+    jQuery.post(ajaxurl, { 'action': 'seravo_reports', 'section': section }, function(rawData) {
+      if (rawData.length == 0) {
+        jQuery('#' + section).html(seravo_reports.no_data);
+      }
+
+      if (section === 'folders_chart') {
+        var allData = JSON.parse(rawData);
+        jQuery('#total_disk_usage').text(allData.data.human);
+        generateChart(allData.dataFolders);
+      } else {
+        var data = JSON.parse(rawData);
+        jQuery('#' + section).text(data.join("\n"));
+      }
+      jQuery('.' + section + '_loading').fadeOut();
+    }).fail(function() {
+      jQuery('.' + section + '_loading').html(seravo_reports.failed);
+    });
+  }
+  seravo_load_http_request_reports();
+  seravo_load_report('folders_chart');
+  seravo_load_report('wp_core_verify');
+  seravo_load_report('git_status');
+  seravo_load_report('redis_info');
+  seravo_load_report('front_cache_status');
+
+  // Accordion script
+  jQuery('.ui-sortable-handle').on('click', function () {
+    jQuery(this).parent().toggleClass("closed");
+  });
+  jQuery('.toggle-indicator').on('click', function () {
+    jQuery(this).parent().parent().toggleClass("closed");
+  });
+});

--- a/lib/reports-ajax.php
+++ b/lib/reports-ajax.php
@@ -6,6 +6,39 @@ if ( ! defined('ABSPATH') ) {
 
 use Seravo\Helpers;
 
+function seravo_ajax_report_http_requests() {
+  $reports = glob('/data/slog/html/goaccess-*.html');
+  // Create array of months with total request sums
+  $months = array();
+  // Track max request value to calculate relative bar widths
+  $max_requests = 0;
+  foreach ( $reports as $report ) {
+    $total_requests_string = exec("grep -oE 'total_requests\": ([0-9]+),' $report");
+    preg_match('/([0-9]+)/', $total_requests_string, $total_requests_match);
+    $total_requests = intval($total_requests_match[1]);
+    if ( $total_requests > $max_requests ) {
+      $max_requests = $total_requests;
+    }
+    array_push(
+      $months,
+      array(
+        'date'     => substr($report, 25, 7),
+        'requests' => $total_requests,
+      )
+    );
+  }
+  if ( count($months) > 0 ) {
+    array_push(
+      $months,
+      array(
+        'max_requests' => $max_requests,
+      ));
+  }
+  echo wp_json_encode($months);
+  wp_die();
+}
+
+
 function seravo_report_folders() {
   exec ('du -sb /data', $data_folder);
   list($data_size, $data_name) = preg_split('/\s+/', $data_folder[0]);

--- a/lib/reports-page.php
+++ b/lib/reports-page.php
@@ -8,6 +8,7 @@ if ( ! defined('ABSPATH') ) {
 <div id="wpbody" role="main">
   <div id="wpbody-content" aria-label="Main content" tabindex="0">
     <div class="wrap">
+    <div class="dashboard-widgets-wrap">
       <div id="dashboard-widgets" class="metabox-holder">
         <div class="postbox-container">
           <div id="normal-sortables" class="meta-box-sortables ui-sortable">
@@ -24,7 +25,7 @@ if ( ! defined('ABSPATH') ) {
                 <div style="padding: 0px 15px;">
                   <p><?php _e('These monthly reports are generated from the site\'s HTTP access logs. They show every HTTP request of the site, including traffic from both humans and bots. Requests blocked at the firewall level (for example during a DDOS attack) are not logged. Log files can be accessed also directly on the server at <code>/data/slog/html/goaccess-*.html</code>.', 'seravo'); ?></p>
                 </div>
-                <div style="padding: 0px;">
+                <div class="http-requests_info_loading" style="padding: 0px;">
                   <table class="widefat fixed striped" style="width: 100%; border: none;">
                     <thead>
                       <tr>
@@ -33,68 +34,14 @@ if ( ! defined('ABSPATH') ) {
                         <th style="width: 25%;"><?php _e('Report', 'seravo'); ?></th>
                       </tr>
                     </thead>
-                    <tbody>
-                      <?php
-                      $reports = glob('/data/slog/html/goaccess-*.html');
-                      // Create array of months with total request sums
-                      $months = array();
-
-                      // Track max request value to calculate relative bar widths
-                      $max_requests = 0;
-
-                      if ( empty($reports) ) {
-                        echo '<tr><td colspan=3>' . __('No reports found at /data/slog/html/. Reports should be available within a month of the creation of a new site.', 'seravo') . '</td></tr>';
-                      } else {
-                        foreach ( $reports as $report ) {
-                          $total_requests_string = exec("grep -oE 'total_requests\": ([0-9]+),' $report");
-                          preg_match('/([0-9]+)/', $total_requests_string, $total_requests_match);
-                          $total_requests = intval($total_requests_match[1]);
-                          if ( $total_requests > $max_requests ) {
-                            $max_requests = $total_requests;
-                          }
-                          array_push(
-                            $months,
-                            array(
-                              'date'     => substr($report, 25, 7),
-                              'requests' => $total_requests,
-                            )
-                          );
-                        }
-                      }
-
-                      // List months in reverse order with newest first
-                      rsort($months);
-
-                      foreach ( $months as $month ) {
-                        $bar_size = intval( $month['requests'] / $max_requests * 100 );
-                        if ( $bar_size <= 10 ) {
-                          $bar_css = 'auto';
-                        } else {
-                          $bar_css = $bar_size . '%';
-                        }
-                        ?>
-                        <tr>
-                          <td>
-                            <a href='?report=<?php echo $month['date']; ?>.html' target='_blank'>
-                              <?php echo $month['date']; ?>
-                            </a>
-                          </td>
-                          <td>
-                            <div style='background: #44A1CB; color: #fff; padding: 3px; width: " <?php echo $bar_css; ?> "; display: inline-block;'>
-                              <?php echo $month['requests']; ?>
-                            </div>
-                          </td>
-                          <td>
-                            <a href='?report=<?php echo $month['date']; ?>.html' target='_blank' class='button hideMobile'>
-                              <?php echo __('View report', 'seravo'); ?>
-                              <span aria-hidden="true" class="dashicons dashicons-external" style="line-height: unset; padding-left: 3px;"></span>
-                            </a>
-                          </td>
-                        </tr>
-                      <?php } ?>
+                    <tbody id="http-reports_table">
+                      
                     </tbody>
                   </table>
+
+
                 </div>
+                <pre id="http-requests_info"></pre>
               </div>
             </div>
           <!--First postbox: end-->
@@ -186,85 +133,6 @@ if ( ! defined('ABSPATH') ) {
         </div>
       </div>
     </div>
+    </div>
   </div>
-
-  <?php
-    wp_register_script( 'chart-js', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js', null, null, true );
-    wp_enqueue_script('chart-js');
-    wp_enqueue_script( 'color-hash', plugins_url( '../js/color-hash.js', __FILE__), 'jquery', null, false );
-    wp_enqueue_script( 'reports-chart', plugins_url( '../js/reports-chart.js', __FILE__), 'jquery', null, false );
-  ?>
-
-  <script>
-    // Generic ajax report loader function
-    function seravo_load_report(section) {
-      jQuery.post(ajaxurl, { 'action': 'seravo_reports', 'section': section }, function(rawData) {
-        if (rawData.length == 0) {
-          jQuery('#' + section).html('No data returned for section.');
-        }
-
-        if (section === 'folders_chart') {
-          var allData = JSON.parse(rawData);
-          jQuery('#total_disk_usage').text(allData.data.human);
-          generateChart(allData.dataFolders);
-        } else {
-          var data = JSON.parse(rawData);
-          jQuery('#' + section).text(data.join("\n"));
-        }
-        jQuery('.' + section + '_loading').fadeOut();
-      }).fail(function() {
-        jQuery('.' + section + '_loading').html('Failed to load. Please try again.');
-      });
-    }
-
-    seravo_load_report('folders_chart');
-    seravo_load_report('wp_core_verify');
-    seravo_load_report('git_status');
-    seravo_load_report('redis_info');
-    seravo_load_report('front_cache_status');
-
-    // Accordion script
-    jQuery('.ui-sortable-handle').on('click', function () {
-      jQuery(this).parent().toggleClass("closed");
-    });
-    jQuery('.toggle-indicator').on('click', function () {
-      jQuery(this).parent().parent().toggleClass("closed");
-    });
-  </script>
 </div>
-
-<style>
-  @media only screen and (min-width: 1500px) {
-    #wpbody-content #dashboard-widgets .postbox-container {
-      width: 50%;
-    }
-  }
-  .js .widget .widget-top, .js .postbox .hndle {
-    cursor: pointer;
-  }
-  pre {
-    overflow: auto;
-    padding-bottom: 15px;
-  }
-  @media only screen and (max-width: 1430px) {
-    .hideMobile {
-      font-size: 0px!important;
-    }
-  }
-  /* Scrollbar on mobile*/
-  ::-webkit-scrollbar {
-    -webkit-appearance: none;
-  }
-  ::-webkit-scrollbar:horizontal {
-    height: 12px;
-  }
-  ::-webkit-scrollbar-thumb {
-    background-color: rgba(0, 0, 0, .5);
-    border-radius: 10px;
-    border: 2px solid #dddede;
-  }
-  ::-webkit-scrollbar-track {
-    border-radius: 10px;
-    background-color: #dddede;
-  }
-</style>

--- a/lib/tests-page.php
+++ b/lib/tests-page.php
@@ -7,36 +7,53 @@ if ( ! defined('ABSPATH') ) {
 
 <div class="wrap">
 
-    <h1><?php _e('Tests', 'seravo'); ?> (beta)</h1>
-
-    <p>
-        <?php
-            _e('Here you can test the core functionality of the WordPress installation on your site.
-                The same effect can be achieved via command line by running <code>wp-test</code>.
-                For more information, check the <a href="https://seravo.com/docs/tests/integration-tests/">
-                Seravo documentation for developers</a>.', 'seravo');
-            ?>
-    </p>
-
-    <button type="button" class="button-primary" id="run-wp-tests"><?php _e('Run Tests', 'seravo'); ?></button>
-
-    <div class="seravo-test-result-wrapper">
-
-        <div class="seravo-test-status" id="seravo_tests_status">
-            <?php _e('Click "Run Tests" to run the Rspec tests', 'seravo'); ?>
-        </div>
-
-        <div id="seravo_test_show_more_wrapper">
-            <a href="" id="seravo_test_show_more"><?php _e('Toggle details', 'seravo'); ?>
-                <div class="dashicons dashicons-arrow-down-alt2" id="seravo_arrow_show_more">
+<div id="wpbody-content" aria-label="Main content" tabindex="0">
+  <div class="wrap">
+    <div class="dashboard-widgets-wrap">
+      <div id="dashboard-widgets" class="metabox-holder">
+        <div class="postbox-container">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!--First postbox:-->
+            <div id="dashboard_tests" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel: <?php _e('Database access', 'seravo'); ?></span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span><?php _e('Tests', 'seravo'); ?> (beta)</span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p>
+                    <?php
+                      _e('Here you can test the core functionality of the WordPress installation on your site.
+                        The same effect can be achieved via command line by running <code>wp-test</code>.
+                        For more information, check the <a href="https://seravo.com/docs/tests/integration-tests/">
+                        Seravo documentation for developers</a>.', 'seravo');
+                      ?>
+                  </p>
+                  <button type="button" class="button-primary" id="run-wp-tests"><?php _e('Run Tests', 'seravo'); ?></button>
+                  <div class="seravo-test-result-wrapper">
+                    <div class="seravo-test-status" id="seravo_tests_status">
+                      <?php _e('Click "Run Tests" to run the Rspec tests', 'seravo'); ?>
+                    </div>
+                    <div class="seravo-test-result">
+                      <pre id="seravo_tests"></pre>
+                    </div>
+                    <div id="seravo_test_show_more_wrapper">
+                      <a href="" id="seravo_test_show_more"><?php _e('Toggle details', 'seravo'); ?>
+                        <div class="dashicons dashicons-arrow-down-alt2" id="seravo_arrow_show_more">
+                        </div>
+                      </a>
+                    </div>
+                  </div>
                 </div>
-            </a>
+              </div>
+            </div>
+            <!--First postbox...-->
+          </div>
         </div>
-
-        <div class="seravo-test-result">
-            <pre id="seravo_tests"></pre>
-        </div>
-
+      </div>
     </div>
-
+  </div>
 </div>

--- a/modules/reports.php
+++ b/modules/reports.php
@@ -19,8 +19,11 @@ if ( ! class_exists('Reports') ) {
     public static function load() {
       add_action( 'admin_menu', array( __CLASS__, 'register_reports_page' ) );
 
+      add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_reports_scripts' ) );
+
       // Add AJAX endpoint for receiving data for various reports
       add_action('wp_ajax_seravo_reports', 'seravo_ajax_reports');
+      add_action('wp_ajax_seravo_report_http_requests', 'seravo_ajax_report_http_requests');
 
       // TODO: check if this hook actually ever fires for mu-plugins
       register_activation_hook( __FILE__, array( __CLASS__, 'register_view_reports_capability' ) );
@@ -32,6 +35,28 @@ if ( ! class_exists('Reports') ) {
 
     public static function load_reports_page() {
       require_once dirname( __FILE__ ) . '/../lib/reports-page.php';
+    }
+
+    public static function enqueue_reports_scripts( $page ) {
+      wp_register_script( 'chart-js', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js', null, null, true );
+      wp_register_script( 'seravo_reports', plugin_dir_url( __DIR__ ) . '/js/reports.js');
+      wp_register_style( 'seravo_reports', plugin_dir_url( __DIR__ ) . '/style/reports.css' );
+      if ( $page === 'tools_page_reports_page' ) {
+        wp_enqueue_style( 'seravo_reports' );
+        wp_enqueue_script('chart-js');
+        wp_enqueue_script( 'color-hash', plugins_url( '../js/color-hash.js', __FILE__), 'jquery', null, false );
+        wp_enqueue_script( 'reports-chart', plugins_url( '../js/reports-chart.js', __FILE__), 'jquery', null, false );
+        wp_enqueue_script( 'seravo_reports' );
+
+        $loc_translation = array(
+          'no_data' => __('No data returned for section.', 'seravo'),
+          'failed' => __('Failed to load. Please try again.', 'seravo'),
+          'no_reports' => __('No reports found at /data/slog/html/. Reports should be available within a month of the creation of a new site.', 'seravo'),
+          'view_report' => __('View report', 'seravo'),
+
+        );
+        wp_localize_script( 'seravo_reports', 'seravo_reports_loc', $loc_translation );
+      }
     }
 
   }

--- a/style/reports.css
+++ b/style/reports.css
@@ -1,0 +1,33 @@
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+pre {
+  overflow: auto;
+  padding-bottom: 15px;
+}
+@media only screen and (max-width: 1430px) {
+  .hideMobile {
+    font-size: 0px!important;
+  }
+}
+/* Scrollbar on mobile*/
+::-webkit-scrollbar {
+  -webkit-appearance: none;
+}
+::-webkit-scrollbar:horizontal {
+  height: 12px;
+}
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, .5);
+  border-radius: 10px;
+  border: 2px solid #dddede;
+}
+::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: #dddede;
+}

--- a/style/tests.css
+++ b/style/tests.css
@@ -2,7 +2,7 @@
     display: block;
     min-height: 5em;
     max-width: 55em;
-    overflow: auto;
+    overflow: hidden;
     border-left: solid 0.5em #e8ba1b;
     -moz-transition: border 1s ease-in;
     -webkit-transition: border 1s ease-in;
@@ -25,6 +25,7 @@
     font-weight: bold;
     text-align: center;
     margin-top: 1.6em;
+    padding-bottom: 7px;
 }
 #seravo_test_show_more_wrapper {
     display: none;


### PR DESCRIPTION
In this changes have been made to the Tests and Reports -pages in order to make future changes easier. The pages are now more similar to how the Cruft remover and Shadows -pages work. With these changes it's easier to redesign the plugin menu layout as described in #98 and #142.