### PR TITLE
Bugfix: Non-numeric value warning on database-page

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -36,6 +36,7 @@ if ( ! class_exists('Helpers') ) {
     }
 
     public static function human_file_size( $size, $precision = 2 ) {
+  	  $size = (int) $size; // 'wp db size' returns value with non-numeric characters
       for ( $i = 0; ( $size / 1024 ) > 0.9; ) {
         $i++;
         $size /= 1024;


### PR DESCRIPTION
Human_file_size function caused a 'non-numeric value' warning when
opening database-page because 'wp db size' returns a 'B' character
at the end of the value.

Fixed by casting the size argument in to integer.