### PR TITLE
Allow updates -tool-page fail gracefully

### DIFF
--- a/lib/updates-page.php
+++ b/lib/updates-page.php
@@ -29,47 +29,51 @@ if ( ! defined('ABSPATH') ) {
               <h2 class="hndle ui-sortable-handle">
                 <span><?php _e('Seravo updates', 'seravo'); ?></span>
               </h2>
-              <div class="inside seravo-updates-postbox">
-                <h2><?php _e('Opt-out form updates by Seravo', 'seravo'); ?></h2>
-
+              <div class="inside seravo-updates-postbox">                
                 <?php
-                if ( $site_info['seravo_updates'] === true ) {
-                  $checked = 'checked="checked"';
+                //WP_error-object
+                if ( gettype($site_info) === 'array' ) {
+                  ?>
+                    <h2><?php _e('Opt-out from updates by Seravo', 'seravo'); ?></h2>
+                  <?php
+                  if ( $site_info['seravo_updates'] === true ) {
+                    $checked = 'checked="checked"';
+                  } else {
+                    $checked = '';
+                  }
+                  $contact_emails = array();
+                  if ( isset($site_info['contact_emails']) ) {
+                    $contact_emails = $site_info['contact_emails'];
+                  }
+                  ?>
+                  <p><?php _e('Seravo\'s upkeep service includes that your WordPress site is kept up-to-date with quick security updates and regular tested updates of both WordPress core and plugins. If you want full control of updates yourself, you can opt-out from Seravo updates.', 'seravo'); ?></p>
+                    <form name="seravo_updates_form" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" method="post">
+                      <?php wp_nonce_field( 'seravo-updates-nonce' ); ?>
+                      <input type="hidden" name="action" value="toggle_seravo_updates">
+                      <div class="checkbox allow_updates_checkbox">
+                        <input id="seravo_updates" name="seravo_updates" type="checkbox" <?php echo $checked; ?>> <?php _e('Seravo updates enabled', 'seravo'); ?><br>
+                      </div>
+                      <hr class="seravo-updates-hr">
+                      <h2><?php _e('Technical contact email addresses', 'seravo'); ?></h2>
+                      <p><?php _e('Seravo may send automatic notifications about site errors and failed updates to these addresses. Remember to add @-character to email.', 'seravo'); ?></p>
+                      <input class="technical_contacts_input" type="email" multiple size="30" placeholder="<?php _e('example@example.com', 'seravo'); ?>" value="" data-emails="<?php echo htmlspecialchars(json_encode($contact_emails)); ?>">
+                      <button type="button" class="technical_contacts_add button"><?php _e('Add', 'seravo'); ?></button>
+                      <span class="technical_contacts_error"><?php _e('Email must be formatted as name@domain.com', 'seravo'); ?></span>
+                      <input name="technical_contacts" type="hidden">
+                      <div class="technical_contacts_buttons"></div>
+                      <p><small class="seravo-developer-letter-hint">
+                      <?php
+                        // translators: %1$s link to Newsletter for WordPress developers
+                        echo wp_sprintf( __('P.S. Subscribe to Seravo\'s %1$sNewsletter for WordPress Developers%2$s to get up-to-date information about our newest features.', 'seravo'), '<a href="https://seravo.com/newsletter-for-wordpress-developers/">', '</a>');
+                      ?>
+                      </small></p>
+                        <input type="submit" id="save_settings_button" class="button button-primary" value="<?php _e('Save settings', 'seravo'); ?>">
+                    </form>
+                  <?php
                 } else {
-                  $checked = '';
+                  echo $site_info->get_error_message();
                 }
-
-                $contact_emails = array();
-                if ( isset($site_info['contact_emails']) ) {
-                  $contact_emails = $site_info['contact_emails'];
-                }
-
                 ?>
-
-                <p><?php _e('Seravo\'s upkeep service includes that your WordPress site is kept up-to-date with quick security updates and regular tested updates of both WordPress core and plugins. If you want full control of updates yourself, you can opt-out from Seravo updates.', 'seravo'); ?></p>
-
-                <form name="seravo_updates_form" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" method="post">
-                  <?php wp_nonce_field( 'seravo-updates-nonce' ); ?>
-                  <input type="hidden" name="action" value="toggle_seravo_updates">
-                  <div class="checkbox allow_updates_checkbox">
-                    <input id="seravo_updates" name="seravo_updates" type="checkbox" <?php echo $checked; ?>> <?php _e('Seravo updates enabled', 'seravo'); ?><br>
-                  </div>
-                  <hr class="seravo-updates-hr">
-                  <h2><?php _e('Technical contact email addresses', 'seravo'); ?></h2>
-                  <p><?php _e('Seravo may send automatic notifications about site errors and failed updates to these addresses. Remember to add @-character to email.', 'seravo'); ?></p>
-                  <input class="technical_contacts_input" type="email" multiple size="30" placeholder="<?php _e('example@example.com', 'seravo'); ?>" value="" data-emails="<?php echo htmlspecialchars(json_encode($contact_emails)); ?>">
-                  <button type="button" class="technical_contacts_add button"><?php _e('Add', 'seravo'); ?></button>
-                  <span class="technical_contacts_error"><?php _e('Email must be formatted as name@domain.com', 'seravo'); ?></span>
-                  <input name="technical_contacts" type="hidden">
-                  <div class="technical_contacts_buttons"></div>
-                  <p><small class="seravo-developer-letter-hint">
-                    <?php
-                      // translators: %1$s link to Newsletter for WordPress developers
-                      echo wp_sprintf( __('P.S. Subscribe to Seravo\'s %1$sNewsletter for WordPress Developers%2$s to get up-to-date information about our newest features.', 'seravo'), '<a href="https://seravo.com/newsletter-for-wordpress-developers/">', '</a>');
-                    ?>
-                  </small></p>
-                  <input type="submit" id="save_settings_button" class="button button-primary" value="<?php _e('Save settings', 'seravo'); ?>">
-                </form>
               </div>
             </div>
           </div>
@@ -87,11 +91,17 @@ if ( ! defined('ABSPATH') ) {
                 </span>
               </h2>
               <div class="inside">
+                <?php if ( gettype($site_info) === 'array' ) : ?>
                 <ul>
                   <li><?php _e('Site created', 'seravo'); ?>: <?php echo $site_info['created']; ?></li>
                   <li><?php _e('Latest update attempt', 'seravo'); ?>: <?php echo $site_info['update_attempt']; ?></li>
                   <li><?php _e('Latest successful update', 'seravo'); ?>: <?php echo $site_info['update_success']; ?></li>
                 </ul>
+                  <?php
+                  else :
+                    echo $site_info->get_error_message();
+                    ?>
+                <?php endif; ?>
               </div>
             </div>
           </div>

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -57,10 +57,6 @@ if ( ! class_exists('Updates') ) {
 
     public static function seravo_admin_get_site_info() {
       $site_info = API::get_site_data();
-      if ( is_wp_error($site_info) ) {
-        die($site_info->get_error_message());
-      }
-
       return $site_info;
     }
 


### PR DESCRIPTION
As described in #148 updates-tools currently handle exceptions so that when API can not be reached, the page is not loaded at all.
In this PR the way how such events are handled is changed so that when encountering an error the postboxes are shown. This makes further development easier.
![image](https://user-images.githubusercontent.com/16817737/42748831-3bea2174-88ea-11e8-8e27-9f38afa555cc.png)
