### PR TITLE
Redesign shadows postbox

### DIFF
--- a/js/shadows.js
+++ b/js/shadows.js
@@ -2,21 +2,64 @@
 'use strict';
 
 jQuery(document).ready(function($) {
-  $('.shadow-reset').click(function(event) {
+  $('#shadow-selector').change(function() {
+    var $shadow = $("[data-shadow=" + $(this).val() + "]");
+    if ($shadow) {
+      $('.shadow-row').addClass('shadow-hidden');
+      $shadow.removeClass('shadow-hidden');
+      $('#shadow-reset').prop('disabled', false);
+      $('#shadow-reset-status').html('');
+      update_data_gui();
+    }
+  });
+  $('.action-link').click(function(event) {
+    event.preventDefault();
+    if (! $(this).hasClass('closed')) {
+      $(this).addClass('closed');
+      $('#shadow-data-actions').addClass('shadow-hidden');
+    } else {
+      $(this).removeClass('closed');
+      $('#shadow-data-actions').removeClass('shadow-hidden');
+      update_data_gui();
+    }
+  });
+
+  function update_data_gui() {
+    var instance = $('#shadow-selector').val();
+    $('#shadow-reset-instance').html(instance);
+    var production_domain = $('input[name=shadow-reset-production]').val();
+    var shadow_domain = $('[data-shadow=' + instance + ']').attr('data-domain');
+    if (shadow_domain) {
+      $('input[name=shadow-reset-sr-from]').val(production_domain);
+      $('input[name=shadow-reset-sr-to]').val('://' + shadow_domain);
+      $('#shadow-reset-sr-alert').removeClass('shadow-hidden');
+      $('#shadow-reset-nosr-alert').addClass('shadow-hidden');
+    } else {
+      $('input[name=shadow-reset-sr-from]').val('');
+      $('input[name=shadow-reset-sr-to]').val('');
+      $('#shadow-reset-sr-alert').addClass('shadow-hidden');
+      $('#shadow-reset-nosr-alert').removeClass('shadow-hidden');
+    }
+    $('#shadow-reset').prop('disabled', false);
+    $('#shadow-reset-status').html('');
+  }
+
+  $('#shadow-reset').click(function(event) {
     var is_user_sure = confirm(seravo_shadows_loc.confirm);
     if ( ! is_user_sure) {
       return;
     }
-    seravo_ajax_reset_shadow($(this).attr("data-shadow-name"),
+    seravo_ajax_reset_shadow($('#shadow-selector').val(),
       function( status ){
         if ( status == 'progress' ) {
           event.target.disabled = true;
+          $('#shadow-reset-status').html("<img src=\"/wp-admin/images/spinner.gif\">");
         } else if ( status == 'success' ) {
-          event.target.innerHTML = seravo_shadows_loc.success;
+          $('#shadow-reset-status').html(seravo_shadows_loc.success);
         } else if ( status == 'failure' ) {
-          event.target.innerHTML = seravo_shadows_loc.failure;
+          $('#shadow-reset-status').html(seravo_shadows_loc.failure);
         } else {
-          event.target.innerHTML = seravo_shadows_loc.error;
+          $('#shadow-reset-status').html(seravo_shadows_loc.error);
         }
       });
   });
@@ -26,8 +69,9 @@ jQuery(document).ready(function($) {
     $.post(
       seravo_shadows_loc.ajaxurl,
       { type: 'POST',
-        'action': 'seravo_reset_shadow',
-        'resetshadow': shadow,
+        'action': 'seravo_ajax_shadows',
+        'section': 'seravo_reset_shadow',
+        'shadow': shadow,
         'nonce': seravo_shadows_loc.ajax_nonce, },
         function( rawData ) {
           var data = JSON.parse(rawData);

--- a/lib/shadows-ajax.php
+++ b/lib/shadows-ajax.php
@@ -6,11 +6,10 @@ if ( ! defined('ABSPATH') ) {
 }
 
 function seravo_reset_shadow() {
-  check_ajax_referer('seravo_shadows', 'nonce');
-  if ( isset($_POST['resetshadow']) && ! empty($_POST['resetshadow']) ) {
-    $shadow = $_POST['resetshadow'];
+  if ( isset($_POST['shadow']) && ! empty($_POST['shadow']) ) {
+    $shadow = $_POST['shadow'];
     $output = array();
-    // check if the shadow is known
+    // Check if the shadow is known
     foreach ( Seravo\API::get_site_data('/shadows') as $data ) {
       if ( $data['name'] == $shadow ) {
         exec('wp-shadow-reset ' . $shadow . ' --force 2>&1', $output);
@@ -20,4 +19,21 @@ function seravo_reset_shadow() {
     }
   }
   wp_die();
+}
+
+function seravo_ajax_shadows() {
+  check_ajax_referer('seravo_shadows', 'nonce');
+
+  switch ( $_REQUEST['section'] ) {
+    case 'seravo_reset_shadow':
+      seravo_reset_shadow();
+      break;
+
+    default:
+      error_log('ERROR: Section ' . $_REQUEST['section'] . ' not defined');
+      break;
+  }
+
+  wp_die();
+
 }

--- a/modules/shadows.php
+++ b/modules/shadows.php
@@ -16,6 +16,7 @@ if ( ! defined('ABSPATH') ) {
 
 require_once dirname(__FILE__) . '/../lib/helpers.php';
 require_once dirname(__FILE__) . '/../lib/shadows-ajax.php';
+require_once dirname(__FILE__) . '/../modules/instance-switcher.php';
 
 if ( ! class_exists('Shadows') ) {
   class Shadows {
@@ -23,7 +24,7 @@ if ( ! class_exists('Shadows') ) {
     public static function load() {
       add_action('admin_menu', array( __CLASS__, 'register_shadows_page' ));
       add_action('admin_enqueue_scripts', array( __CLASS__, 'register_shadows_scripts' ));
-      add_action('wp_ajax_seravo_reset_shadow', 'seravo_reset_shadow');
+      add_action('wp_ajax_seravo_ajax_shadows', 'seravo_ajax_shadows');
 
       seravo_add_postbox(
         'shadows',
@@ -55,9 +56,9 @@ if ( ! class_exists('Shadows') ) {
         wp_enqueue_script('seravo_shadows');
 
         $loc_translation = array(
-          'success'    => __('Success', 'seravo'),
-          'failure'    => __('Failure', 'seravo'),
-          'error'      => __('Error', 'seravo'),
+          'success'    => __('Success!', 'seravo'),
+          'failure'    => __('Failure!', 'seravo'),
+          'error'      => __('Error!', 'seravo'),
           'confirm'    => __('Are you sure? This replaces all information in the selected environment.', 'seravo'),
           'ajaxurl'    => admin_url('admin-ajax.php'),
           'ajax_nonce' => wp_create_nonce('seravo_shadows'),
@@ -72,8 +73,9 @@ if ( ! class_exists('Shadows') ) {
       <div class="seravo-section">
         <div style="padding: 0px 15px">
           <p><?php _e('Allow easy access to site shadows. Resetting a shadow copies the state of the production site to the shadow. All files under /data/wordpress/ will be replaced and the production database imported. For more information, visit our  <a href="https://seravo.com/docs/deployment/shadows/">Developer documentation</a>.', 'seravo'); ?></p>
+          <hr>
         </div>
-        <div style="padding: 0px">
+        <div style="padding: 5px 15px 0 15px">
           <?php
           // Get a list of site shadows
           $api_query = '/shadows';
@@ -82,40 +84,83 @@ if ( ! class_exists('Shadows') ) {
             die($shadow_list->get_error_message());
           }
 
-          // Order the shadow data so they correspond to the table labels.
-          $shadow_data_ordered = array( 'info', 'name', 'ssh', 'created' );
-          if ( ! empty($shadow_list) ) :
+          if ( ! empty($shadow_list) ) {
+          ?>
+            <table id="shadow-table">
+              <tr>
+                <th><?php _e('Name', 'seravo'); ?></th>
+                <td id="shadow-name">
+                  <select id="shadow-selector">
+                    <option value="" disabled selected hidden><?php _e('Select shadow', 'seravo'); ?></option>
+                    <?php
+                    foreach ( $shadow_list as $shadow => $shadow_data ) {
+                      $shadow_list[$shadow]['domain'] = InstanceSwitcher::get_shadow_domain($shadow_data['name']);
+                      printf('<option value="%s">%s</option>', $shadow_data['name'], $shadow_data['info']);
+                    }
+                    ?>
+                  </select>
+                </td>
+              </tr>
+              <?php
+              function add_shadow( $identifier, $ssh, $created, $domain, $hidden = true ) {
+              ?>
+                <tbody data-shadow="<?php echo $identifier; ?>" data-domain="<?php echo $domain; ?>" class="<?php echo ($hidden ? 'shadow-hidden ' : ''); ?>shadow-row">
+                  <tr><th><?php _e('Identifier', 'seravo'); ?></th><td><?php echo $identifier; ?></td></tr>
+                  <tr><th><?php _e('SSH Port', 'seravo'); ?></th><td><?php echo $ssh; ?></td></tr>
+                  <tr><th><?php _e('Domain', 'seravo'); ?></th><td><?php echo (empty($domain) ? '-' : $domain); ?></td></tr>
+                  <tr><th><?php _e('Creation Date', 'seravo'); ?></th><td><?php echo $created; ?></td></tr>
+                  <?php
+                  if ( ! empty($identifier) ) {
+                  ?>
+                    <tr class="data-actions"><th><?php _e('Actions', 'seravo'); ?></th><td><a class="action-link closed" href=""><?php _e('Move Data', 'seravo'); ?><span></span></a></td></tr>
+                    <?php
+                  }
+                    ?>
+                </tbody>
+                <?php
+              }
+              // One empty entry for 'select shadow' in dropdown
+              add_shadow('', '', '', ' ', false);
+              foreach ( $shadow_list as $shadow_data ) {
+                add_shadow($shadow_data['name'], $shadow_data['ssh'], $shadow_data['created'], $shadow_data['domain']);
+              }
+              ?>
+            </table>
+            <?php
+          } else {
             ?>
-          <table class="widefat striped fixed"
-            style="width=100%; border:none" cellspacing="0">
-            <thead>
-              <th><?php _e('Name', 'seravo'); ?></th>
-              <th><?php _e('Identifier', 'seravo'); ?></th>
-              <th><?php _e('SSH Port', 'seravo'); ?></th>
-              <th><?php _e('Creation Date', 'seravo'); ?></th>
-              <th><?php _e('Reset Shadow', 'seravo'); ?></th>
-            </thead>
-            <tbody>
-                <?php foreach ( $shadow_list as $shadow_data ) : ?>
-                  <tr>
-                    <?php foreach ( $shadow_data_ordered as $data_key ) : ?>
-                    <td>
-                      <?php if ( isset($shadow_data[ $data_key ]) ) : ?>
-                        <?php echo $shadow_data[ $data_key ]; ?>
-                      <?php endif; ?>
-                    </td>
-                    <?php endforeach; ?>
-                    <td><button data-shadow-name="<?php echo $shadow_data['name']; ?>" class="shadow-reset button" type="button"><?php _e('Reset Shadow', 'seravo'); ?></button></td>
-                  </tr>
-                <?php endforeach; ?>
-
-            </tbody>
+          <p style="padding: 15px 15px 0 15px;">
+            <?php _e('No shadows found. If your plan is WP Pro or higher, you can request a shadow instance from Seravo admins at <a href="mailto:wordpress@seravo.com"    >wordpress@seravo.com</a>.', 'seravo'); ?>
+          </p>
+            <?php
+          }
+            ?>
+        </div>
+        <div id="shadow-data-actions" class="shadow-hidden">
+          <hr>
+          <h3 style="margin-top:20px;"><?php _e('Reset shadow from production', 'seravo'); ?></h3>
+          <i>production > <span id="shadow-reset-instance">shadow</span></i>
+          <p><?php _e('<b>Warning:</b> This will replace everything currently in the <i>/data/wordpress/</i> directory and the database of the shadow with a copy of production site. Be sure to know what you are doing.', 'seravo'); ?></p>
+          <form>
+            <input type="hidden" name="shadow-reset-production" value="<?php echo str_replace([ 'https://', 'http://' ], '://', get_home_url()); ?>">
+            <table id="shadow-rs-table">
+              <tr><th colspan="2"><input type="checkbox" name="shadow-reset-sr" disabled><?php _e('Execute search-replace', 'seravo'); ?></th></tr>
+              <tr><td>From: </td><td><input type="text" name="shadow-reset-sr-from" disabled></td></tr>
+              <tr><td>To: </td><td><input type="text" name="shadow-reset-sr-to" disabled></td></tr>
+            </table>
+          </form>
+          <div id="shadow-reset-sr-alert" class="shadow-hidden">
+            <?php _e("This shadow uses a custom domain. Search-replace can't currently be ran automatically with shadow reset. Please run it manually afterwards with the values above or the shadow can't be accessed. Instructions can be found in <a href='https://help.seravo.com/en/docs/151'>here</a>.", 'seravo'); ?> 
+          </div>
+          <div id="shadow-reset-nosr-alert">
+            <?php _e("This shadow doesn't need search-replace to be ran afterwards for it to work.", 'seravo'); ?> 
+          </div>
+          <table class="shadow-reset-row">
+            <tr>
+              <td><button class="button" id="shadow-reset"><?php _e('Reset from production', 'seravo'); ?></button></td>
+              <td id="shadow-reset-status"></td>
+            </tr>
           </table>
-          <?php else : ?>
-            <p style="padding: 15px">
-              <?php _e('No shadows found. If your plan is WP Pro or higher, you can request a shadow instance from Seravo admins at <a href="mailto:wordpress@seravo.com">wordpress@seravo.com</a>.', 'seravo'); ?>
-            </p>
-          <?php endif; ?>
         </div>
       </div>
       <?php

--- a/style/shadows.css
+++ b/style/shadows.css
@@ -1,3 +1,53 @@
-#wpbody-content #dashboard-widgets .postbox-container {
+#shadow-table th, #shadow-rs-table th {
+  text-align: left;
+  padding-right: 20px;
+}
+
+.shadow-row table th {
+  text-align: left;
+  padding-right: 20px;
+}
+
+.shadow-hidden {
+  display: none;
+}
+
+#shadow-selector {
   width: 100%;
+  margin-bottom: 10px;
+}
+
+#shadow-reset {
+  margin-top: 10px;
+}
+
+.data-actions th, .data-actions td {
+  padding-top: 10px;
+}
+
+.action-link span:before {
+  position: relative;
+  top: 1px;
+  font: normal 13px/1 dashicons;
+  content: " \f142";
+}
+
+.action-link.closed span:before {
+  content: " \f140";
+}
+
+#shadow-data-actions {
+  padding: 15px;
+}
+
+#shadow-rs-table {
+  margin: 20px 0 5px 0;
+}
+
+.shadow-reset-row {
+  margin-top: 20px;
+}
+
+#shadow-reset {
+  margin: 0;
 }


### PR DESCRIPTION
#### What are the main changes in this PR?

This redesigns shadows page to be more like mails-page. The postbox width is no longer
forced to 100% to support multiple postboxes on the same page. Now that shadows work
better with custom domains, I also added 'domain' field and search-replace instructions.

These changes were supposed to come with wp-shadow-pull feature but I made this now
separately as there's some problems with it and I don't want to slow down toolbox update development. 

##### Why are we doing this? Any context or related work?

This was planned in wp-shadow-pull issue comments.

#### Screenshots

![image](https://user-images.githubusercontent.com/42264063/61516801-69a20280-aa0e-11e9-994e-60a66f7a94ea.png)

![image](https://user-images.githubusercontent.com/42264063/61516846-7e7e9600-aa0e-11e9-9736-e2271f5ba77f.png)

