### PR TITLE
Update crufttheme remover

### DIFF
--- a/js/cruftthemes.js
+++ b/js/cruftthemes.js
@@ -1,6 +1,69 @@
 'use strict';
+
+function removeValue(list, value) {
+  list = list.split(',');
+  list.splice(list.indexOf(value), 1);
+  return list.join(',');
+}
+
+class CruftTheme {
+  constructor(name, title, active) {
+    this.name = name;
+    this.title = title;
+    this.active = active;
+  }
+  seravo_print_theme_table( target ) {
+    if ( ! this.active ) {
+      target.append('<div id="' + this.name + '" class="crufttheme ' + this.name + '" data-theme-name= "' + this.name + '"><div id="button' + this.name + '" class="crufttheme-delete">' +
+      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + this.title + '</div></div>');
+    }
+    return( ! this.active );
+  }
+}
+
+class CruftParent extends CruftTheme {
+  constructor(name, title, active, children) {
+    super(name, title, active);
+    this.children = children;
+  }
+  seravo_print_theme_table( target ){
+    if ( super.seravo_print_theme_table( target ) ) {
+      document.querySelector( '#' + this.name ).className += ' crufttheme-parent';
+      var titles = '';
+      var handles = '';
+      this.children.forEach(element => {
+        target.append( '<div id="' + element.parent + 'box" class="crufttheme-child-container"></div>');
+        element.seravo_print_theme_child( document.querySelector( '#' + this.name + 'box' ) );
+        titles += ', ' + element.title;
+        handles += element.name + ' ';
+      });
+      document.querySelector( '#' + this.name ).innerHTML += '<div class="theme-relative-info" style="padding-left: 5px">' + seravo_cruftthemes_loc.isparentto
+        + '</div><div class="theme-relatives" data-theme-children="' + handles.slice(0, -1) + '" style="padding-left: 5px">' + titles.slice(1) + '</div>';
+      target.find('#button' + this.name).addClass('cruft-button-hide').removeClass('crufttheme-delete-button');
+    } else {
+      this.children.forEach(element => {
+        element.seravo_print_theme_table( target );
+      });
+    }
+  }
+
+}
+
+class CruftChild extends CruftTheme {
+  constructor(name, title, active, parent) {
+    super(name, title, active);
+    this.parent = parent;
+  }
+  seravo_print_theme_child( target_box ) {
+    if ( ! this.parent.active && ! this.active ) {
+      target_box.innerHTML += '<div id="' + this.name + '" class="crufttheme-child crufttheme ' + this.name + '" data-theme-name= "' + this.name + '"><div class="crufttheme-delete child-delete-button">' +
+      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + this.title + '</div></div>';
+    }
+  }
+}
+
 jQuery(document).ready(function($) {
-  function seravo_ajax_delete_theme(theme_name, callback) {
+  function seravo_ajax_delete_theme(theme_name, parent_row, callback) {
     $.post(
       seravo_cruftthemes_loc.ajaxurl,
       { type: 'POST',
@@ -10,12 +73,21 @@ jQuery(document).ready(function($) {
       function( rawData ) {
         var data = JSON.parse(rawData);
         if ( data ) {
-          callback();
+          callback(parent_row, data);
         } else {
           confirm(seravo_cruftthemes_loc.failure);
         }
       });
   }
+
+  function seravo_delete_theme(parent_row, data) {
+    parent_row.animate({
+      opacity: 0
+    }, 600, function() {
+      parent_row.remove();
+    });
+  }
+
   // Generic ajax report loader function
   function seravo_theme_load_report(section) {
     $.post(
@@ -29,35 +101,32 @@ jQuery(document).ready(function($) {
         }
         $('#' + section + '_loading').fadeOut();
         var data = JSON.parse(rawData);
-        // title, name, status
-
-        if ( data.length != 0 ) {
+        // title, name, parent, active
+        var CTTID = 'cruft-theme-table';
+        if ( data.length > 1 ) {
           $( '#cruftthemes_status' ).prepend('<p>' + seravo_cruftthemes_loc.cruftthemes + '</p>');
-          $( '#cruftthemes_status' ).append('<div><div class="cruft-theme-table"></div></div>');
-          //Go through each data. If has a child, print later.
+          $( '#cruftthemes_status' ).append('<div><div id="' + CTTID + '" class="cruft-theme-table"></div></div>');
+          var parent_themes = new Array();
+          var child_themes = new Array();
+          // go through each item and categorize them
           $.each( data, function( i, theme ){
             if (theme.name != '' && theme.parent == '' ) {
-              seravo_print_theme_table( theme );
+              parent_themes.push(new CruftTheme(theme.name, theme.title, theme.active));
+            } else if (theme.name != '' && theme.parent != '' ) {
+              child_themes.push(new CruftChild(theme.name, theme.title, theme.active, theme.parent));
             }
           });
 
-          $('.crufttheme').each( function(i){
-            var children = data.filter(theme => theme.parent == $(this).attr('data-theme-name'));
-            if ( children.length != 0) {
-              var titles = '';
-              var handles = '';
-              children.forEach(element => {
-                seravo_print_theme_table( element, $(this) );
-                titles += ', ' + element.title;
-                handles += element.name + ' ';
-              });
-              $(this).append(
-                '<div class="theme-relative-info" style="padding-left: 5px">' + seravo_cruftthemes_loc.isparentto +
-                '</div><div class="theme-relatives" data-theme-children="' + handles.slice(0, -1) + '" style="padding-left: 5px">' + titles.slice(1) + '</div>'
-              );
-              $(this).find(':first-child').addClass('cruft-button-hide').removeClass('crufttheme-delete-button');
+          parent_themes.forEach( function(parent, index, this_array){
+            if ( child_themes.filter(theme => theme.parent == parent.name).length != 0) {
+              this_array[index] = new CruftParent( parent.name, parent.title, parent.active, child_themes.filter(theme => theme.parent == parent.name) );
             }
           });
+
+          parent_themes.forEach( function(element){
+            element.seravo_print_theme_table( $('#' + CTTID ));
+          });
+
         } else {
           $( '#cruftthemes_status' ).prepend('<b>' + seravo_cruftthemes_loc.no_cruftthemes + '</b>');
         }
@@ -70,33 +139,7 @@ jQuery(document).ready(function($) {
           }
           var parent_row = $(this).parents(':eq(1)');
           var theme_name = parent_row.attr('data-theme-name');
-          seravo_ajax_delete_theme(theme_name, function() {
-            parent_row.animate({
-              opacity: 0
-            },
-            600,
-            function() {
-              var container = parent_row.parents().eq(0);
-              // in data we know which theme is this one's parent.
-              // we remove the child from the parent.
-              var parent = data.filter(theme => theme.name == parent_row.attr('data-theme-name'))[0].parent;
-              var childtitle = data.filter(theme => theme.name == parent_row.attr('data-theme-name'))[0].title;
-              if ( parent != '' ) {
-                if ( $('.' + parent).find('.theme-relatives').attr('data-theme-children').replace(parent_row.attr('data-theme-name'),'') != '' ) {
-                  $('.' + parent).find('.theme-relatives').attr('data-theme-children',$('.' + parent).find('.theme-relatives').attr('data-theme-children').replace(parent_row.attr('data-theme-name'),'').replace(/\s+/g,' ').trim());
-                  $('.' + parent).find('.theme-relatives').html(removeValue($('.' + parent).find('.theme-relatives').html(), childtitle) );
-                  // here we need to remove the appropiate parts from the data-* and string
-                  // tr -> td .theme-relatives has data-* and HTML-text
-                } else {
-                  $('.' + parent).find('.theme-relatives').remove();
-                  $('.' + parent).find('.theme-relative-info').remove();
-                  $('.' + parent).find(':first-child').removeClass('cruft-button-hide').addClass('crufttheme-delete-button');
-
-                }
-              }
-              parent_row.remove();
-            });
-          });
+          seravo_ajax_delete_theme(theme_name, parent_row, seravo_delete_theme);
         });
       }
     ).fail(function() {
@@ -104,28 +147,6 @@ jQuery(document).ready(function($) {
     });
   }
   // titles for the titles that have been printed. theme for the one which is to be printed.
-  function seravo_print_theme_table( theme, target='' ) {
-
-    if ( target == '' ) {
-      $( '.cruft-theme-table' ).append('<div class="crufttheme ' + theme.name + '" data-theme-name= "' + theme.name + '"><div class="crufttheme-delete">' +
-      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + theme.title + '</div></div>');
-    } else {
-      target.addClass('crufttheme-parent');
-      if ( ! target.next().hasClass('crufttheme-child-container') ) {
-        target.after( '<div class="crufttheme-child-container ' + theme.parent + '"></div>');
-      }
-      //if target already has children, append after that
-
-      $('.' + theme.parent + '.crufttheme-child-container').append('<div class="crufttheme-child crufttheme ' + theme.name + '" data-theme-name= "' + theme.name + '"><div class="crufttheme-delete child-delete-button">' +
-      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + theme.title + '</div></div>');
-    }
-  }
-  function removeValue(list, value) {
-    list = list.split(',');
-    list.splice(list.indexOf(value), 1);
-    return list.join(',');
-  }
-
   // Load on page load
   seravo_theme_load_report('cruftthemes_status');
 });

--- a/lib/cruftthemes-ajax.php
+++ b/lib/cruftthemes-ajax.php
@@ -7,12 +7,15 @@ if ( ! defined('ABSPATH') ) {
 function seravo_ajax_list_cruft_themes() {
   check_ajax_referer( 'seravo_cruftthemes', 'nonce' );
   //get an array of WP_Theme -objects
+  $current = wp_get_theme();
   foreach ( wp_get_themes() as $theme ) {
     $output[] = array(
-      'name' => $theme->get_stylesheet(),
-      'title' => $theme->get( 'Name' ),
+      'name'   => $theme->get_stylesheet(),
+      'title'  => $theme->get( 'Name' ),
       'parent' => $theme->get( 'Template' ),
+      'active' => ( $theme->get('Name') === $current->get('Name') ),
     );
+
   }
   set_transient('cruft_themes_found', $output, 600);
   echo wp_json_encode($output);
@@ -25,7 +28,7 @@ function seravo_ajax_remove_themes() {
     $theme = $_POST['removetheme'];
     $legit_removeable_themes = get_transient('cruft_themes_found');
     foreach ( $legit_removeable_themes as $legit_theme ) {
-      if ( $legit_theme['name'] == $theme ) {
+      if ( $legit_theme['name'] == $theme && ! $legit_theme['active'] ) {
         // (void|bool|WP_Error) When void, echoes content.
         echo json_encode(delete_theme($theme));
         wp_die();

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -228,6 +228,7 @@ if ( ! class_exists('Cruftfiles') ) {
           'cruftthemes'    => __( 'The following themes are inactive and can be removed.', 'seravo' ),
           'ajaxurl'        => admin_url('admin-ajax.php'),
           'ajax_nonce'     => wp_create_nonce('seravo_cruftthemes'),
+
         );
         wp_localize_script( 'seravo_cruftfiles', 'seravo_cruftfiles_loc', $loc_translation_files );
         wp_localize_script( 'seravo_cruftplugins', 'seravo_cruftplugins_loc', $loc_translation_plugins );

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -43,6 +43,26 @@ table {
 .child-delete-button {
     margin-left: 30px;
 }
+table {
+  border: collapse;
+}
+.cruft-theme-table {
+    border-bottom: 2px solid black;
+}
+.crufttheme {
+    padding: 1px 1px 1px 1px;
+    display: flex;
+    border-top: 2px solid black;
+    flex-direction: row;
+}
+
+.crufttheme-child {
+    border-top: none;
+}
+/* TODO check this  */
+.child-delete-button {
+    margin-left: 30px;
+}
 
 .cruft-button-hide {
   clip-path: polygon(0px 0px, 0px 0px, 0px 0px, 0px 0px) !important;


### PR DESCRIPTION
This PR fixes #167 
Context for following images: TwentySeventeen is the active theme.
There is only one theme on the page, which is active.
![image](https://user-images.githubusercontent.com/16817737/44446243-d6d5c980-a5ec-11e8-9736-a9ba1f09cc6f.png)
There are some themes on the page. The active theme is not presented to the user for removal.
![image](https://user-images.githubusercontent.com/16817737/44446361-3338e900-a5ed-11e8-8e9d-5de0d9dbe4fb.png)
Avant-X as the active theme
![image](https://user-images.githubusercontent.com/16817737/44446400-5fed0080-a5ed-11e8-8e79-3f740a23fa2d.png)
Removing themes...
![image](https://user-images.githubusercontent.com/16817737/44446419-6f6c4980-a5ed-11e8-84c9-bb25022eb963.png)
Removing themes...
![image](https://user-images.githubusercontent.com/16817737/44446434-7dba6580-a5ed-11e8-86d8-7ef94a6e6dac.png)
SpicePress as the active theme
![image](https://user-images.githubusercontent.com/16817737/44446467-a7738c80-a5ed-11e8-9088-e50347ec0a35.png)
![image](https://user-images.githubusercontent.com/16817737/44446486-b8bc9900-a5ed-11e8-93da-efcd22400aa9.png)
The page needs to be reloaded at this point to achieve the next view.
![image](https://user-images.githubusercontent.com/16817737/44446525-df7acf80-a5ed-11e8-8c76-6b241004a737.png)

