### PR TITLE
Mixed fixes for Seravo Plugin

### DIFF
--- a/lib/domains-page.php
+++ b/lib/domains-page.php
@@ -193,7 +193,7 @@ class Seravo_Domains_List_Table extends WP_List_Table {
         // Send final sort direction to usort
       return ($order === 'asc') ? $result : -$result;
     }
-    usort($data, 'usort_reorder');
+    usort($data, array( __CLASS__, 'usort_reorder' ));
 
     // Required for pagnation
     $current_page = $this->get_pagenum();
@@ -344,7 +344,7 @@ class Seravo_Mails_Forward_Table extends WP_List_Table {
      * to a custom query. The returned data will be pre-sorted, and this array
      * sorting technique would be unnecessary.
      */
-    function usort_reorder( $a, $b ) {
+    function usort_reorder_mail( $a, $b ) {
       // If no sort, default to domain name
       $orderby = (! empty($_REQUEST['orderby'])) ? $_REQUEST['orderby'] : 'source';
       // If no order, default to asc
@@ -354,7 +354,7 @@ class Seravo_Mails_Forward_Table extends WP_List_Table {
       // Send final sort direction to usort
       return ($order === 'asc') ? $result : -$result;
     }
-    usort($data, 'usort_reorder');
+    usort($data, 'usort_reorder_mail');
 
     $this->items = $data;
 

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -14,12 +14,12 @@ if ( ! class_exists('Upkeep') ) {
       add_action('admin_enqueue_scripts', array( __CLASS__, 'register_scripts' ));
       add_action('wp_ajax_seravo_ajax_upkeep', 'seravo_ajax_upkeep');
 
-      add_action('admin_post_toogle_seravo_updates', array( __CLASS__, 'seravo_admin_toggle_seravo_updates' ), 20);
+      add_action('admin_post_toggle_seravo_updates', array( __CLASS__, 'seravo_admin_toggle_seravo_updates' ), 20);
 
       // TODO: check if this hook actually ever fires for mu-plugins
       register_activation_hook(__FILE__, array( __CLASS__, 'register_view_updates_capability' ));
 
-      if ( getenv('WP_ENV') === 'productiom' ) {
+      if ( getenv('WP_ENV') === 'production' ) {
         seravo_add_postbox(
           'site-status',
           __('Site Status', 'seravo'),
@@ -597,7 +597,7 @@ if ( ! class_exists('Upkeep') ) {
         die($response->get_error_message());
       }
 
-      wp_redirect(admin_url('tools.php?page=updates_page&settings-updated=true'));
+      wp_redirect(admin_url('tools.php?page=upkeep_page&settings-updated=true'));
       die();
     }
 

--- a/modules/wp-cli.php
+++ b/modules/wp-cli.php
@@ -28,7 +28,7 @@ class Seravo_WP_CLI extends WP_CLI_Command {
 
     if ( $site_info['seravo_updates'] === true ) {
       WP_CLI::success('Seravo Updates: enabled');
-    } elseif ( $site_info['seravo_updates'] === true ) {
+    } elseif ( $site_info['seravo_updates'] === false ) {
       WP_CLI::success('Seravo Updates: disabled');
     } else {
       WP_CLI::error('Seravo API failed to return information about updates.');


### PR DESCRIPTION
This PR include fixes for the next things:
  - Fix a few typos in the upkeep page code
  - Change usort_reorder to usort_reorder_mail in the domains page code
  - Fix a bug in wp-cli that causes error message on command `wp seravo updates` when Seravo Updates is disabled

Testing:
  - On the upkeep page, disable or enable Seravo updates and save settings
  - View the zones in your domain
  - Once Seravo updates is disabled, run `wp seravo updates` in the site CLI