### PR TITLE
Add GUI for PHP compatibility check

### DIFF
--- a/js/updates.js
+++ b/js/updates.js
@@ -133,6 +133,53 @@ jQuery(document).ready(function($) {
     $buttonsDiv.html(generateButtons(emails));
   });
 
+  jQuery('#check-php-compatibility-button').click(function() {
+    jQuery(this).fadeOut(400, function(){
+      jQuery(this).hide();
+    });
+    jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+      jQuery(this).html('<img src="/wp-admin/images/spinner.gif" style="display:inline-block"> ' + seravo_updates_loc.compatibility_check_running).fadeIn(400);
+    });
+    checkPHPCompatibility();
+  });
+
+  function checkPHPCompatibility() {
+    jQuery.post(
+      seravo_updates_loc.ajaxurl, {
+        'action': 'seravo_ajax_updates',
+        'section': 'seravo_check_php_compatibility',
+        'nonce': seravo_updates_loc.ajax_nonce,
+      },
+      function(rawData) {
+        if ( rawData.length == 0 ) {
+          jQuery('#check-php-compatibility-status').html(seravo_updates_loc.compatiblity_no_data);
+        }
+        var data = JSON.parse(rawData);
+
+        /* Display error if wp-php-compatibility-check returns non-zero exit code
+        * Else display the number of errors found.
+        * If output string is empty, show green light for PHP version change
+        */
+        if ( data['exit_code'] != 0 ) {
+          jQuery("#check-php-compatibility-button").fadeOut(400, function() {
+            jQuery(this).show();
+          });
+          jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+            jQuery(this).html('<div>' + seravo_updates_loc.compatibility_run_fail + '</div>').fadeIn(400);
+          });
+        } else if ( data['output'].length ) {
+          jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+            jQuery(this).html('<div style="color:red;font-weight:bold">' + data['output'] + seravo_updates_loc.compatibility_check_error + '</div>').fadeIn(400);
+          });
+        } else {
+          jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+            jQuery(this).html('<div style="color:green;font-weight:bold">' + seravo_updates_loc.compatibility_check_clear + '</div>').fadeIn(400);
+          });
+        }
+      }
+    );
+  }
+
   jQuery('#change-php-version-button').click(function() {
     jQuery("#change-php-version-status").fadeOut(400, function() {
       jQuery(this).show();

--- a/lib/updates-ajax.php
+++ b/lib/updates-ajax.php
@@ -62,6 +62,15 @@ function seravo_plugin_version_update() {
   exec('wp-seravo-plugin-update &');
 }
 
+function seravo_check_php_compatibility() {
+  exec('wp-php-compatibility-check | grep "FOUND.*ERRORS AFFECTING.*" | awk \'{ print $2 }\'', $output, $return_value);
+  $return_arr = array(
+    'output' => $output,
+    'exit_code' => $return_value,
+  );
+  return $return_arr;
+}
+
 function seravo_ajax_updates() {
   check_ajax_referer('seravo_updates', 'nonce');
   switch ( sanitize_text_field($_REQUEST['section']) ) {
@@ -79,6 +88,10 @@ function seravo_ajax_updates() {
 
     case 'seravo_plugin_version_update':
       echo seravo_plugin_version_update();
+      break;
+
+    case 'seravo_check_php_compatibility':
+      echo wp_json_encode(seravo_check_php_compatibility());
       break;
 
     default:

--- a/modules/updates.php
+++ b/modules/updates.php
@@ -94,6 +94,11 @@ if ( ! class_exists('Updates') ) {
         wp_enqueue_script('seravo_updates', plugins_url('../js/updates.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
 
         $loc_translation_updates = array(
+          'compatibility_check_running' => __('Running PHP compatibility check, this can take a while depending on the number of plugins and themes installed.', 'seravo'),
+          'compatibility_check_error' => __(' errors found. See logs for more information.', 'seravo'),
+          'compatibility_check_clear' => __('&#x2705; No errors found! See logs for more information.', 'seravo'),
+          'compatibility_run_fail' => __('There was an error starting the compatibility check.', 'seravo'),
+          'compatibility_no_data' => __('No data returned for the section.', 'seravo'),
           'ajaxurl'    => admin_url('admin-ajax.php'),
           'ajax_nonce' => wp_create_nonce('seravo_updates'),
         );
@@ -304,6 +309,13 @@ if ( ! class_exists('Updates') ) {
         );
         ?>
       </p>
+        
+      <button id='check-php-compatibility-button'><?php _e('Check PHP compatibility', 'seravo'); ?></button>
+      
+      <div id="check-php-compatibility-status" class="hidden">
+        <img src="/wp-admin/images/spinner.gif" style="display:inline-block">
+      </div>
+      
       <p>
         <?php
         _e('See also <a target="_blank" href="https://help.seravo.com/en/knowledgebase/13/docs/107-set-your-site-to-use-newest-php-version">more information on PHP version upgrades</a>.', 'seravo');


### PR DESCRIPTION
#### What are the main changes in this PR?

Adds a button for running the wp-php-compatibility-check to the Updates page
of seravo-plugin. Once the check is done running, the number of errors found
is displayed to the user. If the check exits with a non-zero exit code, the
button is re-enabled and an error is displayed.

##### Why are we doing this? Any context or related work?
#271 

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
![image](https://user-images.githubusercontent.com/26429376/63348331-b0627f80-c361-11e9-89c7-7b13923d77b8.png)

![image](https://user-images.githubusercontent.com/26429376/63348340-b7898d80-c361-11e9-84e2-6a270e63b18f.png)

![image](https://user-images.githubusercontent.com/26429376/63348360-bfe1c880-c361-11e9-8dad-b532d3aa8603.png)

![image](https://user-images.githubusercontent.com/26429376/63417803-aba5d600-c40a-11e9-83cf-02488b4aef09.png)

