### PR TITLE
Fix alloptions not updating in cache

### DIFF
--- a/modules/fixes.php
+++ b/modules/fixes.php
@@ -69,15 +69,13 @@ if ( ! class_exists('Fixes') ) {
      */
     public static function maybe_clear_alloptions_cache( $option ) {
 
-      // error_log("added/updated/deleted option: $option");
-
       if ( wp_installing() === false ) {
         $alloptions = wp_load_alloptions(); // alloptions should be cached at this point
 
-        // If option is part of the alloptions collection then clear it.
+        // If alloptions collection has $option key, clear the collection from cache
+        // because it can't be trusted to be correct after modifications in options.
         if ( array_key_exists($option, $alloptions) ) {
-          wp_cache_delete($option, 'options');
-          // error_log("deleted from cache group 'options': $option");
+          wp_cache_delete('alloptions', 'options');
         }
       }
     }


### PR DESCRIPTION
#### What are the main changes in this PR?

Forces updating of 'alloptions' in cache. Some WordPress-hosts 
are running similar fixes. Issue explained in the [commit message](https://github.com/Seravo/seravo-plugin/commit/95f03d047917cb7e88e51140182a6c7752b0ef48). 

##### Why are we doing this? Any context or related work?

The issue has caused problems on some customers but
affects everyone.

#### Manual testing steps?

This has already been tested on some sites and probably 
doesn't need more testing. The performance impact has also been
tested with `wp-speed-test` and no clear difference was noticed.

If the issue needs to be reproduced, it should be possible like this:
1. Run `while sleep 0.1; do wp option set debug-option $(openssl rand -hex 1); done`
2. In other shell instance, update some option key a until it stops working (refuses to change):

![image](https://user-images.githubusercontent.com/42264063/61278222-729b9580-a7bc-11e9-8798-bc6d4aadc626.png)

Previous shouldn't be possible with the fix applied.