### PR TITLE
Implement zone editing using AJAX

### DIFF
--- a/js/domains.js
+++ b/js/domains.js
@@ -1,0 +1,133 @@
+'use strict';
+
+jQuery(document).ready(function($) {
+
+  var update_zone_button = jQuery('#update-zone-btn');
+
+  update_zone_button.click(function (event) {
+
+    event.preventDefault();
+
+    var response_div = jQuery("#zone-edit-response");
+    var spinner_div = jQuery("#zone-update-spinner");
+
+    jQuery("#zone-fetch-response").html("");
+
+    response_div.html("");
+    spinner_div.html("<img src=\"/wp-admin/images/spinner.gif\">");
+
+    jQuery.post(seravo_domains_loc.ajaxurl, {
+      'action': 'seravo_ajax_domains',
+      'section': 'update_zone',
+      'domain': $("input[name='domain']").val(),
+      'compulsory': $("textarea[name='compulsory']").val(),
+      'zonefile': $("textarea[name='zonefile']").val(),
+      'nonce': seravo_domains_loc.ajax_nonce,
+    },
+
+    function (rawData) {
+
+      if (rawData == 0) {
+        // If eg. AJAX callback not found
+        response_div.html('<p><b>No data returned for the update request.</b></p>');
+
+      } else {
+
+        var response = JSON.parse(rawData);
+
+        if (response['status'] && response['status'] === 400) {
+
+          response_div.html("<p><b>" + seravo_domains_loc.zone_update_failed + ":</b></p><p>" + response['reason'] + "</p>");
+
+        } else {
+
+          var response_html = "<p><b>" + seravo_domains_loc.zone_update_success + "</b></p>";
+          // Add modifications to response_html as an ordered list
+          var modifications = response['modifications'];
+          if (modifications != null && modifications.length > 0) {
+            response_html += "<p>" + seravo_domains_loc.zone_modifications + "</p><ol>";
+            response_html += "<li>" + modifications.join("</li><li>") + "</li>";
+            response_html += "</ol>";
+          }
+
+          response_div.html(response_html);
+          // Refresh records for sanitized data
+          fetch_dns();
+
+        }
+
+      }
+
+      spinner_div.html("");
+
+    }
+
+    ).fail(function () {
+
+      zone_update_failed();
+
+    });
+
+    function zone_update_failed() {
+
+      response_div.html('<p><b>Failed to update the zone. Please try again.</b></p>');
+
+    }
+
+  });
+
+  function fetch_dns() {
+
+    var response_div = jQuery("#zone-fetch-response");
+    var compulsory_records = jQuery("textarea[name='compulsory']");
+    var editable_records = jQuery("textarea[name='zonefile']");
+
+    if (response_div.length && compulsory_records.length && editable_records.length) {
+
+      jQuery.post(seravo_domains_loc.ajaxurl, {
+        'action': 'seravo_ajax_domains',
+        'section': 'fetch_dns',
+        'domain': $("input[name='domain']").val(),
+        'nonce': seravo_domains_loc.ajax_nonce,
+      },
+
+      function (rawData) {
+
+        if (rawData == 0) {
+          // If eg. AJAX callback not found
+          fetch_error('No data returned for the dns fetch.');
+
+        } else {
+
+          var response = JSON.parse(rawData);
+
+          if (response['reason'] && response['status'] && response['status'] === 400) {
+            fetch_error(response['reason']);
+          } else if ( response['error'] ) {
+            fetch_error(response['error']);
+          } else {
+            compulsory_records.val(response['compulsory']['records'].join("\n"));
+            editable_records.val(response['editable']['records'].join("\n"));
+            editable_records.prop('readonly', false);
+          }
+
+        }
+
+      }
+
+      ).fail(function () {
+        fetch_error('DNS fetch failed! Please refresh the page.');
+      });
+
+      function fetch_error(error) {
+        response_div.html('<p style="margin:0;"><b>' + error + '</b></p>');
+        // Disable further editing when errors
+        editable_records.prop('readonly', true);
+        update_zone_button.attr("disabled", true);
+      }
+
+    }
+
+  }
+
+});

--- a/lib/domains-ajax.php
+++ b/lib/domains-ajax.php
@@ -1,0 +1,92 @@
+<?php
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists( 'Seravo_Domains_DNS_Table' ) ) {
+  require_once dirname( __FILE__ ) . '/domains-dns.php';
+}
+
+function seravo_respond_error_json( $reason = '' ) {
+  return json_encode( array(
+    'status' => 400,
+    'reason' => $reason,
+  ) );
+}
+
+function seravo_admin_change_zone_file() {
+
+  $response = '';
+
+  if ( isset( $_REQUEST['zonefile'] ) && isset( $_REQUEST['domain'] ) ) {
+    // Attach the editable records to the compulsory
+    if ( $_REQUEST['compulsory'] ) {
+      $zone = $_REQUEST['compulsory'] . "\n" . $_REQUEST['zonefile'];
+    } else {
+      $zone = $_REQUEST['zonefile'];
+    }
+
+    // Remove the escapes that are not needed.
+    // This makes \" into "
+    $data_str = str_replace( '\"', '"', $zone );
+    // This makes \\\\" into \"
+    $data_str = str_replace( '\\\\"', '\"', $data_str );
+    $data = explode( "\r\n", $data_str );
+
+    $response = Seravo\API::update_site_data( $data, '/domain/' . $_REQUEST['domain'] . '/zone', [ 200, 400 ] );
+    if ( is_wp_error( $response ) ) {
+      return seravo_respond_error_json( $response->get_error_message() );
+      wp_die();
+    }
+  } else {
+    // 'No data returned'
+    return;
+  }
+
+  return $response;
+
+  wp_die();
+
+}
+
+function seravo_fetch_dns() {
+
+  if ( isset( $_REQUEST['domain'] ) ) {
+    $records = Seravo_Domains_DNS_Table::fetch_dns_records( $_REQUEST['domain'] );
+    if ( is_wp_error( $records ) ) {
+      return seravo_respond_error_json( $records->get_error_message() );
+      wp_die();
+    }
+    return json_encode($records);
+  }
+
+  // 'No data returned'
+  return;
+
+  wp_die();
+
+}
+
+function seravo_ajax_domains() {
+
+  check_ajax_referer( 'seravo_domains', 'nonce' );
+
+  switch ( $_REQUEST['section'] ) {
+    case 'update_zone':
+      echo seravo_admin_change_zone_file();
+      break;
+
+    case 'fetch_dns':
+      echo seravo_fetch_dns();
+      break;
+
+    default:
+      error_log('ERROR: Section ' . $_REQUEST['section'] . ' not defined');
+      break;
+  }
+
+  wp_die();
+
+}

--- a/lib/domains-dns.php
+++ b/lib/domains-dns.php
@@ -45,28 +45,28 @@ class Seravo_Domains_DNS_Table {
     if ( ! isset( $this->records ) ) {
       return;
     }
-    if ( $this->records['pending_activation'] ) {
+
+    $error = isset( $this->records['error'] );
+
+    if ( ! $error && $this->records['pending_activation'] ) {
       echo '<hr>';
       // translators: %s domain of the site
       echo '<p style="max-width:50%;">' . wp_sprintf( __( 'Our systems have detected that <strong>%s</strong> does not point to the Seravo servers. For your protection, manual editing is disabled. Please contact the Seravo customer service if you want changes to be done to the zone in question. You can publish the site yourself when you so desire with the following button:', 'seravo'), $this->records['name'] ) . '</p>';
       wp_nonce_field( 'seravo-zone-nonce' );
       echo '<input type="hidden" name="action" value="change_zone_file">';
       echo '<input type="hidden" name="domain" value="' . $this->records['name'] . '">';
-      echo '<textarea type="hidden" name="zonefile" style="display: none; font-family: monospace;">' .
-      $this->compulsory_as_string() . "\n" . $this->editable_as_string() .
-      '</textarea>';
+      echo '<textarea type="hidden" name="zonefile" style="display: none; font-family: monospace;">' . ( $this->compulsory_as_string() . "\n" . $this->editable_as_string() ) . '</textarea>';
       echo '<input style="margin-bottom:8px;" type="submit" value="' . __( 'Publish', 'seravo' ) . '"" formaction="' . esc_url( admin_url( 'admin-post.php' ) ) . '" formmethod="post" >';
       echo '<hr>';
     } else {
-      if ( isset( $this->records['error'] ) ) {
-        echo '<div><p style="margin-left: 3px;"><b>' . $this->records['error'] . '</b></p></div>';
-        return;
-      }
+
+      // If $error is true, show empty / disabled fields
+
       echo '<hr>';
-      wp_nonce_field( 'seravo-zone-nonce' );
       echo '<input type="hidden" name="action" value="change_zone_file">';
-      echo '<input type="hidden" name="domain" value="' . $this->records['name'] . '">';
+      echo '<input type="hidden" name="domain" value="' . ( $error ? '' : $this->records['name'] ) . '">';
       echo '<table>';
+
       echo '<tr><td style="padding-bottom: 0px;">';
       echo '<h2 style="margin: 0px 0px 5px 0px;">' . __( 'Compulsory Records', 'seravo' ) . '</h2>';
       echo '<p>' . __( 'It is not recommended to edit these records. Please contact the Seravo customer service if you want changes to be done to them.', 'seravo' ) . '</p>';
@@ -74,47 +74,16 @@ class Seravo_Domains_DNS_Table {
       echo '<h2 style="margin: 0px 0px 5px 0px;">' . __( 'Editable records', 'seravo' ) . '</h2>';
       echo '<p>' . __( 'Here you can add, edit and delete records. Please do not try to add records conflicting with the compulsory records. They will not be activated.', 'seravo') . '</p>';
       echo '</td></tr>';
-      echo '<tr><td style="width:50%">';
-      echo '<textarea name="compulsory" readonly style="width: 100%; font-family: monospace;" rows="15">';
-      echo $this->compulsory_as_string();
-      echo '</textarea>';
-      echo '</td><td style="width:50%">';
-      echo '<textarea name="zonefile" style="width: 100%; font-family: monospace;" rows="15">';
-      echo $this->editable_as_string();
-      echo '</textarea>';
-      echo '</td></tr>';
-      echo '<tr><td></td><td><input type="submit" class="button alignright" formaction="' . esc_url( admin_url( 'admin-post.php' ) ) . '"
-            formmethod="post" value="' . __( 'Update Zone', 'seravo' ) . '"></td></tr>';
+
+      echo '<tr><td style="padding:0 0 0 10px;"><div id="zone-fetch-response"><p style="margin:0;"><b>' . ( $error ? $this->records['error'] : '' ) . '</p></b></div></td></tr>';
+      echo '<tr><td style="width:50%"><textarea name="compulsory" readonly style="width: 100%; font-family: monospace;" rows="15">' . ( $error ? '' : $this->compulsory_as_string() ) . '</textarea></td>';
+      echo '<td style="width:50%"><textarea name="zonefile" style="width: 100%; font-family: monospace;" rows="15"' . ( $error ? ' readonly>' : '>' . $this->editable_as_string() ) . '</textarea></td></tr>';
+      echo '<tr><td><div id="zone-edit-response"></div></td><td>';
+      echo '<button id="update-zone-btn" class="button alignright"' . ( $error ? ' disabled' : '' ) . '>' . __( 'Update Zone', 'seravo' ) . '</button>';
+      echo '<div id="zone-update-spinner" class="alignright" style="margin: 4px 10px 0 0"></div></td></tr>';
       echo '</table>';
       echo '<hr>';
     }
-  }
-
-  public function display_results( $modifications = false, $error = false ) {
-
-    if ( ! $error ) {
-      echo '<p><b>' . __('The zone was updated succesfully!', 'seravo') . '</b></p>';
-      if ( $modifications ) {
-        echo '<div>' . __('The following modifications were done for the zone: ', 'seravo');
-        echo '<ol>';
-        foreach ( $modifications as $m ) {
-          echo '<li>' . $m . '</li>';
-        }
-        echo '</ol></div>';
-      }
-    } else {
-      echo '<p><b>' . __( 'The zone update failed', 'seravo' ) . '</b></p>';
-      echo '<div>' . $error . '</div>';
-    }
-  }
-
-  public function fetch_dns_records( $url ) {
-    $api_query = '/domain/' . $url . '/zone';
-    $records = Seravo\API::get_site_data( $api_query );
-    if ( is_wp_error( $records ) ) {
-      die( $records->get_error_message() );
-    }
-    $this->records = $records;
   }
 
   private function records_as_str( $records ) {
@@ -143,4 +112,19 @@ class Seravo_Domains_DNS_Table {
   private function editable_as_string() {
     return implode( "\n", $this->records['editable']['records'] );
   }
+
+  public static function fetch_dns_records( $url ) {
+
+    $api_query = '/domain/' . $url . '/zone';
+
+    $records = Seravo\API::get_site_data( $api_query );
+
+    if ( is_wp_error( $records ) ) {
+      $records = array( 'error' => $records->get_error_message() );
+    }
+
+    return $records;
+
+  }
+
 }

--- a/lib/domains-page.php
+++ b/lib/domains-page.php
@@ -147,10 +147,10 @@ class Seravo_Domains_List_Table extends WP_List_Table {
     if ( 'delete' === $this->current_action() ) {
       wp_die('Items deleted (or they would be if we had items to delete)!');
     } elseif ( 'view' === $this->current_action() ) {
-      $this->dns->fetch_dns_records($_REQUEST['domain']);
+      $this->dns->records = Seravo_Domains_DNS_Table::fetch_dns_records($_REQUEST['domain']);
     } elseif ( 'edit' === $this->current_action() ) {
       // Fetch something to edit
-      $this->dns->fetch_dns_records($_REQUEST['domain']);
+      $this->dns->records = Seravo_Domains_DNS_Table::fetch_dns_records($_REQUEST['domain']);
     }
   }
 
@@ -246,12 +246,6 @@ class Seravo_Domains_List_Table extends WP_List_Table {
         $this->dns->display();
       } elseif ( 'edit' === $this->current_action() ) {
         $this->dns->display_edit();
-      } elseif ( isset( $_REQUEST['zone-updated'] ) ) {
-        if ( $_REQUEST['zone-updated'] === 'true' ) {
-          $modifications = isset( $_REQUEST['modifications'] ) ? $_REQUEST['modifications'] : false;
-          $error = isset( $_REQUEST['error'] ) ? $_REQUEST['error'] : false;
-          $this->dns->display_results( $modifications, $error );
-        }
       }
 
       echo '</td></tr>';


### PR DESCRIPTION
Implements zone editing using AJAX (as originally planned in #182) and makes it more user friendly.

Improvements:
- No need to load the page again (Can be annoying with larger domain lists).
- Don't need to start over when trying to save invalid zone.
- Gets sanitized version of zone right after saving.
- Disables editing with errors (eg. Record fetch failed) to make accidentally breaking zone harder.