### PR TITLE
Fix transient handling in relative urls in feeds (Closes #197)

### DIFF
--- a/modules/relative-urls.php
+++ b/modules/relative-urls.php
@@ -102,8 +102,8 @@ if ( ! class_exists(__NAMESPACE__ . '\\RelativeUrls') ) {
       $transient_key = 'seravo_feed_' . $letter_count . '_' . $hash;
 
       // Use transient to store the results
-      $content = get_transient( $transient_key );
-      if ( ( isset($_SERVER['HTTP_PRAGMA'] ) && $_SERVER['HTTP_PRAGMA'] === 'no-cache' ) || false === ( $content ) ) {
+      $transient = get_transient( $transient_key );
+      if ( ( isset($_SERVER['HTTP_PRAGMA'] ) && $_SERVER['HTTP_PRAGMA'] === 'no-cache' ) || false === ( $transient ) ) {
 
         // Again integrate with https://github.com/seravo/https-domain-alias
         $url = ( defined('HTTPS_DOMAIN_ALIAS_FRONTEND_URL') ? HTTPS_DOMAIN_ALIAS_FRONTEND_URL : self::$siteurl );
@@ -114,6 +114,8 @@ if ( ! class_exists(__NAMESPACE__ . '\\RelativeUrls') ) {
         // Save to transient
         set_transient( $transient_key, $content, 15 * MINUTE_IN_SECONDS );
 
+      } else {
+        $content = $transient;
       }
 
       return $content;


### PR DESCRIPTION
Previously the code overrode the $content value with transient
even if the transient was false. On top of that, the false was stored as
a transient which was intepreted as an empty string.

Now the transient is a separate value, so mixups won't happen.

### How to review
Try to curl a site's feed (the site should have feeds as full posts enabled). In master, the feed does not include the whole posts. 

Then change to this branch, flush cache and curl. Full posts should be visible now :) See #197 for the original issue