### PR TITLE
Improve Optimize images UI

### DIFF
--- a/js/optimize-images.js
+++ b/js/optimize-images.js
@@ -16,5 +16,22 @@
                 $(this).addClass('.max-resolution-field');
             });
         });
+        //Postbox animations
+        jQuery('.ui-sortable-handle').on('click', function () {
+            jQuery(this).parent().toggleClass("closed");
+          if (jQuery(this).parent().hasClass("closed")) {
+            jQuery(this).parents().eq(3).height(60);
+          } else {
+            jQuery(this).parents().eq(3).height('auto');
+          }
+        });
+        jQuery('.toggle-indicator').on('click', function () {
+            jQuery(this).parent().parent().toggleClass("closed");
+          if (jQuery(this).parent().hasClass("closed")) {
+            jQuery(this).parents().eq(4).height(60);
+          } else {
+            jQuery(this).parents().eq(4).height('auto');
+          }
+        });
     });
 })(jQuery);

--- a/lib/optimize-images-page.php
+++ b/lib/optimize-images-page.php
@@ -1,0 +1,39 @@
+<?php
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+?>
+
+<div id="dashboard-widgets" class="metabox-holder">
+  <!-- container 1 -->
+  <div class="postbox-container-max">
+    <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+      <!--First postbox: Image optimizer-->
+      <div id="dashboard_optimize_images" class="postbox">
+        <button type="button" class="handlediv button-link" aria-expanded="true">
+          <span class="screen-reader-text">Toggle panel: <?php _e(  'Optimize Images (beta)', 'seravo' ); ?></span>
+          <span class="toggle-indicator" aria-hidden="true"></span>
+        </button>
+        <h2 class="hndle ui-sortable-handle">
+          <span><?php _e('Optimize Images (beta)', 'seravo'); ?></span>
+        </h2>
+
+        <div class="inside">
+          <div class="seravo-section">
+            <?php
+            settings_errors();
+            echo '<form method="post" action="options.php" class="seravo-general-form">';
+            settings_fields( 'seravo-optimize-images-settings-group' );
+            do_settings_sections( 'optimize_images_settings' );
+            submit_button( __( 'Save', 'seravo' ), 'primary', 'btnSubmit' );
+            echo '</form>';
+            ?>
+          </div>
+        </div>
+      </div>
+      <!--First postbox: end-->
+    </div>
+  </div>
+  <!-- end 1 -->
+</div>

--- a/modules/optimize-images.php
+++ b/modules/optimize-images.php
@@ -32,7 +32,7 @@ if ( ! class_exists('Optimize_Images') ) {
 
     public static function register_optimize_image_settings() {
       add_settings_section(
-        'seravo-optimize-images-settings', __( 'Optimize Images', 'seravo' ) . ' (beta)',
+        'seravo-optimize-images-settings', '',
         array( __CLASS__, 'optimize_images_settings_description' ), 'optimize_images_settings'
       );
 
@@ -64,9 +64,11 @@ if ( ! class_exists('Optimize_Images') ) {
 
     public static function admin_enqueue_styles( $page ) {
       wp_register_script( 'optimize-images', plugin_dir_url(__DIR__) . '/js/optimize-images.js', array(), null );
+      wp_register_style('optimize-images', plugin_dir_url(__DIR__) . 'style/optimize-images.css', array(), null );
 
       if ( $page === 'tools_page_optimize_images_page' ) {
         wp_enqueue_script( 'optimize-images' );
+        wp_enqueue_style( 'optimize-images' );
       }
     }
 
@@ -89,13 +91,7 @@ if ( ! class_exists('Optimize_Images') ) {
     }
 
     public static function load_optimize_images_page() {
-      settings_errors();
-      echo '<div class="wrap">
-        <form method="post" action="options.php" class="seravo-general-form">';
-      settings_fields( 'seravo-optimize-images-settings-group' );
-      do_settings_sections( 'optimize_images_settings' );
-      submit_button( __( 'Save', 'seravo' ), 'primary', 'btnSubmit' );
-      echo '</form></div>';
+      require_once dirname( __FILE__ ) . '/../lib/optimize-images-page.php';
     }
 
     public static function seravo_image_max_width_field() {

--- a/style/optimize-images.css
+++ b/style/optimize-images.css
@@ -1,0 +1,41 @@
+.seravo-general-form .inside {
+  padding: 10px 15px 0px 15px!important;
+}
+.seravo-section {
+  margin-bottom: 2.5rem;
+}
+.js .widget .widget-top, .js .postbox .hndle {
+  cursor: pointer;
+}
+.postbox-container-max {
+  width: 100%;
+}
+
+
+@media only screen and (min-width: 1500px) {
+  #wpbody-content #dashboard-widgets .postbox-container {
+    width: 50%;
+  }
+}
+
+td {
+  padding-right: 15px;
+}
+
+@media only screen and (max-width: 1025px) {
+  .label_buttons {
+    display: block;
+  }
+  .to_button, .adminer_button {
+    padding-top: 15px;
+  }
+  .optionboxes {
+    padding-left: 10%;
+  }
+  .to_label {
+    padding-right: 15%;
+  }
+  .from_label {
+    padding-right: 10%;
+  }
+}


### PR DESCRIPTION
This PR makes the Optimize images -tool use the WordPress-postbox
style.
![image](https://user-images.githubusercontent.com/16817737/42818931-ce625422-89da-11e8-9cc1-4102c4fd8b4e.png)
Currently the Optimize images-option has it's own page in the Tools-menu. To make the Seravo-plugin user experience more unified, the setting must be contained in it's own postbox. This also makes further development easier.
![image](https://user-images.githubusercontent.com/16817737/42818695-42b07f08-89da-11e8-95de-83a97ab117f0.png)
