### PR TITLE
Add support for non-sortable full-width postboxes

### DIFF
--- a/lib/seravo-postbox.php
+++ b/lib/seravo-postbox.php
@@ -203,7 +203,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
       // Loop through the postboxes for this context
       if ( isset($this->postboxes[ $screen ][ $context ]) && ! empty($this->postboxes[ $screen ][ $context ]) ) {
         foreach ( $this->postboxes[ $screen ][ $context ] as $postbox_id => &$postbox_content ) {
-          $this->display_single_postbox($postbox_id, $postbox_content);
+          $this->display_single_postbox($postbox_id, $context, $postbox_content);
         }
       }
     }
@@ -224,6 +224,15 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
       <!-- Postbox wrapper -->
       <div class="dashboard-widgets-wrap">
+
+        <!-- Full-width postboxes first with full_width context -->
+        <div class="metabox-holder seravo-postbox-holder full-width">
+          <div class="postbox-container">
+            <?php $this->do_postboxes($current_screen, 'full_width'); ?>
+          </div>
+        </div>
+
+        <!-- Sortable smaller postboxes -->
         <div id="dashboard-widgets" class="metabox-holder seravo-postbox-holder">
           <?php foreach ( $container_contexts as $container_context ) : ?>
             <div id="postbox-container-<?php echo $context_index; ?>" class="postbox-container">
@@ -247,7 +256,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
       do_action('after_seravo_postboxes_' . $current_screen);
     }
 
-    private function display_single_postbox( $postbox_id, $postbox_content ) {
+    private function display_single_postbox( $postbox_id, $postbox_context, $postbox_content ) {
       $closed = in_array($postbox_id, $this->closed_postboxes);
       ?>
 
@@ -263,8 +272,15 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
           <span class="toggle-indicator" aria-hidden="true"></span>
         </button>
 
+        <?php
+        // All other contexts but full_width are sortable
+        $handle_class = 'hndle';
+        if ( $postbox_context !== 'full_width' ) {
+          $handle_class .= ' ui-sortable-handle';
+        }
+        ?>
         <!-- Postbox title -->
-        <h2 class="hndle ui-sortable-handle">
+        <h2 class="<?php echo $handle_class; ?>">
           <span><?php echo $postbox_content['title']; ?></span>
         </h2>
 

--- a/style/seravo-postbox.css
+++ b/style/seravo-postbox.css
@@ -35,6 +35,26 @@
   border-radius: 10px;
 }
 
+#wpbody-content .dashboard-widgets-wrap .seravo-postbox-holder {
+  padding-top: 0;
+}
+
+#wpbody-content .dashboard-widgets-wrap .seravo-postbox-holder.full-width {
+  padding-top: 10px;
+}
+
+.seravo-postbox-holder.full-width .postbox-container {
+  float: none;
+  margin: 0 8px 0px 8px;
+}
+
+.seravo-postbox .toggle-indicator:before {
+  content: "\f142";
+  display: inline-block;
+  font: normal 20px/1 dashicons;
+  speak: none;
+}
+
 @media only screen and (min-width:1430px) {
   .seravo-postbox .inside {
     padding: 10px 15px 0px 15px;


### PR DESCRIPTION
#### What are the main changes in this PR?
Add support for displaying full-width postboxes on the top of `seravo_postboxes_page` by adding the `'full_width'` postbox content parameter that can be used as the fifth parameter for `seravo_add_postbox()`.

##### Why are we doing this? Any context or related work?
Related to the discussions in https://github.com/Seravo/seravo-plugin/issues/233.

#### Where should a reviewer start?
Locally or on a test site, try adding postboxes to pages with `full_width` context, e.g.:
```
seravo_add_postbox(
   'full-width-test',
   __('Full-width Postbox', 'seravo'),
   array( __CLASS__, 'database_adminer_postbox' ),
   'tools_page_database_page',
   'full_width'
);
```

#### Manual testing steps?
The full-width postboxes should be displayed on the top of the page before the sortable postboxes.

#### Screenshots
![Firefox_Screenshot_2019-08-30T08-21-32 708Z](https://user-images.githubusercontent.com/24781811/64005099-5491b680-cb18-11e9-90af-3bdf8aae378b.png)
![Firefox_Screenshot_2019-08-30T07-46-09 691Z](https://user-images.githubusercontent.com/24781811/64005113-59ef0100-cb18-11e9-9be5-13f204a64456.png)
![Firefox_Screenshot_2019-08-30T07-29-11 729Z](https://user-images.githubusercontent.com/24781811/64005120-5d828800-cb18-11e9-992c-2f863a3b7353.png)
