### PR TITLE
Make "Purge Cache" button run full wp-purge-cache with AJAX (closes #83)

### DIFF
--- a/js/purge-cache.js
+++ b/js/purge-cache.js
@@ -1,0 +1,23 @@
+'use strict';
+jQuery(document).ready(function($) {
+
+  // Add event listener for clicking the purge cache button
+  $('#wp-admin-bar-nginx-helper-purge-all .ab-item').click(function(evt) {
+    evt.preventDefault();
+
+    // Show spinning animation
+    $('.seravo-purge-cache-icon', this).addClass('spin');
+
+    // Ask for server to empty cache via AJAX
+    $.post(seravo_purge_cache_loc.ajax_url, {
+      action: 'seravo_purge_cache',
+      nonce: seravo_purge_cache_loc.seravo_purge_cache_nonce,
+    }, function(response) {
+      var query_object = {
+        'seravo_purge_success': response.success,
+      };
+      window.location = window.location.pathname + '?' + $.param(query_object);
+    });
+
+  });
+});

--- a/modules/purge-cache.php
+++ b/modules/purge-cache.php
@@ -4,129 +4,105 @@
  * Description: Purges the Seravo cache
  */
 
+namespace Seravo;
+
 // Deny direct access to this file
 if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 
-/**
- * Make capability filterable
- */
+if ( ! class_exists('Purge_Cache') ) {
+  class Purge_Cache {
 
-function _seravo_purge_capability() {
-  return apply_filters( 'seravo_purge_cache_capability', 'edit_posts' );
-}
-
-/**
- * Add a purge button in the WP Admin Bar
- */
-add_action( 'admin_bar_menu', '_seravo_purge_button', 999 );
-function _seravo_purge_button( $admin_bar ) {
-
-  // check permissions
-  if ( ! current_user_can( _seravo_purge_capability() ) ) {
-    return;
-  }
-
-  /*
-   * Add 'Purge cache' button to menu
-   */
-  $purge_url = add_query_arg( 'seravo_purge_cache', '1' );
-  $admin_bar->add_menu( array(
-    'id'    => 'nginx-helper-purge-all',
-    'title' => '<span class="ab-icon"></span><span title="' .
-      // translators: %s cache refresh interval
-      sprintf(__('Seravo.com uses front proxies to deliver lightning fast responses to your visitors. Cached pages will be refreshed every %s. This button is used for clearing all cached pages from the frontend proxy immediately.', 'seravo'), '15 min') .
-      '" class="ab-label">' . __('Purge Cache', 'seravo') . '</span>',
-    'href'  => wp_nonce_url( $purge_url, '_seravo_purge', '_seravo_nonce' ),
-  ));
-
-  /*
-   * Add style snippet in context of adminbar
-   */
-  ?>
-  <style type="text/css" media="screen">
-    #wpadminbar #wp-admin-bar-nginx-helper-purge-all .ab-item .ab-icon:before {
-      content: "\f463";
-      top: 3px;
-    }
-  </style>
-  <?php
-}
-
-/**
- * Purge the cache via REQUEST parameters
- */
-add_action( 'admin_init', '_maybe_seravo_purge_cache' );
-function _maybe_seravo_purge_cache() {
-
-  // check permissions
-  if ( ! current_user_can( _seravo_purge_capability() ) ) {
-    return;
-  }
-
-  if ( isset($_REQUEST['seravo_purge_cache']) ) {
-
-    // check nonce
-    if ( ! isset($_GET['_seravo_nonce']) || ! wp_verify_nonce($_GET['_seravo_nonce'], '_seravo_purge') ) {
-      return;
+    public static function load() {
+      // Check permissions before registering actions
+      if ( current_user_can(self::custom_capability()) ) {
+        add_action('admin_bar_menu', array( __CLASS__, 'purge_button' ), 999);
+        add_action('wp_ajax_seravo_purge_cache', array( __CLASS__, 'purge_cache' ));
+        add_action('wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+        add_action('admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+        add_action( 'admin_notices', array( __CLASS__, 'seravo_purge_notification' ));
+      }
     }
 
-    // purge the cache
-    $response = _seravo_purge_cache();
-    error_log( "NOTICE: Cache flush initiated from wp-admin. Response: \n" . $response );
+    /**
+     * Add a purge button in the WP Admin Bar
+     */
+    public static function purge_button( $admin_bar ) {
+      $purge_url = add_query_arg('seravo_purge_cache', '1');
+      $admin_bar->add_menu(array(
+        'id'    => 'nginx-helper-purge-all',
+        'title' => '<span class="ab-icon seravo-purge-cache-icon"></span><span title="' .
+          // translators: %s cache refresh interval
+          sprintf(__('Seravo.com uses front proxies to deliver lightning fast responses to your visitors. Cached pages will be refreshed every %s. This button is used for clearing all cached pages from the frontend proxy immediately.', 'seravo'), '15 min') .
+          '" class="ab-label seravo-purge-cache-text">' . __('Purge Cache', 'seravo') . '</span>',
+      ));
+    }
 
-    // redirect to the original siteurl with notification
-    $redirect_url = remove_query_arg( array( 'seravo_purge_cache', '_seravo_nonce' ) );
+    /**
+     * Load required scripts and styles for this module
+     */
+    public static function enqueue_scripts() {
+      wp_enqueue_style('seravo_purge_cache', plugin_dir_url(__DIR__) . '/style/purge-cache.css', '', Helpers::seravo_plugin_version());
+      wp_enqueue_script('seravo_purge_cache', plugins_url( '../js/purge-cache.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
+      $loc_array = array(
+        'seravo_purge_cache_nonce' => wp_create_nonce('seravo_purge_cache_nonce'),
+        'ajax_url'                 => admin_url( 'admin-ajax.php' ),
+      );
+      wp_localize_script('seravo_purge_cache', 'seravo_purge_cache_loc', $loc_array);
+    }
 
-    // Check if response was like "Cache purged successfully for <container>."
-    // Return 1 or 0 as middle argument based on if success or not.
-    $redirect_url = add_query_arg(
-      'seravo_purge_success',
-      strpos($response, 'success'),
-      $redirect_url
-    );
+    /**
+     * Make capability filterable
+     */
+    public static function custom_capability() {
+      return apply_filters('seravo_purge_cache_capability', 'edit_posts');
+    }
 
-    wp_redirect($redirect_url);
+    public static function seravo_purge_notification() {
+      // Don't show anything if there is no need to.
+      if ( ! isset($_REQUEST['seravo_purge_success']) ) {
+        return;
+      }
+      $success = filter_var($_REQUEST['seravo_purge_success'], FILTER_VALIDATE_BOOLEAN);
 
-    die();
+      if ( $success ) : ?>
+        <div class="notice updated is-dismissible">
+          <p><strong><?php _e( 'Success:', 'seravo' ); ?></strong> <?php _e( 'The cache was flushed.', 'seravo' ); ?> <button type="button" class="notice-dismiss"></button></p>
+        </div>
+      <?php else : ?>
+        <div class="notice notice-error is-dismissible">
+          <p><strong><?php _e( 'Error:', 'seravo' ); ?></strong> <?php _e( 'The cache was not flushed, please check your PHP error log for details.', 'seravo' ); ?> <button type="button" class="notice-dismiss"></button></p>
+        </div>
+      <?php
+      endif;
+    }
+
+    /**
+     * Purge the cache via AJAX
+     */
+    public static function purge_cache() {
+      $response = array();
+
+      // Check nonce
+      if ( ! isset($_REQUEST['nonce']) || ! wp_verify_nonce($_REQUEST['nonce'], 'seravo_purge_cache_nonce') ) {
+        $response['success'] = false;
+        $response['output'] = __('Error: the nonce did not verify.', 'seravo');
+
+      } else {
+        // Run wp-purge-cache, return command code and output
+        exec('wp-purge-cache 2>&1', $output, $return_code);
+        $response['success'] = (bool) ( $return_code === 0 );
+        $response['output'] = implode("\n", $output);
+      }
+
+      // Log any errors
+      if ( ! $response['success'] ) {
+        error_log('Seravo Purge Cache error: ' . $response['output']);
+      }
+
+      wp_send_json($response);
+    }
   }
-}
-
-/**
- * Displays the cache purged notification
- */
-add_action( 'admin_notices', '_seravo_purge_notification' );
-function _seravo_purge_notification() {
-
-  // check permissions
-  if ( ! current_user_can( _seravo_purge_capability() ) ) {
-    return;
-  }
-
-  // check to see if we should show notification
-  if ( ! isset($_REQUEST['seravo_purge_success']) ) {
-    return;
-  }
-
-  ?>
-  <div class="notice updated is-dismissible">
-      <p><strong><?php _e( 'Success:', 'seravo' ); ?></strong> <?php _e( 'The cache was flushed.', 'seravo' ); ?> <button type="button" class="notice-dismiss"></button></p>
-  </div>
-  <?php
-}
-
-/**
- * Purges the cache
- */
-function _seravo_purge_cache() {
-
-  // send a purge request to the downstream server
-  $nginx_purge_endpoint = 'http://' . getenv('HTTPS_DOMAIN_ALIAS') . '/purge/';
-  $ch = curl_init( $nginx_purge_endpoint );
-  curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PURGE');
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-  $return = curl_exec($ch);
-
-  return $return;
+  Purge_Cache::load();
 }

--- a/style/purge-cache.css
+++ b/style/purge-cache.css
@@ -1,0 +1,40 @@
+#wpadminbar #wp-admin-bar-nginx-helper-purge-all .ab-item .seravo-purge-cache-icon {
+  padding: 0px !important;
+  margin-top: 5px;
+  transform-origin: center center;
+}
+#wp-admin-bar-nginx-helper-purge-all .ab-item:hover {
+  cursor: pointer;
+}
+#wpadminbar #wp-admin-bar-nginx-helper-purge-all .ab-item .seravo-purge-cache-icon:before {
+  content: "\f463";
+}
+#wpadminbar #wp-admin-bar-nginx-helper-purge-all .spin {
+  animation: purge-cache-spin 1.2s infinite;
+  animation-timing-function: linear;
+}
+
+@moz-keyframes purge-cache-spin {
+  0% {
+    transform: rotate( 0deg );
+  }
+  100% {
+    transform: rotate( 360deg );
+  }
+}
+@webkit-keyframes purge-cache-spin {
+  0% {
+    transform: rotate( 0deg );
+  }
+  100% {
+    transform: rotate( 360deg );
+  }
+}
+@keyframes purge-cache-spin {
+  0% {
+    transform: rotate( 0deg );
+  }
+  100% {
+    transform: rotate( 360deg );
+  }
+}


### PR DESCRIPTION
Changes to the current mechansim:
- Run `wp-purge-cache` to also empty other caches than the Nginx front cache
- Also display failure message instead of merely success when in WP Admin, log errors to php-error.log
- Use AJAX instead of `wp_nonce_url` => Redirect from JS instead of PHP
- Include a neat cache spinning animation with keyframes :)

***Note:*** for this to work properly, the recent change involving the removation of `wp-restart-nginx` from `wp-purge-cache` must be available.

I haven't myself performed testing this on other sites than my own test site (where it works flawlessly), but will soon do that to find all the scenarios where the mechanism may fail.

EDIT: remember to also test this with other browsers than Chrome.