### PR TITLE
Fix display of wp-test results on Tests page

### DIFF
--- a/js/tests.js
+++ b/js/tests.js
@@ -12,14 +12,14 @@ jQuery(window).on('load', function() {
         }
         jQuery('#seravo_tests_status').fadeOut('slow', function() {
           var data = JSON.parse(rawData);
-          var data_joined = data.join("\n");
+          var data_joined = data['test_result'].join("\n");
 
-          if ( ! (/Failed examples.*/g).test(data_joined) ) {
-            // No failures, if the string "Failed examples" was not found in data
+          if ( data['exit_code'] === 0 ) {
+            // No failures, if the return value from wp-test was 0
             jQuery(this).html(seravo_tests_loc.test_success).fadeIn('slow');
             jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
           } else {
-            // At least 1 failure, if the string "Failed examples" was found
+            // At least 1 failure, if the return value was non-zero
             jQuery(this).html(seravo_tests_loc.test_fail).fadeIn('slow');
             jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
           }

--- a/lib/tests-ajax.php
+++ b/lib/tests-ajax.php
@@ -7,8 +7,12 @@ if ( ! defined('ABSPATH') ) {
 }
 
 function seravo_tests() {
-  exec('wp-test', $output);
-  return $output;
+  exec('wp-test', $output, $return_variable);
+  $return_arr = array(
+    'test_result' => $output,
+    'exit_code' => $return_variable,
+  );
+  return $return_arr;
 }
 
 function seravo_ajax_tests() {


### PR DESCRIPTION
#### What are the main changes in this PR?
Fixes the checking of failed tests by changing the checking of "Failed examples" string to check the return value of wp-test instead. Update Tests postbox now displays failed tests correctly if the return value of wp-test is non-zero.
##### Why are we doing this? Any context or related work?
Issue #243 

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
![image](https://user-images.githubusercontent.com/26429376/61042472-efa1c600-a3dc-11e9-8e98-8a9d4aa0d4a0.png)
