### PR TITLE
Fix WP-notification handling

### DIFF
--- a/lib/backups-page.php
+++ b/lib/backups-page.php
@@ -5,9 +5,7 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<div id="wpbody" role="main">
-  <div id="wpbody-content" aria-label="Main content" tabindex="0">
-    <div class="wrap">
+
       <div id="dashboard-widgets" class="metabox-holder">
         <div class="postbox-container">
           <div id="normal-sortables" class="meta-box-sortables ui-sortable">
@@ -98,6 +96,4 @@ if ( ! defined('ABSPATH') ) {
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
+

--- a/lib/cruftfiles-page.php
+++ b/lib/cruftfiles-page.php
@@ -7,9 +7,7 @@ if ( ! defined('ABSPATH') ) {
 
 
 
-  <div id="wpbody" role="main">
-    <div id="wpbody-content" aria-label="Main content" tabindex="0">
-      <div class="wrap">
+
         <div id="dashboard-widgets" class="metabox-holder">
           <!-- container 1 -->
           <div class="postbox-container-max">
@@ -87,6 +85,4 @@ if ( ! defined('ABSPATH') ) {
 
           </div>
           <!-- end 3 -->
-        </div>
-      </div>
-    </div>
+

--- a/lib/database-page.php
+++ b/lib/database-page.php
@@ -5,9 +5,7 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<div id="wpbody" role="main">
-  <div id="wpbody-content" aria-label="Main content" tabindex="0">
-    <div class="wrap">
+
       <div id="dashboard-widgets" class="metabox-holder">
         <div class="postbox-container">
           <div id="normal-sortables" class="meta-box-sortables ui-sortable">
@@ -188,6 +186,4 @@ if ( ! defined('ABSPATH') ) {
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
+

--- a/lib/reports-page.php
+++ b/lib/reports-page.php
@@ -5,9 +5,7 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<div id="wpbody" role="main">
-  <div id="wpbody-content" aria-label="Main content" tabindex="0">
-    <div class="wrap">
+
     <div class="dashboard-widgets-wrap">
       <div id="dashboard-widgets" class="metabox-holder">
         <div class="postbox-container">
@@ -133,6 +131,4 @@ if ( ! defined('ABSPATH') ) {
         </div>
       </div>
     </div>
-    </div>
-  </div>
-</div>
+

--- a/lib/shadows-page.php
+++ b/lib/shadows-page.php
@@ -11,9 +11,7 @@ if ( ! defined('ABSPATH') ) {
 require_once dirname( __FILE__ ) . '/api.php';
 ?>
 
-<div id="wpbody" role="main">
-  <div id="wpbody-content" aria-label="Main content" tabindex="0">
-    <div class="wrap">
+
         <div id="dashboard-widgets" class="metabox-holder">
           <!-- container  -->
           <div class="postbox-container-max">
@@ -86,6 +84,4 @@ require_once dirname( __FILE__ ) . '/api.php';
           </div>
           <!-- end container -->
         </div>
-    </div>
-  </div>
-</div>
+

--- a/lib/tests-page.php
+++ b/lib/tests-page.php
@@ -5,10 +5,7 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<div class="wrap">
 
-<div id="wpbody-content" aria-label="Main content" tabindex="0">
-  <div class="wrap">
     <div class="dashboard-widgets-wrap">
       <div id="dashboard-widgets" class="metabox-holder">
         <div class="postbox-container">
@@ -54,6 +51,4 @@ if ( ! defined('ABSPATH') ) {
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
+

--- a/lib/updates-page.php
+++ b/lib/updates-page.php
@@ -4,9 +4,7 @@ if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 ?>
-<div id="wpbody" role="main">
-  <div id="wpbody-content" aria-label="Main content" tabindex="0">
-    <div class="wrap">
+
       <?php
       $site_info = Seravo\Updates::seravo_admin_get_site_info();
       ?>
@@ -99,6 +97,4 @@ if ( ! defined('ABSPATH') ) {
           </div>
         </div>
       </div>
-    </div>
-  </div>
-</div>
+


### PR DESCRIPTION
Remove redundant div-elements to show WP-notifications in the correct part of the page. Closes #145