### PR TITLE
Add null-checking to suppress PHP-warnings

### DIFF
--- a/lib/domains-page.php
+++ b/lib/domains-page.php
@@ -246,8 +246,12 @@ class Seravo_Domains_List_Table extends WP_List_Table {
         $this->dns->display();
       } else if ( 'edit' === $this->current_action() ) {
         $this->dns->display_edit();
-      } elseif ( $_REQUEST['zone-updated'] ) {
-        $this->dns->display_results( $_REQUEST['modifications'], $_REQUEST['error'] );
+      } elseif ( isset( $_REQUEST['zone-updated'] ) ) {
+        if ( $_REQUEST['zone-updated'] === 'true' ) {
+          $modifications = isset( $_REQUEST['modifications'] ) ? $_REQUEST['modifications'] : false;
+          $error = isset( $_REQUEST['error'] ) ? $_REQUEST['error'] : false;
+          $this->dns->display_results( $modifications, $error );
+        }
       }
 
       echo '</td></tr>';

--- a/modules/logs.php
+++ b/modules/logs.php
@@ -91,11 +91,13 @@ if ( ! class_exists('Logs') ) {
       }
 
       // Default log view is the PHP error log as it is the most important one
-      $current_logfile = 'php-error.log';
+      $default_logfile = 'php-error.log';
 
       // Use supplied log name if given
       if ( isset( $_GET['logfile'] ) ) {
         $current_logfile = $_GET['logfile'];
+      } else {
+        $current_logfile = $default_logfile;
       }
 
       $max_num_of_rows = 50;
@@ -117,8 +119,14 @@ if ( ! class_exists('Logs') ) {
         $logfiles[ basename( $log ) ] = $log;
       }
 
-      // Set logfile based on supplied log name
-      $logfile = $logfiles[ $current_logfile ];
+      // Set logfile based on supplied log name if it's available
+      if ( isset( $logfiles[ $current_logfile ] ) ) {
+        $logfile = $logfiles[ $current_logfile ];
+      } else if ( isset( $logfiles[ $default_logfile ] ) ) {
+        $logfile = $logfiles[ $default_logfile ];
+      } else {
+        $logfile = null;
+      }
 
       ?>
   <div class="wrap">


### PR DESCRIPTION
Adds null-checking to domain and log -pages. These
pages otherwise give PHP-warnings with WP_DEBUG enabled.

Logs-page has been designed so that it doesn't try to
use log files that don't exists. But always using
'php-error.log' as default didn't verify its existence.