### PR TITLE
Add Seravo plugin updater to the Updates subpage

### DIFF
--- a/js/updates.js
+++ b/js/updates.js
@@ -182,6 +182,44 @@ jQuery(document).ready(function($) {
       });
     }, 5000);
   }
+
+  jQuery.post(
+    seravo_updates_loc.ajaxurl, {
+      'action': 'seravo_ajax_updates',
+      'section': 'seravo_plugin_version_check',
+      'nonce': seravo_updates_loc.ajax_nonce
+    }, function(is_uptodate_version) {
+      if (is_uptodate_version) {
+        $('#uptodate_seravo_plugin_version').show();
+      } else {
+        $('#old_seravo_plugin_version').show();
+        $("#seravo_plugin_update_button").show();
+      }
+    });
+
+  jQuery('#seravo_plugin_update_button').click(function() {
+    jQuery("#old_seravo_plugin_version").hide();
+    jQuery("#seravo_plugin_update_button").hide();
+    jQuery("#update_seravo_plugin_status").fadeIn(400, function() {
+      jQuery(this).show();
+    });
+    update_seravo_plugin();
+  });
+
+  function update_seravo_plugin() {
+    jQuery.post(
+      seravo_updates_loc.ajaxurl, {
+        'action': 'seravo_ajax_updates',
+        'section': 'seravo_plugin_version_update',
+        'nonce': seravo_updates_loc.ajax_nonce
+      });
+      setTimeout(function() {
+        jQuery("#update_seravo_plugin_status").fadeOut(400, function() {
+          jQuery(this).hide();
+        });
+        jQuery("#seravo_plugin_updated").show();
+      }, 5000);
+  }
 });
 
 jQuery(window).load(function(){

--- a/lib/updates-ajax.php
+++ b/lib/updates-ajax.php
@@ -38,6 +38,30 @@ function seravo_php_check_version() {
   }
 }
 
+function seravo_plugin_version_check() {
+  $current_version = Seravo\Helpers::seravo_plugin_version();
+
+  if ( $current_version == seravo_plugin_upstream_version() ) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function seravo_plugin_upstream_version() {
+  $upstream_version = get_transient('seravo_plugin_upstream_version');
+  if ( $upstream_version === false ) {
+    $upstream_version = exec('curl -s https://api.github.com/repos/seravo/seravo-plugin/tags | grep "name" -m 1 | awk \'{gsub("\"","")}; {gsub(",","")}; {print $2}\'');
+    set_transient('seravo_plugin_upstream_version', $upstream_version, 10800);
+  }
+
+  return $upstream_version;
+}
+
+function seravo_plugin_version_update() {
+  exec('wp-seravo-plugin-update &');
+}
+
 function seravo_ajax_updates() {
   check_ajax_referer('seravo_updates', 'nonce');
   switch ( sanitize_text_field($_REQUEST['section']) ) {
@@ -47,6 +71,14 @@ function seravo_ajax_updates() {
 
     case 'seravo_php_check_version':
       echo seravo_php_check_version();
+      break;
+
+    case 'seravo_plugin_version_check':
+      echo seravo_plugin_version_check();
+      break;
+
+    case 'seravo_plugin_version_update':
+      echo seravo_plugin_version_update();
       break;
 
     default:

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -71,6 +71,13 @@ if ( ! class_exists('Updates') ) {
         'side'
       );
 
+      seravo_add_postbox(
+        'seravo-plugin-updater',
+        __('Seravo Plugin Updater', 'seravo'),
+        array( __CLASS__, 'seravo_plugin_updater_postbox' ),
+        'tools_page_updates_page',
+        'normal'
+      );
     }
 
     /**
@@ -366,6 +373,38 @@ if ( ! class_exists('Updates') ) {
         </p>
         <p id="activation-failed-line" class="hidden"><?php _e('PHP version change failed. Using fallback PHP 5.6.', 'seravo'); ?></p>
       </div>
+      <?php
+    }
+
+    public static function seravo_plugin_updater_postbox() {
+      ?>
+      <p><?php _e('Seravo automatically updates your site and the Seravo Plugin as well. If you want to immediately update to the latest Seravo Plugin version, you can do it here.', 'seravo'); ?></p>
+      <p>
+      <?php
+      printf(
+        // translators: current Seravo plugin version
+        __('Current version: %s', 'seravo'),
+        Helpers::seravo_plugin_version()
+      );
+      ?>
+      </p>
+      <p>
+      <?php
+      printf(
+        // translators: upstream Seravo plugin version
+        __('Upstream version: %s', 'seravo'),
+        seravo_plugin_upstream_version()
+      );
+      ?>
+      </p>
+      <p id='uptodate_seravo_plugin_version' class='hidden' style='color: green'><?php _e('The currently installed version is the same as the latest available version.', 'seravo'); ?></p>
+      <p id='old_seravo_plugin_version' class='hidden' style='color: orange'><?php _e('There is a new version available', 'seravo'); ?></p>
+      <p id='seravo_plugin_updated' class='hidden' style='color: green'><?php _e('Seravo Plugin updated', 'seravo'); ?></p>
+      <div id="update_seravo_plugin_status" class="hidden">
+        <img src="/wp-admin/images/spinner.gif" style="display:inline-block">
+        <?php _e('Updating... Please wait up to 5 seconds', 'seravo'); ?>
+      </div>
+      <button id='seravo_plugin_update_button' class='hidden'><?php _e('Update plugin now', 'seravo'); ?></button>
       <?php
     }
 


### PR DESCRIPTION
This change will add Seravo Plugin Updater.

A pictures of the change
New update available:
![seravo-updater-new-version-available](https://user-images.githubusercontent.com/43742796/61442749-df479900-a950-11e9-9898-716087c94dfb.png)

Latest version:
![plugin-updater-latest-version](https://user-images.githubusercontent.com/43742796/61443055-6eed4780-a951-11e9-9188-e72d8e60970e.png)
