### PR TITLE
Added missing filter that exists in documentation

### DIFF
--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -132,8 +132,8 @@ class Loader {
      * Add a cache purge button to the WP adminbar
      */
     if ( apply_filters('seravo_use_purge_cache', true) ) {
-		  require_once dirname( __FILE__ ) . '/modules/purge-cache.php';
-	  }
+      require_once dirname( __FILE__ ) . '/modules/purge-cache.php';
+    }
 
     /*
      * Hide the domain alias from search engines

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -131,7 +131,9 @@ class Loader {
     /*
      * Add a cache purge button to the WP adminbar
      */
-    require_once dirname( __FILE__ ) . '/modules/purge-cache.php';
+    if ( apply_filters('seravo_use_purge_cache', true) ) {
+		  require_once dirname( __FILE__ ) . '/modules/purge-cache.php';
+	  }
 
     /*
      * Hide the domain alias from search engines


### PR DESCRIPTION
Added the missing filter. In seravo docs there is filter named seravo_use_purge_cache, but it's missing from the actual plugin file.