### PR TITLE
Fix cruft themes remover bugs

### DIFF
--- a/modules/cruftfiles.php
+++ b/modules/cruftfiles.php
@@ -235,7 +235,7 @@ if ( ! class_exists('Cruftfiles') ) {
         $loc_translation_themes = array(
           'isparentto'     => __('is parent to: ', 'seravo'),
           'confirm'        => __('Are you sure you want to remove this theme?', 'seravo'),
-          'failure'        => __('Failed to remove theme', 'seravo'),
+          'failure'        => __('Failed to remove some themes!', 'seravo'),
           'no_cruftthemes' => __('There are currently no unused themes on the website.', 'seravo'),
           'cruftthemes'    => __('The following themes are inactive and can be removed.', 'seravo'),
           'ajaxurl'        => admin_url('admin-ajax.php'),


### PR DESCRIPTION
#### What are the main changes in this PR?

This fixes multiple bugs related to cruft themes remover:
- Possible to remove active themes on multisites
- Possible to remove parent themes with 'select all' checkbox
- Removing themes duplicates the table
- Confirmation is asked multiple times

Also adds small UI changes left out at some point. 

##### Why are we doing this? Any context or related work?

First bug reported in #254 

#### Manual testing steps?

Testing if the cruft themes remover works as expected should be enough. It
should be done on multisite (joosuatesti @ ams-test1 can be used, it's already using these commits).