### PR TITLE
Update PHP version warning message

### DIFF
--- a/lib/seravo-notification.php
+++ b/lib/seravo-notification.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File for Seravo custom notification functionality.
+ */
+
+namespace Seravo;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('Seravo_Notification') ) {
+  class Seravo_Notification {
+
+    /**
+     * Instance of this class.
+     */
+    private static $instance = null;
+
+    /**
+     * Class constructor.
+     */
+    private function __construct() {
+      $this->load();
+    }
+
+    /**
+     * Get singleton instance.
+     * @return Seravo_Notification Instance of the Seravo_Notification class
+     */
+    public static function get_instance() {
+      if ( self::$instance === null ) {
+        self::$instance = new Seravo_Notification();
+      }
+      return self::$instance;
+    }
+
+    /**
+     * Enqueue necessary scripts and styles for Seravo postbox functionality.
+     */
+    public static function enqueue_notification_scripts() {
+        wp_enqueue_style('seravo_notification', plugin_dir_url(__DIR__) . 'style/seravo-notification.css', array(), Helpers::seravo_plugin_version());
+    }
+
+    public static function load() {
+      if ( is_admin() ) {
+        add_action( 'admin_enqueue_scripts', array(  __CLASS__,  'enqueue_notification_scripts' ) );
+      }
+    }
+  }
+}
+
+/**
+ * Create singleton class for Seravo notifications if not set.
+ */
+global $seravo_notification;
+if ( ! isset($seravo_notification) ) {
+  $seravo_notification = Seravo_Notification::get_instance();
+}

--- a/modules/check-php-version.php
+++ b/modules/check-php-version.php
@@ -41,18 +41,38 @@ if ( ! class_exists('CheckPHPVersion') ) {
     public static function _seravo_show_php_warning( $recommended_version ) {
 
 	  ?>
-		<div class="notice notice-error">
-	  <?php
 
-      // The line below is very long, but PHPCS standards requires translation
-      // strings to be one one line
-      printf(
-        // translators: %1$s: current php version, %2$s: recommended php version
-        __('The PHP version %1$s currently in use is lower than the recommended %2$s. Security updates might not be available for the version in use. Please consider <a target="_blank" href="https://help.seravo.com/en/knowledgebase/13/docs/107-set-your-site-to-use-newest-php-version">updating the PHP version</a>.', 'seravo'),
-        PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION, $recommended_version
-      );
+		<div class="notice notice-error seravo-notice">
+      <div class="seravo-banner">
+        <div class="seravo-emblem">
+          <a href="https://seravo.com">
+            <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" viewBox="0 0 34 25" width="34" height="25" >
+              <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" id="namedview132" />
+              <defs id="defs113">
+                <style id="style111">.cls-2{fill:#fff}</style>
+              </defs>
+              <path d="M0 9.3006C0 2.5719 10.44057 1.6086 10.44057 1.6086L33.97477.0 33.85747 19.5789c0 4.9585-11.7241 7.0158-22.89 4.0416v.016L.00653 20.6037z" id="path115" inkscape:connector-curvature="0" style="fill:#00a9d9;fill-rule:evenodd;stroke-width:.01675605" />
+              <path class="cls-2" d="m17.56337 21.276c-1.5818.0-3.7674-.2301-5.2344-.633-.345-.086-.5464-.3166-.5464-.6621v-2.3318c0-.2878.201-.5467.5464-.5467h.1151c1.5529.2011 3.969.4021 4.8892.4021 1.3806.0 1.6969-.3741 1.6969-1.1226.0-.4318-.259-.7483-1.0642-1.2088l-3.7387-2.1578c-1.6106-.9201-2.5597-2.3878-2.5597-4.2584.0-2.9067 1.927-4.4607 5.8958-4.4607 2.2719.0 3.6528.2879 5.1191.6621.3454.086.5464.3165.5464.6617v2.3311c0 .3453-.201.5467-.4887.5467h-.086c-.834-.1151-3.3073-.3741-4.7742-.3741-1.1216.0-1.5248.1727-1.5248.8346.0.4316.3164.662.8915 1.0072l3.5663 2.0442c2.3871 1.3812 2.9049 2.8775 2.9049 4.4315 5e-4 2.7044-1.9553 4.8348-6.1542 4.8348z" id="path117" inkscape:connector-curvature="0" style="fill:#fff;stroke-width:.01675605" />
+              <path class="cls-2" d="M26.65517 10.1155z" id="path129" style="fill:#fff;stroke-width:.01675605"/>
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div class="seravo-notice-content">
+        <span>
+      	  <?php
 
-	  ?>
+          // The line below is very long, but PHPCS standards requires translation
+          // strings to be one one line
+          printf(
+            // translators: %1$s: current php version, %2$s: recommended php version
+            __('The PHP version %1$s currently in use is lower than the recommended %2$s. Security updates might not be available for the version in use. Please consider <a target="_blank" href="https://help.seravo.com/en/knowledgebase/13/docs/107-set-your-site-to-use-newest-php-version">updating the PHP version</a>.', 'seravo'),
+            PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION, $recommended_version
+          );
+
+      	  ?>
+        </span>
+      </div>
 		</div>
 	  <?php
 

--- a/modules/check-php-version.php
+++ b/modules/check-php-version.php
@@ -46,7 +46,7 @@ if ( ! class_exists('CheckPHPVersion') ) {
       <div class="seravo-banner">
         <div class="seravo-emblem">
           <a href="https://seravo.com">
-            <svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" viewBox="0 0 34 25" width="34" height="25" >
+            <svg class="seravo-logo" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" viewBox="0 0 34 25" width="34" height="25" >
               <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" id="namedview132" />
               <defs id="defs113">
                 <style id="style111">.cls-2{fill:#fff}</style>

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -43,6 +43,11 @@ require_once dirname( __FILE__ ) . '/lib/api.php';
  */
 require_once dirname( __FILE__ ) . '/lib/seravo-postbox.php';
 
+/**
+ * Load Seravo notifications functionalities
+ */
+require_once dirname( __FILE__ ) . '/lib/seravo-notification.php';
+
 /*
  * Load Canonical Domain and HTTPS. Check first that WP CLI is not defined so the module will not
  * perform any redirections locally.

--- a/style/seravo-notification.css
+++ b/style/seravo-notification.css
@@ -1,0 +1,41 @@
+/*
+  Styles regaring admin notifications created by the Seravo-plugin
+*/
+
+/* The notice bar */
+div.seravo-notice {
+  display: flex;
+  align-items: center;
+  box-shadow: 0 0 0 1px rgba(200,215,225,.5),0 1px 2px #e9eff3;
+}
+
+/* Banner element containing the logo */
+div.seravo-banner {
+  display: flex;
+  align-items: center;
+  margin: 1em;
+}
+
+/* The Seravo logo */
+div.seravo-emblem {
+    display: flex;
+    align-items: center;
+    width: 2em;
+    height: 2em;
+    margin: auto;
+}
+
+/* Notice text content */
+div.seravo-notice-content {
+  display: flex;
+  padding-top: 1em;
+  padding-bottom:  1em;
+
+}
+
+svg {
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}

--- a/style/seravo-notification.css
+++ b/style/seravo-notification.css
@@ -3,10 +3,22 @@
 */
 
 /* The notice bar */
-div.seravo-notice {
-  display: flex;
-  align-items: center;
-  box-shadow: 0 0 0 1px rgba(200,215,225,.5),0 1px 2px #e9eff3;
+
+@media only screen and (min-width: 600px) {
+  .seravo-notice {
+    display: flex;
+    align-items: center;
+    box-shadow: 0 0 0 1px rgba(200,215,225,.5),0 1px 2px #e9eff3;
+  }
+}
+
+@media only screen and (max-width: 784px) {
+  .seravo-notice {
+    margin-top: 5px;
+    margin-right: 15px;
+    margin-bottom: 2px;
+    margin-left: 15px;
+  }
 }
 
 /* Banner element containing the logo */
@@ -26,14 +38,15 @@ div.seravo-emblem {
 }
 
 /* Notice text content */
-div.seravo-notice-content {
-  display: flex;
-  padding-top: 1em;
-  padding-bottom:  1em;
-
+@media only screen and (min-width: 784px) {
+  div.seravo-notice-content {
+    display: flex;
+    padding-top: 1em;
+    padding-bottom:  1em;
+  }
 }
 
-svg {
+.seravo-logo {
   align-items: center;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Currently the PHP version checking module in the Seravo-plugin is reaching users effectively, but the link in the notification and the link itself are far too generic.
![image](https://user-images.githubusercontent.com/16817737/50766305-594fe480-1281-11e9-8379-a419a4906dfd.png)

To ensure that users know where the notification stems from and what actions they have available, the message could be as follows: (PHP version recommendation exaggerated for demonstration purposes)
![image](https://user-images.githubusercontent.com/16817737/50766286-4c32f580-1281-11e9-9fa3-2d6a026c65b6.png)

The link leads to the [knowledgebase](https://help.seravo.com/en/knowledgebase/13/docs/107-uusimpaan-php-versioon-siirtyminen) article in the respective language.

The image used is an inline svg image for added performance.

The added notification style loading functionalities are somewhat similar to the existing postbox-module loading. This could be implemented later into a more generic notification building.

Suggestions and help on styling is much appriciated.

Related to #218 