### PR TITLE
Add ellipsis also for IP address

### DIFF
--- a/lib/security-ajax.php
+++ b/lib/security-ajax.php
@@ -46,6 +46,9 @@ function seravo_logins_info( $max = 10 ) {
       unset($login_data[ $i ]);
     } else if ( strpos($login_data[ $i ], 'SUCCESS' ) ) {
 
+      // Get IP. IP address is in the beginning of log line and ends to " -"
+      $ip = substr($login_data[ $i ], 0, strpos($login_data[ $i ], ' -'));
+
       // Get the username. Username in log files between first "-" and "["
       $username_start = strpos($login_data[ $i ], '-') + 1;
       $username = substr($login_data[ $i ], $username_start, strpos($login_data[ $i ], '[') - $username_start );
@@ -54,7 +57,8 @@ function seravo_logins_info( $max = 10 ) {
       $login_data[ $i ] = substr($login_data[ $i ], 0, strpos($login_data[ $i ], ' +0000]'));
 
       // Insert table elements to every row
-      $login_data[ $i ] = '<tr><td>' . $login_data[ $i ] . '</td></tr>';
+      // Add tooltip for IP. CSS ellipsis will shorten IP if it doesn't fit the postbox otherwise
+      $login_data[ $i ] = '<tr><td class="ip_tooltip" title="' . $ip . '">' . $login_data[ $i ] . '</td></tr>';
 
       // Log file data is in the format: IP - username [ date : time
       // Insert table elements in place of characters - [ :

--- a/style/security.css
+++ b/style/security.css
@@ -6,9 +6,12 @@
 .login_info_th {
   text-align: left;
 }
-
+.ip_tooltip {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
 .username_tooltip {
-  width: 90px;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
This will add CSS ellipsis also for IP address. Currently if postbox happens to be really narrow and the IP is near the maximum length of 15 characters the last digits of the IP are written over the username. This bugfix will shorten the IP and add it in a tooltip if the IP doesn't fit otherwise.

#### Screenshots

Currently:
![Screenshot at 2019-07-04 16-33-46](https://user-images.githubusercontent.com/51294504/60720323-179fae00-9f33-11e9-8918-2d2c7631b6a5.png)

With IP ellipsis:
Narrow:
![Screenshot at 2019-07-05 11-03-03](https://user-images.githubusercontent.com/51294504/60720331-1d958f00-9f33-11e9-913e-818687995fc4.png)

Wide:
![Screenshot at 2019-07-05 11-06-11](https://user-images.githubusercontent.com/51294504/60720333-1f5f5280-9f33-11e9-8c94-bef1a12cd39c.png)
