### PR TITLE
Check the exit code of the wp-backup command on search-replace ajax

### DIFF
--- a/lib/search-replace-ajax.php
+++ b/lib/search-replace-ajax.php
@@ -16,13 +16,13 @@ function seravo_search_replace( $from, $to, $options ) {
   if ( $options['dry_run'] === 'false' && $options['skip_backup'] === 'false' ) {
     $backup = 'wp-backup';
     array_push($output, '<b>$ ' . $backup . '</b>');
-    exec($backup . ' 2>&1', $output);
+    exec($backup . ' 2>&1', $output, $return_code);
   }
   // Only way this is not true, is if the backups fail
-  // wp-backup output line 4 should have "Success: Exported to '<name>_<id>.sql'."
   if ( $options['dry_run'] === 'true' ||
         $options['skip_backup'] === 'true' ||
-        strpos($output[3], 'Success:') !== false ) {
+    $return_code === 0
+  ) {
     array_push($output, '<b>$ ' . $command . '</b>');
     exec($command . ' 2>&1', $output);
   } else {


### PR DESCRIPTION
#### What are the main changes in this PR?
Add check for the third line of wp-backup output to search-replace-ajax.

##### Why are we doing this? Any context or related work?
Currently, search-replace-ajax check only if the fourth line of wp-backup output is "Success: Exported to 'example.sql'". But some sites wp-backup output not contains "No path given as argument. Using default path." and "Success: Exported to 'example.sql'" is in the third line of output. This causes search-replace failing.

#### Screenshots
Before change:
![search-replace-fail](https://user-images.githubusercontent.com/43742796/65021203-5096ce80-d937-11e9-9f08-a10429f5ebb4.png)


After change:
![search-replace-success](https://user-images.githubusercontent.com/43742796/65021216-54c2ec00-d937-11e9-85f7-daa39430d9d3.png)
