### PR TITLE
Decrease the value of the "limit" attribute in while-loop (Closes: #298)

### DIFF
--- a/modules/logs.php
+++ b/modules/logs.php
@@ -389,6 +389,7 @@ if ( ! class_exists('Logs') ) {
         while ( $offset < -1 && $limit > 0 ) {
           array_pop($complete_lines);
           $offset++;
+          $limit--;
         }
 
         // apply a regex filter


### PR DESCRIPTION
#### What are the main changes in this PR?
Decrease the value of the "limit" attribute.

##### Why are we doing this? Any context or related work?
#298

#### Manual testing steps?
1. Go to the Logs page
2. Choose a log file that contains more than 50 lines. (Example: wp-php-compatibility.log)
3. Scroll to the first line of the log file.