### PR TITLE
Show database size in a human readable format

### DIFF
--- a/lib/database-ajax.php
+++ b/lib/database-ajax.php
@@ -26,7 +26,7 @@ function seravo_wp_db_info_to_table( $array ) {
       $columns = explode("\t", $value);
       $output .= '<tr>';
       foreach ( $columns as $j => $column ) {
-        $output .= '<td>' . $column . '</td>';
+        $output .= '<td>' . ( ( Helpers::human_file_size($column) == '0B' ) ? $column : Helpers::human_file_size($column) ) . '</td>';
       }
       $output .= '</tr>';
     }


### PR DESCRIPTION
In this PR the database visualization tool shows the total size of the database in a human readable format.
Currently:
![image](https://user-images.githubusercontent.com/16817737/43185710-59e903fe-8ff5-11e8-87d0-0a9e0d719bc5.png)
New version:
![image](https://user-images.githubusercontent.com/16817737/43185674-40a85408-8ff5-11e8-81ef-a1d441724bcc.png)
