### PR TITLE
Add new layout to cruft plugin (Closes: #215)

### DIFF
--- a/js/cruftplugins.js
+++ b/js/cruftplugins.js
@@ -1,19 +1,18 @@
 'use strict';
 
-
-
-
-jQuery(document).ready(function($) {
+jQuery(document).ready(function ($) {
   function seravo_ajax_delete_plugin(plugin_name, callback) {
     $.post(
-      seravo_cruftplugins_loc.ajaxurl,
-      { type: 'POST',
+      seravo_cruftplugins_loc.ajaxurl, {
+        type: 'POST',
         'action': 'seravo_remove_plugins',
         'removeplugin': plugin_name,
-        'nonce': seravo_cruftplugins_loc.ajax_nonce, },
-      function( rawData ) {
+        'nonce': seravo_cruftplugins_loc.ajax_nonce,
+      },
+      function (rawData) {
         var data = JSON.parse(rawData);
-        if ( data[ data.length - 1 ].indexOf('Success: Deleted 1 of 1 plugins.') != -1 ) {
+        console.log(data)
+        if (data[data.length - 1].indexOf('Success: Deleted 1 of 1 plugins.') != -1) {
           callback();
         } else {
           confirm(seravo_cruftplugins_loc.failure);
@@ -24,80 +23,150 @@ jQuery(document).ready(function($) {
   // Generic ajax report loader function
   function seravo_plugin_load_report(section) {
     $.post(
-      seravo_cruftplugins_loc.ajaxurl,
-      { 'action': 'seravo_list_cruft_plugins',
+      seravo_cruftplugins_loc.ajaxurl, {
+        'action': 'seravo_list_cruft_plugins',
         'section': section,
-        'nonce': seravo_cruftplugins_loc.ajax_nonce, },
-      function(rawData) {
+        'nonce': seravo_cruftplugins_loc.ajax_nonce,
+      },
+      function (rawData) {
         if (rawData.length == 0) {
           $('#' + section).html(seravo_cruftplugins_loc.no_data);
         }
         $('#' + section + '_loading').fadeOut();
+        var $bodyElement = $('#cruftplugins_status');
+        // Parse data
         var data = JSON.parse(rawData);
-        // title, name, status
-        var titles = new Array();
-        $.each( data, function( i, plugin ){
-          if (plugin.name != '') {
-            titles = seravo_print_plugin_table( titles, plugin );
-          }
-        });
-        if ( titles.length != 0 ) {
-          $( '#cruftplugins_status' ).prepend('<p>' + seravo_cruftplugins_loc.cruftplugins + '</p>');
+        var sortedData = sort_plugin_data_array(data);
+        // Show message
+        if (Object.keys(sortedData).length != 0) {
+          $('#cruftplugins_status').prepend('<p>' + seravo_cruftplugins_loc.cruftplugins + '</p>');
         } else {
-          $( '#cruftplugins_status' ).prepend('<b>' + seravo_cruftplugins_loc.no_cruftplugins + '</b>');
+          $('#cruftplugins_status').prepend('<b>' + seravo_cruftplugins_loc.no_cruftplugins + '</b>');
         }
-        $( '#cruftplugins_status_loading img' ).fadeOut
-        $('.cruftplugin-delete-button').click(function(event) {
+        // Create tables
+        $.each(Object.keys(sortedData), function (i, status) {
+          // Create table body
+          appendTable($bodyElement, status)
+          // Insert entries
+          var $entries = $('#cruftplugins_' + status + ' .cruftplugins_entries_' + status);
+          $.each(sortedData[status], function (o, plugin) {
+            var html = '<tr class="cruftplugin">' +
+              '<td class="cruftplugin-delete"><input data-plugin-name="' + plugin.name + '" class="cruftplugin-check_' + status + '" type="checkbox"></td>' +
+              '<td class="cruftplugin-path">' + plugin.name + '</td>' +
+              '</tr>';
+            $entries.append(html);
+          })
+          if ($('#cruftplugins_' + status).find('.cruftplugins_entries_' + status).children().length >= 30) {
+            $('#cruftplugins_' + status).find('.cruftplugins_less-than').show(400);
+          }
+          // Add checkbox click events
+          $('.cruftplugin-select-all_' + status).click(function (event) {
+            if (this.checked) {
+
+              // Iterate each checkbox
+              $('.cruftplugin-check_' + status + ', .cruftplugin-select-all_' + status).each(function () {
+                this.checked = true;
+              });
+            } else {
+              $('.cruftplugin-check_' + status + ', .cruftplugin-select-all_' + status).each(function () {
+                this.checked = false;
+              });
+            }
+          });
+          $('.cruftplugin-check_' + status).click(function () {
+            if ($('.cruftplugin-check_' + status + ':checked').length == $('.cruftplugin-check_' + status).length) {
+              $('.cruftplugin-select-all_' + status).each(function () {
+                this.checked = true;
+              });
+            } else {
+              $('.cruftplugin-select-all_' + status).each(function () {
+                this.checked = false;
+              });
+            }
+          })
+        });
+        // Remove files
+        $('.cruftplugin-delete-button').click(function (event) {
           event.preventDefault();
           var is_user_sure = confirm(seravo_cruftplugins_loc.confirm);
-          if ( ! is_user_sure ) {
+          if ( ! is_user_sure) {
             return;
           }
-          var parent_row = $(this).parents(':eq(1)');
-          var plugin_name = parent_row.attr('data-plugin-name');
-          seravo_ajax_delete_plugin(plugin_name, function() {
-            parent_row.animate({
-              opacity: 0
-            }, 600, function() {
-              var container = parent_row.parents().eq(0);
-              parent_row.remove();
-              // purge empty lists
-              if ( container.children().length == 0 ) {
-                container.parents(':eq(1)').remove();
-              }
-            });
+          var $this = $(this);
+          var status = $this.data('status');
+          var $body = $('#cruftplugins_' + status);
+          var cruft_list = [];
+          var remove_rows = [];
+          // Get selected checkboxes
+          $body.find('.cruftplugin-check_' + status).each(function () {
+            var $cthis = $(this);
+            if ($cthis.is(":checked")) {
+              remove_rows.push($cthis.parents(':eq(1)'));
+              cruft_list.push($cthis.attr('data-plugin-name'));
+            }
           });
+          // Delete plugins
+          if (cruft_list.length > 0) {
+            seravo_ajax_delete_plugin(cruft_list, function () {
+              remove_rows.forEach(function (row) {
+                row.animate({
+                  opacity: 0
+                }, 600, function () {
+                  row.remove();
+                  if ($body.find('.cruftplugins_entries_' + status).children().length >= 30) {
+                    $body.find('.cruftplugins_less-than_' + status).show(400);
+                  }
+                  if ($body.find('.cruftplugins_entries_' + status).children().length == 0) {
+                    $body.children().remove();
+                    $body.append('<b>' + seravo_cruftplugins_loc.no_cruftplugins + '</b>');
+                    $body.next('.cruftplugin-delete-button').remove();
+                  }
+                });
+              });
+            });
+          }
         });
-
       }
-    ).fail(function() {
+    ).fail(function () {
       $('#' + section + '_loading').html(seravo_cruftplugins_loc.fail);
     });
   }
-  // titles for the titles that have been printed. plugin for the one which is to be printed.
-  function seravo_print_plugin_table( titles, plugin) {
-    if (titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_status').append('<div class="cruft-plugin-set"><table><tbody class="cruft-plugin-table" id="cruftplugins_' + plugin.status + '"></tbody></table></div>');
-    }
-    if (plugin.status == 'cache_plugins' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.cache_plugins + '</b><p>' + seravo_cruftplugins_loc.cache_plugins_desc + '</p>');
-    } else if (plugin.status == 'security_plugins' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.security_plugins + '</b><p>' + seravo_cruftplugins_loc.security_plugins_desc + '</p>');
-    } else if (plugin.status == 'db_plugins' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.db_plugins + '</b><p>' + seravo_cruftplugins_loc.db_plugins_desc + '</p>');
-    } else if (plugin.status == 'backup_plugins' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.backup_plugins + '</b><p>' + seravo_cruftplugins_loc.backup_plugins_desc + '</p>');
-    } else if (plugin.status == 'poor_security' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.poor_security + '</b><p>' + seravo_cruftplugins_loc.poor_security_desc + '</p>');
-    } else if (plugin.status == 'inactive' && titles.indexOf(plugin.status) == -1) {
-      $( '#cruftplugins_' + plugin.status ).parents().eq(1).prepend('<b>' + seravo_cruftplugins_loc.inactive + '</b><p>' + seravo_cruftplugins_loc.inactive_desc + '</p>');
-    }
-    titles.push(plugin.status);
-    $( '#cruftplugins_' + plugin.status ).append('<tr class="cruftplugin" data-plugin-name= "' + plugin.name + '"><td class="cruftplugin-delete">' +
-      '<a href="" class="dashicons dashicons-trash cruftplugin-delete-button" >' +
-      '</td><td class="cruftplugin-path">' + plugin.title + '</td></tr>');
 
-    return titles;
+  function sort_plugin_data_array(dataArray) {
+    var resultArray = {};
+    $.each(dataArray, function (i, plugin) {
+      // If no plugin key is created create one
+      if (Object.keys(resultArray).indexOf(plugin.status) === -1) {
+        resultArray[plugin.status] = [];
+      }
+      // Push plugin to array
+      resultArray[plugin.status].push(plugin);
+    });
+    return resultArray;
+  }
+
+  function appendTable($element, status) {
+    var html =
+      '<b>' + seravo_cruftplugins_loc[status] + '</b><p>' + seravo_cruftplugins_loc[status + '_desc'] + '</p>' +
+      '<table id="cruftplugins_' + status + '">' +
+      '<thead>' +
+      '<tr>' +
+      '<td><input class="cruftplugin-select-all_' + status + '" type="checkbox"></td>' +
+      '<td class="cruft-tool-selector cruft-plugin-td"><b>Select all files</b></td>' +
+      '</tr>' +
+      '</thead>' +
+      '<tbody class="cruftplugins_entries_' + status + '">' +
+      '</tbody>' +
+      '<tfoot class="cruftplugins_less-than_' + status + '" style="display: none;">' +
+      '<tr>' +
+      '<td><input class="cruftplugin-select-all_' + status + '" type="checkbox"></td>' +
+      '<td class="cruft-tool-selector cruft-plugin-td"><b>Select all files</b></td>' +
+      '</tr>' +
+      '</tfoot>' +
+      '</table>' +
+      '<button class="cruftplugin-delete-button" data-status="' + status + '" type="button">Delete</button>' +
+      '</br>';
+    $element.append(html)
   }
 
   // Load on page load

--- a/js/cruftthemes.js
+++ b/js/cruftthemes.js
@@ -1,152 +1,138 @@
 'use strict';
 
-function removeValue(list, value) {
-  list = list.split(',');
-  list.splice(list.indexOf(value), 1);
-  return list.join(',');
-}
-
-class CruftTheme {
-  constructor(name, title, active) {
-    this.name = name;
-    this.title = title;
-    this.active = active;
-  }
-  seravo_print_theme_table( target ) {
-    if ( ! this.active ) {
-      target.append('<div id="' + this.name + '" class="crufttheme ' + this.name + '" data-theme-name= "' + this.name + '"><div id="button' + this.name + '" class="crufttheme-delete">' +
-      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + this.title + '</div></div>');
+jQuery(document).ready(function ($) {
+  var section = 'cruftthemes_status';
+  var $body = $('#' + section);
+  // Entries variable fill be filled when table is appended
+  var $entries;
+  function appendTable() {
+    // If table is appended return entries
+    if ($entries) {
+      return $entries;
     }
-    return( ! this.active );
-  }
-}
-
-class CruftParent extends CruftTheme {
-  constructor(name, title, active, children) {
-    super(name, title, active);
-    this.children = children;
-  }
-  seravo_print_theme_table( target ){
-    if ( super.seravo_print_theme_table( target ) ) {
-      document.querySelector( '#' + this.name ).className += ' crufttheme-parent';
-      var titles = '';
-      var handles = '';
-      this.children.forEach(element => {
-        target.append( '<div id="' + element.parent + 'box" class="crufttheme-child-container"></div>');
-        element.seravo_print_theme_child( document.querySelector( '#' + this.name + 'box' ) );
-        titles += ', ' + element.title;
-        handles += element.name + ' ';
-      });
-      document.querySelector( '#' + this.name ).innerHTML += '<div class="theme-relative-info" style="padding-left: 5px">' + seravo_cruftthemes_loc.isparentto
-        + '</div><div class="theme-relatives" data-theme-children="' + handles.slice(0, -1) + '" style="padding-left: 5px">' + titles.slice(1) + '</div>';
-      target.find('#button' + this.name).addClass('cruft-button-hide').removeClass('crufttheme-delete-button');
-    } else {
-      this.children.forEach(element => {
-        element.seravo_print_theme_table( target );
-      });
-    }
+    var html =
+      '<table id="' + section + '">' +
+      '<thead>' +
+      '<tr>' +
+      '<td><input class="' + section + '_select-all" type="checkbox"></td>' +
+      '<td class="cruft-tool-selector cruft-themes-td"><b>Select all files</b></td>' +
+      '</tr>' +
+      '</thead>' +
+      '<tbody class="' + section + '_entries">' +
+      '</tbody>' +
+      '<tfoot class="' + section + '_less-than" style="display: none;">' +
+      '<tr>' +
+      '<td><input class="' + section + '_select-all" type="checkbox"></td>' +
+      '<td class="cruft-tool-selector"><b>Select all files</b></td>' +
+      '</tr>' +
+      '</tfoot>' +
+      '</table>' +
+      '<button class="crufttheme-delete-button ' + section + '_delete" type="button">Delete</button>';
+    $body.append(html)
+    $entries = $('.' + section + '_entries');
+    return $entries;
   }
 
-}
-
-class CruftChild extends CruftTheme {
-  constructor(name, title, active, parent) {
-    super(name, title, active);
-    this.parent = parent;
-  }
-  seravo_print_theme_child( target_box ) {
-    if ( ! this.parent.active && ! this.active ) {
-      target_box.innerHTML += '<div id="' + this.name + '" class="crufttheme-child crufttheme ' + this.name + '" data-theme-name= "' + this.name + '"><div class="crufttheme-delete child-delete-button">' +
-      '<a href="" class="dashicons dashicons-trash crufttheme-delete-button" ></a></div><div>' + this.title + '</div></div>';
+  function appendLine($element, theme, isChild) {
+    var html =
+    '<tr class="crufttheme" data-plugin-name="' + theme.name + '" data-active="' + theme.active + '" data-childs="' + (theme.childs ? 'true' : 'false') + '"  data-is-child="' + (isChild ? 'true' : 'false') + '">';
+      html += '<td class="crufttheme-delete">' +
+      '<input data-plugin-name="' + theme.name + '" class="crufttheme-check" type="checkbox">' +
+      '</td>';
+    html += '<td class="crufttheme-path">' + theme.name + '</td>' +
+    '</tr>';
+    $element.append(html)
+    // Apply childs
+    if (theme.childs) {
+      theme.childs.forEach(function (child) {
+        appendLine($element, child, true)
+      })
     }
   }
-}
 
-jQuery(document).ready(function($) {
-  function seravo_ajax_delete_theme(theme_name, parent_row, callback) {
-    $.post(
-      seravo_cruftthemes_loc.ajaxurl,
-      { type: 'POST',
-        'action': 'seravo_remove_themes',
-        'removetheme': theme_name,
-        'nonce': seravo_cruftthemes_loc.ajax_nonce, },
-      function( rawData ) {
-        var data = JSON.parse(rawData);
-        if ( data ) {
-          callback(parent_row, data);
-        } else {
-          confirm(seravo_cruftthemes_loc.failure);
-        }
-      });
-  }
-
-  function seravo_delete_theme(parent_row, data) {
-    parent_row.animate({
-      opacity: 0
-    }, 600, function() {
-      parent_row.remove();
-    });
-  }
-
-  // Generic ajax report loader function
-  function seravo_theme_load_report(section) {
-    $.post(
-      seravo_cruftthemes_loc.ajaxurl,
-      { 'action': 'seravo_list_cruft_themes',
-        'section': section,
-        'nonce': seravo_cruftthemes_loc.ajax_nonce, },
-      function(rawData) {
-        if (rawData.length == 0) {
-          $('#' + section).html(seravo_cruftthemes_loc.no_data);
-        }
-        $('#' + section + '_loading').fadeOut();
-        var data = JSON.parse(rawData);
-        // title, name, parent, active
-        var CTTID = 'cruft-theme-table';
-        if ( data.length > 1 ) {
-          $( '#cruftthemes_status' ).prepend('<p>' + seravo_cruftthemes_loc.cruftthemes + '</p>');
-          $( '#cruftthemes_status' ).append('<div><div id="' + CTTID + '" class="cruft-theme-table"></div></div>');
-          var parent_themes = new Array();
-          var child_themes = new Array();
-          // go through each item and categorize them
-          $.each( data, function( i, theme ){
-            if (theme.name != '' && theme.parent == '' ) {
-              parent_themes.push(new CruftTheme(theme.name, theme.title, theme.active));
-            } else if (theme.name != '' && theme.parent != '' ) {
-              child_themes.push(new CruftChild(theme.name, theme.title, theme.active, theme.parent));
-            }
-          });
-
-          parent_themes.forEach( function(parent, index, this_array){
-            if ( child_themes.filter(theme => theme.parent == parent.name).length != 0) {
-              this_array[index] = new CruftParent( parent.name, parent.title, parent.active, child_themes.filter(theme => theme.parent == parent.name) );
-            }
-          });
-
-          parent_themes.forEach( function(element){
-            element.seravo_print_theme_table( $('#' + CTTID ));
-          });
-
-        } else {
-          $( '#cruftthemes_status' ).prepend('<b>' + seravo_cruftthemes_loc.no_cruftthemes + '</b>');
-        }
-        $( '#cruftthemes_status_loading img' ).fadeOut
-        $('.crufttheme-delete-button').click(function(event) {
-          event.preventDefault();
-          var is_user_sure = confirm(seravo_cruftthemes_loc.confirm);
-          if ( ! is_user_sure ) {
-            return;
-          }
-          var parent_row = $(this).parents(':eq(1)');
-          var theme_name = parent_row.attr('data-theme-name');
-          seravo_ajax_delete_theme(theme_name, parent_row, seravo_delete_theme);
-        });
+  function createOnClick() {
+    // Delete button
+    $('.cruftthemes_status_delete').click(function (event) {
+      event.preventDefault();
+      var is_user_sure = confirm(seravo_cruftthemes_loc.confirm);
+      if ( ! is_user_sure ) {
+        return;
       }
-    ).fail(function() {
+      $('.crufttheme-delete .crufttheme-check:checked').each(function (key, obj) {
+        $.post(seravo_cruftthemes_loc.ajaxurl, {
+          type: 'POST',
+          action: 'seravo_remove_themes',
+          removetheme: obj.dataset.pluginName,
+          nonce: seravo_cruftthemes_loc.ajax_nonce
+        }, function( rawData ) {
+          var data = JSON.parse(rawData);
+          if ( data ) {
+            $('table#' + section).remove();
+            $('.' + section + '_delete').remove();
+            // Clear entries
+            $entries = null;
+            getData();
+          } else {
+            confirm(seravo_cruftthemes_loc.failure);
+          }
+        });
+      })
+      // Create triggers
+      createOnClick();
+    })
+    // Select all checkbox
+    var $selectAll = $('.cruftthemes_status_select-all');
+    $selectAll.click(function () {
+      var $checkboxes = $('.crufttheme[data-active="false"] .crufttheme-check');
+      if ($selectAll.attr('checked')) {
+        $checkboxes.prop( "checked", true );
+      } else {
+        $checkboxes.prop( "checked", false );
+      }
+    })
+  }
+
+  function getData()  {
+    // Create by default
+    $.post(seravo_cruftthemes_loc.ajaxurl, {
+      'action': 'seravo_list_cruft_themes',
+      'section': section,
+      'nonce': seravo_cruftthemes_loc.ajax_nonce
+    }, function(rawData) {
+      var data = JSON.parse(rawData);
+      $('#' + section + '_loading').fadeOut();
+      if (data.length == 1) {
+        $('#' + section).html('<b>' + seravo_cruftthemes_loc.no_cruftthemes + '</b>');
+        return
+      }
+      // Create table
+      appendTable();
+      // Create parsed array where we can create table from
+      var parsedArray = [];
+      data.forEach(function (theme) {
+        if ( ! theme.parent.length) {
+          parsedArray[theme.name] = {}
+          Object.assign(parsedArray[theme.name], theme)
+        } else {
+          // Create array if not yet created'
+          if ( ! parsedArray[theme.parent]) {
+            parsedArray[theme.parent] = {}
+          }
+          if ( ! $.isArray(parsedArray[theme.parent]['childs'])) {
+            parsedArray[theme.parent]['childs'] = [];
+          }
+          parsedArray[theme.parent]['childs'].push(theme)
+        }
+      })
+      // Create lines
+      Object.keys(parsedArray).forEach(function (theme) {
+        appendLine($entries, parsedArray[theme])
+      })
+      // Create delete function
+      createOnClick();
+    }).fail(function() {
       $('#' + section + '_loading').html(seravo_cruftthemes_loc.fail);
     });
   }
-  // titles for the titles that have been printed. theme for the one which is to be printed.
-  // Load on page load
-  seravo_theme_load_report('cruftthemes_status');
+  getData();
 });

--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -102,6 +102,10 @@ if ( ! class_exists('Cruftfiles') ) {
             <?php _e( 'Searching for plugins...', 'seravo' ); ?>
             <img src="/wp-admin/images/spinner.gif">
           </div>
+          <!-- Filled by JS -->
+          <div id="cruftplugins_status_loading" style="display: none;">
+            Searching for files... <img src="/wp-admin/images/spinner.gif">
+          </div>
         </div>
       </p>
       <?php

--- a/style/cruftfiles.css
+++ b/style/cruftfiles.css
@@ -1,13 +1,31 @@
-.cruftfile-delete-button {
-  background: #f7f7f7;
+.cruftfile-delete-button, .cruftplugin-delete-button, .crufttheme-delete-button {
+  background: #DA534F;
   border-radius: 3px;
-  box-shadow: 0 1px 0 #cccccc;
-  color: #555;
+  border-color: #AA5955;
+  box-shadow: 0 1px 0 #AA5955;
+  color: #ffffff;
   cursor: pointer;
   height: 28px;
   line-height: 22px;
   margin-top: 20px;
   padding: 0 10px 1px;
+}
+
+.cruftplugin-delete-button {
+  margin-bottom: 20px;
+}
+
+.plugin-separation-line {
+  margin: 30px 0px;
+  border-top: 2px solid #F9F9F9;
+}
+
+.cruft-plugin-td {
+  width: 100%;
+}
+
+.cruft-themes-td {
+  width: 100%;
 }
 
 .cruftfile-delete-button:hover {
@@ -16,6 +34,9 @@
   outline: none;
 }
 
+.cruftfile-delete-button:active,
+.cruftfile-delete-button:focus,
+.cruftfile-delete-button:visited,
 .cruftfile-delete-button:active,
 .cruftfile-delete-button:focus,
 .cruftfile-delete-button:visited {
@@ -33,7 +54,10 @@
 }
 
 .cruft-tool-selector {
-  background-color: antiquewhite;
+  background-color: #F9F9F9;
+  padding-left: 7px;
+  font-weight: 600;
+  height: 45px;
 }
 
 table {
@@ -45,8 +69,7 @@ table {
 }
 
 .crufttheme {
-  border-top: 2px solid black;
-  display: flex;
+  flex-direction: row;
   padding: 1px 1px 1px 1px;
 }
 
@@ -59,18 +82,11 @@ table {
 }
 
 table {
-border: collapse;
+  border: collapse;
 }
 
 .cruft-theme-table {
   border-bottom: 2px solid black;
-}
-
-.crufttheme {
-  border-top: 2px solid black;
-  display: flex;
-  flex-direction: row;
-  padding: 1px 1px 1px 1px;
 }
 
 .crufttheme-child {
@@ -93,6 +109,19 @@ border: collapse;
 
 .crufttheme-delete {
   padding-right: 10px;
+}
+
+.crufttheme[data-active="true"] {
+  display: none;
+}
+
+[data-childs="true"] .crufttheme-path {
+  padding-top: 1em;
+  font-weight: bold;
+}
+
+[data-childs="true"] .crufttheme-delete {
+  display: none;
 }
 
 @media only screen and (max-width: 1025px) {


### PR DESCRIPTION
This pr closes #215.

I think that after this pr cruft plugin is more pleasant to use. Plugin has consistent layout, and you can select all cruft files, plugins and themes; and delete them.

_In cruft themes, if theme has a child theme it will be bolded and can't be deleted before child theme._ 

![image](https://user-images.githubusercontent.com/15683849/57912944-328b6580-7894-11e9-9f2a-d51786dd40e7.png)
