### PR TITLE
Fix cruft file remover information retrieval

### DIFF
--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -143,6 +143,16 @@ function seravo_ajax_list_cruft_files() {
           $crufts = array_merge($crufts, $cruft_found);
         }
       }
+
+      $crufts = array_filter($crufts, function( $item ) use ( $crufts ) {
+        foreach ( $crufts as $substring ) {
+          if ( strpos($item, $substring) === 0 && $item !== $substring ) {
+            return false;
+          }
+        }
+        return true;
+      });
+
       $crufts = array_unique($crufts);
       set_transient('cruft_files_found', $crufts, 600);
 


### PR DESCRIPTION
This commit fixes the issue #153 by removing sub-directories and files from the listings. This also changes how the cruft remover shows file size information. Previously the shown directory size information was about the first directory within the directory, if applicable.