### PR TITLE
Add 'two column' postboxes page layout

### DIFF
--- a/lib/seravo-postbox.php
+++ b/lib/seravo-postbox.php
@@ -156,7 +156,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
     /**
      * Filter the postboxes in such a way that they are in the user specified order.
      */
-    private function apply_user_postbox_settings() {
+    private function apply_user_postbox_settings( $column_count = 'four_column' ) {
       $screen = get_current_screen()->id;
 
       // Preload closed postboxes. If the setting is not set, WP returns an empty string, so don't
@@ -184,9 +184,18 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
                 // Move the postbox data to the new context
                 if ( in_array($postbox_id, array_keys($postboxes_array)) ) {
-                  $postbox_data = $postboxes_array[ $postbox_id ];
-                  unset($postboxes_array[ $postbox_id ]);
-                  $this->postboxes[ $screen ][ $custom_context ][ $postbox_id ] = $postbox_data;
+
+                  if ( $column_count === 'two_column' ) {
+                    if ( $custom_context === 'column3' ) {
+                      $custom_context = 'normal';
+                    } elseif ( $custom_context === 'column4' ) {
+                      $custom_context = 'side';
+                    }
+                  }
+
+                  $postbox_data = $postboxes_array[$postbox_id];
+                  unset($postboxes_array[$postbox_id]);
+                  $this->postboxes[$screen][$custom_context][$postbox_id] = $postbox_data;
                   break;
                 }
               }
@@ -211,12 +220,17 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
     /**
      * Display a page with all currently registered postboxes.
      */
-    public function display_postboxes_page() {
+    public function display_postboxes_page( $column_count = 'four_column' ) {
       // These are the same postbox contexts that are used in WP core.
       $container_contexts = array( 'normal', 'side', 'column3', 'column4' );
+
+      if ( $column_count === 'two_column' ) {
+        $container_contexts = array( 'normal', 'side' );
+      }
+
       $context_index = 1;
       $current_screen = get_current_screen()->id;
-      $this->apply_user_postbox_settings();
+      $this->apply_user_postbox_settings($column_count);
 
       // Fire pre-postbox action
       do_action('before_seravo_postboxes_' . $current_screen);
@@ -226,7 +240,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
       <div class="dashboard-widgets-wrap">
         <div id="dashboard-widgets" class="metabox-holder seravo-postbox-holder">
           <?php foreach ( $container_contexts as $container_context ) : ?>
-            <div id="postbox-container-<?php echo $context_index; ?>" class="postbox-container">
+            <div id="postbox-container-<?php echo $context_index; ?>" class="postbox-container <?php echo $column_count === 'two_column' ? 'two-column-layout' : ''; ?>">
               <div id="<?php echo $container_context; ?>-sortables" class="meta-box-sortables ui-sortable">
                 <?php $this->do_postboxes($current_screen, $container_context); ?>
               </div>
@@ -308,5 +322,10 @@ function seravo_add_postbox( $id, $title, $callback, $screen = 'tools_page', $co
  */
 function seravo_postboxes_page() {
   global $seravo_postbox_factory;
-  $seravo_postbox_factory->display_postboxes_page();
+  $seravo_postbox_factory->display_postboxes_page('four_column');
+}
+
+function seravo_two_column_postboxes_page() {
+  global $seravo_postbox_factory;
+  $seravo_postbox_factory->display_postboxes_page('two_column');
 }

--- a/style/seravo-postbox.css
+++ b/style/seravo-postbox.css
@@ -47,3 +47,33 @@
     font-size: 0px;
   }
 }
+
+#dashboard-widgets .postbox-container.two-column-layout {
+  width: 1050px;
+}
+
+@media only screen and (max-width: 2300px) {
+  #dashboard-widgets .postbox-container.two-column-layout {
+    width: 49.5%;
+  }
+}
+
+@media only screen and (min-width: 1500px) and (max-width: 1800px) {
+  #wpbody-content #dashboard-widgets #postbox-container-1.two-column-layout {
+    width: 50.5%;
+  }
+
+  #wpbody-content #dashboard-widgets .postbox-container.two-column-layout {
+    width: 49.5%;
+  }
+}
+
+@media only screen and (min-width: 800px) and (max-width: 1499px) {
+  #wpbody-content #dashboard-widgets .postbox-container.two-column-layout {
+    width: 49.5%;
+  }
+
+  #wpbody-content #dashboard-widgets #postbox-container-2.two-column-layout {
+    width: 50.5%;
+  }
+}


### PR DESCRIPTION
#### What are the main changes in this PR?
This PR will add an optional two column page layout to postboxes. Also, in two column postboxes, if window width is more than 2300px, it will limit postboxes width to 1050px.

##### Why are we doing this? Any context or related work?
The issue #233

#### Manual testing steps?
Set any add_submenu_page() look like:
 ```
add_submenu_page(
    'tools.php',
    __('Example', 'seravo'),
    __('Example', 'seravo'),
    'manage_options',
    'example_page',
    'Seravo\seravo_two_column_postboxes_page'
 );
```

#### Screenshots
width 1920px:
![fullhd](https://user-images.githubusercontent.com/43742796/64420990-2fb5ba00-d0a9-11e9-8c82-a30890c6f366.png)

width 3840px:
![big](https://user-images.githubusercontent.com/43742796/64421284-e4e87200-d0a9-11e9-8947-4412f0fe3df7.png)



