### PR TITLE
Fix backwards compatibility issue

### DIFF
--- a/lib/cruftplugins-ajax.php
+++ b/lib/cruftplugins-ajax.php
@@ -75,7 +75,7 @@ function seravo_ajax_list_cruft_plugins() {
   }
     $output = array_udiff($output, $remove_from_list,
       function ( $obj_a, $obj_b ) {
-        return $obj_a->name <=> $obj_b->name;
+        return strcmp($obj_a->name, $obj_b->name);
       }
     );
   //to check if the system has these


### PR DESCRIPTION
A number of websites are not running on the latest version of PHP at this time. With this commit the cruft plugin/file remover is compatible with older PHP versions, such as PHP 5.6.