### PR TITLE
Fix #262 (Update summary blank on some sites, should never be)

### DIFF
--- a/modules/updates.php
+++ b/modules/updates.php
@@ -223,15 +223,16 @@ if ( ! class_exists('Updates') ) {
               $update_log_output = implode('<br>', $update_log_contents);
             }
 
-            echo '<p>' .
-                __(
-                  'Last succesful full site update was over a month ago. A developer should take
-                a look at the update log and fix the issue preventing the site from updating.',
-                  'seravo'
-                ) .
-                '</p><p><h3>' . __('Latest update.log:', 'seravo') . '</h3></p><p>' .
-                $update_log_output . '</p>' .
-                '<p><a href="tools.php?page=logs_page&logfile=update.log&max_num_of_rows=50">See the logs page for more info.</a></p>';
+            echo '<p>' . __(
+              'Last succesful full site update was over a month ago. A developer should take
+              a look at the update log and fix the issue preventing the site from updating.',
+              'seravo'
+            ) . '</p>';
+            if ( ! empty($update_log_contents) ) {
+              echo '<p><b>' . __('Latest update.log:', 'seravo') . '</b></p><p>' .
+              $update_log_output . '</p>';
+            }
+            echo '<p><a href="tools.php?page=logs_page&logfile=update.log&max_num_of_rows=50">' . __('See the logs page for more info.', 'seravo') . '</a></p>';
           }
         }
 


### PR DESCRIPTION
#### What are the main changes in this PR?
Fixes the incorrectly displayed empty update.log contents by checking that there is content to display. Also adds missing translations to Updates page update notification and links.
##### Why are we doing this? Any context or related work?
If there is an issue related to this PR, please link it here for context.
Issue: #262 
#### Where should a reviewer start?
2b87e5d fixes the empty display and should be checked that it now functions correctly. If update.log has no content to show but the full update has not been succesful, only the notification should now display. If the update.log has lines starting with "Updates failed!" those lines are shown.
1b761ef adds translations

