### PR TITLE
Install specific versions of PHPCS and WP Coding Standards in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ matrix:
       env: SNIFF=1
 
 before_install:
-  - if [[ "$SNIFF" == "1" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
-  - if [[ "$SNIFF" == "1" ]]; then export SNIFFS_DIR=/tmp/sniffs; fi
+  # Set the target directories and versions for PHP_CodeSniffer and WP Coding Standards.
+  - if [[ "$SNIFF" == "1" ]]; then export PHPCS_DIR=/tmp/phpcs; export PHPCS_VERSION=3.3.2; fi
+  - if [[ "$SNIFF" == "1" ]]; then export SNIFFS_DIR=/tmp/sniffs; export SNIFFS_VERSION=1.0.0; fi
   # Install PHP_CodeSniffer.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/squizlabs/PHP_CodeSniffer/archive/$PHPCS_VERSION.tar.gz -O $PHPCS_VERSION.tar.gz && tar -xf $PHPCS_VERSION.tar.gz && mv PHP_CodeSniffer-$PHPCS_VERSION $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then wget https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/$SNIFFS_VERSION.tar.gz -O $SNIFFS_VERSION.tar.gz && tar -xf $SNIFFS_VERSION.tar.gz && mv WordPress-Coding-Standards-$SNIFFS_VERSION $SNIFFS_DIR; fi
   # Set install path for WordPress Coding Standards.
   - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $SNIFFS_DIR; fi
   # After CodeSniffer install you should refresh your path.


### PR DESCRIPTION
There have been now a couple of incidents in which the PHP code sniff has
been successful locally, but then failed in the remote Travis CI build to
to different versions of PHPCS and WP Coding Standards. Instead of cloning
the repos directly from GitHub, we should stick to specific releases and
update them periodically.