### PR TITLE
Load assets only if user is logged in or in staging.

### DIFF
--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -64,8 +64,10 @@ if ( ! class_exists('InstanceSwitcher') ) {
     * Load JavaScript and stylesheets for the switcher and the banner
     */
     public static function assets() {
-      wp_enqueue_script('seravo', plugins_url('../js/instance-switcher.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
-      wp_enqueue_style('seravo', plugins_url('../style/instance-switcher.css', __FILE__), null, Helpers::seravo_plugin_version(), 'all');
+      if ( is_user_logged_in() || Helpers::is_staging() ) {
+        wp_enqueue_script('seravo', plugins_url('../js/instance-switcher.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
+        wp_enqueue_style('seravo', plugins_url('../style/instance-switcher.css', __FILE__), null, Helpers::seravo_plugin_version(), 'all');
+      }
     }
 
     /**


### PR DESCRIPTION
Fixes #274.

## What are the main changes in this PR?

Load switcher assets only if user is logged in or in staging.

## Why are we doing this? Any context or related work?
`instance-switcher.js ` is loaded in front-end even when user is logged out. And it even has dependency of jQuery. This should not happen when user is logged out (regular site user).


