### PR TITLE
Add feature for removing inactive WordPress themes

### DIFF
--- a/js/cruftthemes.js
+++ b/js/cruftthemes.js
@@ -1,0 +1,131 @@
+'use strict';
+jQuery(document).ready(function($) {
+  function seravo_ajax_delete_theme(theme_name, callback) {
+    $.post(
+      seravo_cruftthemes_loc.ajaxurl,
+      { type: 'POST',
+        'action': 'seravo_remove_themes',
+        'removetheme': theme_name,
+        'nonce': seravo_cruftthemes_loc.ajax_nonce, },
+      function( rawData ) {
+        var data = JSON.parse(rawData);
+        if ( data ) {
+          callback();
+        } else {
+          confirm(seravo_cruftthemes_loc.failure);
+        }
+      });
+  }
+  // Generic ajax report loader function
+  function seravo_theme_load_report(section) {
+    $.post(
+      seravo_cruftthemes_loc.ajaxurl,
+      { 'action': 'seravo_list_cruft_themes',
+        'section': section,
+        'nonce': seravo_cruftthemes_loc.ajax_nonce, },
+      function(rawData) {
+        if (rawData.length == 0) {
+          $('#' + section).html(seravo_cruftthemes_loc.no_data);
+        }
+        $('#' + section + '_loading').fadeOut();
+        var data = JSON.parse(rawData);
+        // title, name, status
+
+        if ( data.length != 0 ) {
+          $( '#cruftthemes_status' ).prepend('<p>' + seravo_cruftthemes_loc.cruftthemes + '</p>');
+          $( '#cruftthemes_status' ).append('<div><div class="cruft-theme-table"></div></div>');
+          //Go through each data. If has a child, print later.
+          $.each( data, function( i, theme ){
+            if (theme.name != '' && theme.parent == '' ) {
+              seravo_print_theme_table( theme );
+            }
+          });
+
+          $('.crufttheme').each( function(i){
+            var children = data.filter(theme => theme.parent == $(this).attr('data-theme-name'));
+            if ( children.length != 0) {
+              var titles = '';
+              var handles = '';
+              children.forEach(element => {
+                seravo_print_theme_table( element, $(this) );
+                titles += ', ' + element.title;
+                handles += element.name + ' ';
+              });
+              $(this).append(
+                '<div class="theme-relative-info" style="padding-left: 5px">' + seravo_cruftthemes_loc.isparentto +
+                '</div><div class="theme-relatives" data-theme-children="' + handles.slice(0, -1) + '" style="padding-left: 5px">' + titles.slice(1) + '</div>'
+              );
+              $(this).find(':first-child').addClass('cruft-button-hide').removeClass('crufttheme-delete-button');
+            }
+          });
+        } else {
+          $( '#cruftthemes_status' ).prepend('<b>' + seravo_cruftthemes_loc.no_cruftthemes + '</b>');
+        }
+        $( '#cruftthemes_status_loading img' ).fadeOut
+        $('.crufttheme-delete-button').click(function(event) {
+          event.preventDefault();
+          var is_user_sure = confirm(seravo_cruftthemes_loc.confirm);
+          if ( ! is_user_sure ) {
+            return;
+          }
+          var parent_row = $(this).parents(':eq(1)');
+          var theme_name = parent_row.attr('data-theme-name');
+          seravo_ajax_delete_theme(theme_name, function() {
+            parent_row.animate({
+              opacity: 0
+            },
+            600,
+            function() {
+              var container = parent_row.parents().eq(0);
+              // in data we know which theme is this one's parent.
+              // we remove the child from the parent.
+              var parent = data.filter(theme => theme.name == parent_row.attr('data-theme-name'))[0].parent;
+              var childtitle = data.filter(theme => theme.name == parent_row.attr('data-theme-name'))[0].title;
+              if ( parent != '' ) {
+                if ( $('.' + parent).find('.theme-relatives').attr('data-theme-children').replace(parent_row.attr('data-theme-name'),'') != '' ) {
+                  $('.' + parent).find('.theme-relatives').attr('data-theme-children',$('.' + parent).find('.theme-relatives').attr('data-theme-children').replace(parent_row.attr('data-theme-name'),'').replace(/\s+/g,' ').trim());
+                  $('.' + parent).find('.theme-relatives').html(removeValue($('.' + parent).find('.theme-relatives').html(), childtitle) );
+                  // here we need to remove the appropiate parts from the data-* and string
+                  // tr -> td .theme-relatives has data-* and HTML-text
+                } else {
+                  $('.' + parent).find('.theme-relatives').remove();
+                  $('.' + parent).find('.theme-relative-info').remove();
+                  $('.' + parent).find(':first-child').removeClass('cruft-button-hide').addClass('crufttheme-delete-button');
+
+                }
+              }
+              parent_row.remove();
+            });
+          });
+        });
+      }
+    ).fail(function() {
+      $('#' + section + '_loading').html(seravo_cruftthemes_loc.fail);
+    });
+  }
+  // titles for the titles that have been printed. theme for the one which is to be printed.
+  function seravo_print_theme_table( theme, target='' ) {
+
+    if ( target == '' ) {
+      $( '.cruft-theme-table' ).append('<div class="crufttheme ' + theme.name + '" data-theme-name= "' + theme.name + '"><div class="crufttheme-delete">' +
+      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + theme.title + '</div></div>');
+    } else {
+      target.addClass('crufttheme-parent');
+      if ( ! target.next().hasClass('crufttheme-child-container') ) {
+        target.after( '<div class="crufttheme-child-container ' + theme.parent + '"></div>');
+      }
+      //if target already has children, append after that
+
+      $('.' + theme.parent + '.crufttheme-child-container').append('<div class="crufttheme-child crufttheme ' + theme.name + '" data-theme-name= "' + theme.name + '"><div class="crufttheme-delete child-delete-button">' +
+      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + theme.title + '</div></div>');
+    }
+  }
+  function removeValue(list, value) {
+    list = list.split(',');
+    list.splice(list.indexOf(value), 1);
+    return list.join(',');
+  }
+
+  // Load on page load
+  seravo_theme_load_report('cruftthemes_status');
+});

--- a/lib/cruftfiles-page.php
+++ b/lib/cruftfiles-page.php
@@ -5,84 +5,117 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-
-
-
-        <div id="dashboard-widgets" class="metabox-holder">
-          <!-- container 1 -->
-          <div class="postbox-container-max">
-            <div id="normal-sortables" class="meta-box-sortables ui-sortable">
-              <!--First postbox: Cruft remover-->
-              <div id="dashboard_cruft_files" class="postbox">
-                <button type="button" class="handlediv button-link" aria-expanded="true">
-                  <span class="screen-reader-text">Toggle panel:
-                    <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
-                  </span>
-                  <span class="toggle-indicator" aria-hidden="true"></span>
-                </button>
-                <h2 class="hndle ui-sortable-handle">
-                  <span>
-                    <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
-                  </span>
-                </h2>
-                <div class="inside">
-                  <div class="seravo-section">
-                    <p>
-                      <?php _e( 'Find and delete unnecessary files in the filesystem', 'seravo' ); ?>
-                    </p>
-                    <p>
-                      <div id="cruftfiles_status">
-                        <table>
-                          <tbody id="cruftfiles_entries">
-                          </tbody>
-                        </table>
-                        <div id="cruftfiles_status_loading">
-                          <?php _e( 'Finding files...', 'seravo' ); ?>
-                          <img src="/wp-admin/images/spinner.gif">
-                        </div>
+      <div id="dashboard-widgets" class="metabox-holder">
+        <!-- container 1 -->
+        <div class="postbox-container-max">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!--First postbox: Cruft remover-->
+            <div id="dashboard_cruft_files" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel:
+                  <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
+                </span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span>
+                  <?php _e( 'Cruft Files (beta)', 'seravo' ); ?>
+                </span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p>
+                    <?php _e( 'Find and delete unnecessary files in the filesystem', 'seravo' ); ?>
+                  </p>
+                  <p>
+                    <div id="cruftfiles_status">
+                      <table>
+                        <tbody id="cruftfiles_entries">
+                        </tbody>
+                      </table>
+                      <div id="cruftfiles_status_loading">
+                        <?php _e( 'Finding files...', 'seravo' ); ?>
+                        <img src="/wp-admin/images/spinner.gif">
                       </div>
-                    </p>
-                  </div>
+                    </div>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- container 3 -->
+        <div class="postbox-container-max">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!-- -->
+            <div id="dashboard_plugins" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel:
+                  <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
+                </span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span>
+                  <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
+                </span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p>
+                    <?php _e( 'Find and remove plugins that are unnecessary or inactive. For more information, read our <a href="https://help.seravo.com/en/knowledgebase/19-teemat-ja-lisaosat/docs/51-wordpress-lisaosat-wp-palvelu-fi-ssa">Helpy-page</a>.', 'seravo' ); ?>
+                  </p>
+                  <p>
+                    <div id="cruftplugins_status">
+                      <div id="cruftplugins_status_loading">
+                        <?php _e( 'Finding plugins...', 'seravo' ); ?>
+                        <img src="/wp-admin/images/spinner.gif">
+                      </div>
+                    </div>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <!-- -->
+          </div>
+
+        </div>
+        <!-- end 3 -->
+
+        <!-- container 3 -->
+        <div class="postbox-container-max">
+          <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+            <!-- -->
+            <div id="dashboard_themes" class="postbox">
+              <button type="button" class="handlediv button-link" aria-expanded="true">
+                <span class="screen-reader-text">Toggle panel:
+                  <?php _e( 'Unnecessary themes', 'seravo' ); ?>
+                </span>
+                <span class="toggle-indicator" aria-hidden="true"></span>
+              </button>
+              <h2 class="hndle ui-sortable-handle">
+                <span>
+                  <?php _e( 'Unnecessary themes', 'seravo' ); ?>
+                </span>
+              </h2>
+              <div class="inside">
+                <div class="seravo-section">
+                  <p>
+                    <?php _e( 'Find and remove themes that are unnecessary or inactive.', 'seravo' ); ?>
+                  </p>
+                  <p>
+                    <div id="cruftthemes_status">
+                      <div id="cruftthemes_status_loading">
+                        <?php _e( 'Finding themes...', 'seravo' ); ?>
+                        <img src="/wp-admin/images/spinner.gif">
+                      </div>
+                    </div>
+                  </p>
                 </div>
               </div>
             </div>
           </div>
 
-          <!-- container 3 -->
-          <div class="postbox-container-max">
-            <div id="normal-sortables" class="meta-box-sortables ui-sortable">
-              <!-- -->
-              <div id="dashboard_plugins" class="postbox">
-                <button type="button" class="handlediv button-link" aria-expanded="true">
-                  <span class="screen-reader-text">Toggle panel:
-                    <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
-                  </span>
-                  <span class="toggle-indicator" aria-hidden="true"></span>
-                </button>
-                <h2 class="hndle ui-sortable-handle">
-                  <span>
-                    <?php _e( 'Unnecessary plugins', 'seravo' ); ?>
-                  </span>
-                </h2>
-                <div class="inside">
-                  <div class="seravo-section">
-                    <p>
-                      <?php _e( 'Find and remove plugins that are unnecessary or inactive. For more information, read our <a href="https://help.seravo.com/en/knowledgebase/19-teemat-ja-lisaosat/docs/51-wordpress-lisaosat-wp-palvelu-fi-ssa">Helpy-page</a>.', 'seravo' ); ?>
-                    </p>
-                    <p>
-                      <div id="cruftplugins_status">
-                        <div id="cruftplugins_status_loading">
-                          <?php _e( 'Finding plugins...', 'seravo' ); ?>
-                          <img src="/wp-admin/images/spinner.gif">
-                        </div>
-                      </div>
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <!-- -->
-            </div>
-
-          </div>
-          <!-- end 3 -->
-
+        </div>
+        <!-- end 3 -->

--- a/lib/cruftthemes-ajax.php
+++ b/lib/cruftthemes-ajax.php
@@ -1,0 +1,35 @@
+<?php
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+function seravo_ajax_list_cruft_themes() {
+  check_ajax_referer( 'seravo_cruftthemes', 'nonce' );
+  //get an array of WP_Theme -objects
+  foreach ( wp_get_themes() as $theme ) {
+    $output[] = array(
+      'name' => $theme->get_stylesheet(),
+      'title' => $theme->get( 'Name' ),
+      'parent' => $theme->get( 'Template' ),
+    );
+  }
+  set_transient('cruft_themes_found', $output, 600);
+  echo wp_json_encode($output);
+  wp_die();
+}
+
+function seravo_ajax_remove_themes() {
+  check_ajax_referer( 'seravo_cruftthemes', 'nonce' );
+  if ( isset($_POST['removetheme']) && ! empty($_POST['removetheme']) ) {
+    $theme = $_POST['removetheme'];
+    $legit_removeable_themes = get_transient('cruft_themes_found');
+    foreach ( $legit_removeable_themes as $legit_theme ) {
+      if ( $legit_theme['name'] == $theme ) {
+        // (void|bool|WP_Error) When void, echoes content.
+        echo json_encode(delete_theme($theme));
+        wp_die();
+      }
+    }
+  }
+}

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -14,6 +14,7 @@ if ( ! defined('ABSPATH') ) {
 
 require_once dirname( __FILE__ ) . '/../lib/cruftfiles-ajax.php';
 require_once dirname( __FILE__ ) . '/../lib/cruftplugins-ajax.php';
+require_once dirname( __FILE__ ) . '/../lib/cruftthemes-ajax.php';
 
 if ( ! class_exists('Cruftfiles') ) {
   class Cruftfiles {
@@ -26,9 +27,13 @@ if ( ! class_exists('Cruftfiles') ) {
       add_action( 'wp_ajax_seravo_cruftfiles', 'seravo_ajax_list_cruft_files' );
       add_action( 'wp_ajax_seravo_delete_file', 'seravo_ajax_delete_cruft_files' );
 
-      // AJAX functionality for listing ... plugins
+      // AJAX functionality for listing and removing plugins
       add_action( 'wp_ajax_seravo_list_cruft_plugins', 'seravo_ajax_list_cruft_plugins' );
       add_action( 'wp_ajax_seravo_remove_plugins', 'seravo_ajax_remove_plugins' );
+
+      // AJAX functionality for listing and removing themess
+      add_action( 'wp_ajax_seravo_list_cruft_themes', 'seravo_ajax_list_cruft_themes' );
+      add_action( 'wp_ajax_seravo_remove_themes', 'seravo_ajax_remove_themes' );
     }
 
     public static function register_cruftfiles_page() {
@@ -98,11 +103,13 @@ if ( ! class_exists('Cruftfiles') ) {
       wp_register_style( 'seravo_cruftfiles', plugin_dir_url( __DIR__ ) . '/style/cruftfiles.css', '', Helpers::seravo_plugin_version());
       wp_register_script( 'seravo_cruftfiles', plugin_dir_url( __DIR__ ) . '/js/cruftfiles.js', '', Helpers::seravo_plugin_version());
       wp_register_script( 'seravo_cruftplugins', plugin_dir_url( __DIR__ ) . '/js/cruftplugins.js', '', Helpers::seravo_plugin_version());
+      wp_register_script( 'seravo_cruftthemes', plugin_dir_url( __DIR__ ) . '/js/cruftthemes.js', '', Helpers::seravo_plugin_version());
 
       if ( $hook === 'tools_page_cruftfiles_page' ) {
         wp_enqueue_style( 'seravo_cruftfiles' );
         wp_enqueue_script( 'seravo_cruftfiles' );
         wp_enqueue_script( 'seravo_cruftplugins' );
+        wp_enqueue_script( 'seravo_cruftthemes' );
 
         // Localize the javascript file.
         $loc_translation_files = array(
@@ -120,7 +127,7 @@ if ( ! class_exists('Cruftfiles') ) {
         );
         $loc_translation_plugins = array(
           'inactive'                => __( 'Inactive plugins:', 'seravo' ),
-          'inactive_desc'           => __( 'These plugins are currently not in use. They can be removed to save disk storage.' ),
+          'inactive_desc'           => __( 'These plugins are currently not in use. They can be removed to save disk storage.', 'seravo' ),
           'cache_plugins'           => __( 'Unnecessary cache plugins:', 'seravo' ),
           'cache_plugins_desc'      => __( 'Your website runs on a server which has serverside caching. Any plugins that provide caching can not improve upon the provided service.', 'seravo' ),
           'security_plugins'        => __( 'Unnecessary security plugins:', 'seravo' ),
@@ -138,8 +145,18 @@ if ( ! class_exists('Cruftfiles') ) {
           'ajaxurl'                 => admin_url('admin-ajax.php'),
           'ajax_nonce'              => wp_create_nonce('seravo_cruftplugins'),
         );
+        $loc_translation_themes = array(
+          'isparentto'     => __( 'is parent to: ', 'seravo' ),
+          'confirm'        => __( 'Are you sure you want to remove this theme?', 'seravo' ),
+          'failure'        => __( 'Failed to remove theme', 'seravo' ),
+          'no_cruftthemes' => __( 'There are currently no unnecessary themes on the website.', 'seravo' ),
+          'cruftthemes'    => __( 'The following themes are inactive and can be removed.', 'seravo' ),
+          'ajaxurl'        => admin_url('admin-ajax.php'),
+          'ajax_nonce'     => wp_create_nonce('seravo_cruftthemes'),
+        );
         wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation_files );
         wp_localize_script( 'seravo_cruftplugins', 'seravo_cruftplugins_loc', $loc_translation_plugins );
+        wp_localize_script( 'seravo_cruftthemes', 'seravo_cruftthemes_loc', $loc_translation_themes );
       }
     }
   }

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -39,9 +39,35 @@
     width: 50%;
   }
 }
+table {
+  border: collapse;
+}
+.cruft-theme-table {
+    border-bottom: 2px solid black;
+}
+.crufttheme {
+    padding: 1px 1px 1px 1px;
+    display: flex;
+    border-top: 2px solid black;
+}
 
-td {
-  padding-right: 15px;
+.crufttheme-child {
+    border-top: none;
+}
+
+.child-delete-button {
+    margin-left: 30px;
+}
+
+.cruft-button-hide {
+  clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px) !important;
+    color: #CCC;
+}
+.cruft-highlight {
+  background: red !important;
+}
+.crufttheme-delete {
+  padding-right: 10px;
 }
 
 @media only screen and (max-width: 1025px) {


### PR DESCRIPTION
This commit adds a feature requested in #93.

![image](https://user-images.githubusercontent.com/16817737/42998516-07dc0e38-8c23-11e8-9b77-250dbd89c7a2.png)
The user is not allowed to remove parent themes before all the child themes are removed. Themes are categorized so that relatives are grouped together.