### PR TITLE
Add cache status improvements

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -108,6 +108,7 @@ jQuery(document).ready(function($) {
   seravo_load_report('wp_core_verify');
   seravo_load_report('git_status');
   seravo_load_report('redis_info');
+  seravo_load_report('longterm_cache');
 
   jQuery('#run-cache-tests').click(function() {
     jQuery('#seravo_cache_tests').html('');

--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -76,7 +76,25 @@ jQuery(document).ready(function($) {
         var allData = JSON.parse(rawData);
         jQuery('#total_disk_usage').text(allData.data.human);
         generateChart(allData.dataFolders);
-      } else {
+      } else if (section === 'front_cache_status') {
+        var data = JSON.parse(rawData);
+        var data_joined = data['test_result'].join("\n");
+
+        if ( data['success'] === true ) {
+          jQuery('.seravo_cache_tests_status').html(seravo_site_status_loc.cache_success).fadeIn('slow');
+          jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
+        } else {
+          jQuery('.seravo_cache_tests_status').html(seravo_site_status_loc.cache_failure).fadeIn('slow');
+          jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
+        }
+
+        jQuery('#seravo_cache_tests').append(data_joined);
+        jQuery('#run-cache-tests').prop('disabled', false);
+
+        jQuery(this).fadeIn('slow', function() {
+          jQuery('.seravo_cache_test_show_more_wrapper').fadeIn('slow');
+        });
+      } else {
         var data = JSON.parse(rawData);
         jQuery('#' + section).text(data.join("\n"));
       }
@@ -90,7 +108,39 @@ jQuery(document).ready(function($) {
   seravo_load_report('wp_core_verify');
   seravo_load_report('git_status');
   seravo_load_report('redis_info');
-  seravo_load_report('front_cache_status');
+
+  jQuery('#run-cache-tests').click(function() {
+    jQuery('#seravo_cache_tests').html('');
+    jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
+    jQuery('.seravo_cache_test_show_more_wrapper').hide();
+
+    if ( jQuery('#seravo_arrow_cache_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+      jQuery('.seravo-cache-test-result').hide(function() {
+        jQuery('#seravo_arrow_cache_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+      });
+    }
+
+    jQuery('.seravo_cache_tests_status').fadeOut(400, function() {
+      jQuery(this).html('<div class="front_cache_status_loading"><img src="/wp-admin/images/spinner.gif" style="display:inline-block"> ' + seravo_site_status_loc.running_cache_tests + '</div>').fadeIn(400);
+    });
+
+    jQuery(this).prop('disabled', true);
+    seravo_load_report('front_cache_status');
+  });
+
+  jQuery('.seravo_cache_test_show_more').click(function(event) {
+    event.preventDefault();
+
+    if ( jQuery('#seravo_arrow_cache_show_more').hasClass('dashicons-arrow-down-alt2') ) {
+      jQuery('.seravo-cache-test-result').slideDown('fast', function() {
+        jQuery('#seravo_arrow_cache_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+      });
+    } else if ( jQuery('#seravo_arrow_cache_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+      jQuery('.seravo-cache-test-result').hide(function() {
+        jQuery('#seravo_arrow_cache_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+      });
+    }
+  });
 
   $('#shadow-selector').change(function() {
     var $shadow = $("[data-shadow=" + $(this).val() + "]");

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -116,32 +116,13 @@ function seravo_report_redis_info() {
 }
 
 function seravo_report_front_cache_status() {
-  exec('curl -ILk ' . get_site_url(), $output);
-  array_unshift($output, '$ curl -ILk ' . get_site_url());
+  exec('wp-check-http-cache ' . get_site_url(), $output);
+  array_unshift($output, '$ wp-check-http-cache ' . get_site_url());
 
-  if ( preg_match('/X-Proxy-Cache: ([A-Z]+)/', implode("\n", $output), $matches) ) {
-
-    switch ( $matches[1] ) {
-      case 'HIT':
-      case 'EXPIRED':
-        $result = 'Front cache is working correctly.';
-        break;
-
-      case 'MISS':
-        $result = 'Front page is not cached due to cookies or expiry headers emitted from the site.';
-        break;
-
-      default:
-        $result = 'Unable to detect front cache status.';
-        break;
-    }
-  } else {
-    $result = 'No front cache available in this WordPress instance.';
-  }
-
-  array_unshift($output, $result, '');
-
-  return $output;
+  return [
+    'success' => strpos(implode("\n", $output), "\nSUCCESS: ") == true,
+    'test_result' => $output,
+  ];
 }
 
 function seravo_reset_shadow() {

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -90,6 +90,28 @@ function seravo_report_git_status() {
 
 function seravo_report_redis_info() {
   exec('redis-cli info stats | grep keys', $output);
+
+  foreach ( $output as $line ) {
+    if ( strpos($line, 'keyspace_hits') === 0 ) {
+      $hits = explode(':', $line)[1];
+    } else if ( strpos($line, 'keyspace_misses') === 0 ) {
+      $misses = explode(':', $line)[1];
+    }
+  }
+
+  $output = str_replace(
+    [ 'expired_keys:', 'evicted_keys:', 'keyspace_hits:', 'keyspace_misses:' ],
+    [ 'Expired keys: ', 'Evicted keys: ', 'Keyspace hits: ', 'Keyspace misses: ' ],
+    $output
+  );
+
+  if ( isset($hits) && isset($misses) ) {
+    $total = $hits + $misses;
+    if ( $total > 0 ) {
+      array_push($output, 'Keyspace hit rate: ' . round(($hits / $total) * 100) . '%');
+    }
+  }
+
   return $output;
 }
 

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -187,6 +187,11 @@ if ( ! class_exists('Site_Status') ) {
         <img src="/wp-admin/images/spinner.gif">
       </div>
       <pre id="redis_info"></pre>
+      <h3><?php _e('Long-term HTTP Cache Stats', 'seravo'); ?></h3>
+      <div class="longterm_cache_loading">
+        <img src="/wp-admin/images/spinner.gif">
+      </div>
+      <pre id="longterm_cache"></pre>
       <h3><?php _e('Nginx HTTP Cache', 'seravo'); ?></h3>
       <div id="front_cache_status">
         <p>

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -137,16 +137,19 @@ if ( ! class_exists('Site_Status') ) {
         wp_enqueue_script('seravo_site_status');
 
         $loc_translation = array(
-          'no_data'     => __('No data returned for the section.', 'seravo'),
-          'failed'      => __('Failed to load. Please try again.', 'seravo'),
-          'no_reports'  => __('No reports found at /data/slog/html/. Reports should be available within a month of the creation of a new site.', 'seravo'),
-          'view_report' => __('View report', 'seravo'),
-          'success'    => __('Success!', 'seravo'),
-          'failure'    => __('Failure!', 'seravo'),
-          'error'      => __('Error!', 'seravo'),
-          'confirm'    => __('Are you sure? This replaces all information in the selected environment.', 'seravo'),
-          'ajaxurl'     => admin_url('admin-ajax.php'),
-          'ajax_nonce'  => wp_create_nonce('seravo_site_status'),
+          'no_data'             => __('No data returned for the section.', 'seravo'),
+          'failed'              => __('Failed to load. Please try again.', 'seravo'),
+          'no_reports'          => __('No reports found at /data/slog/html/. Reports should be available within a month of the creation of a new site.', 'seravo'),
+          'view_report'         => __('View report', 'seravo'),
+          'running_cache_tests' => __('Running cache tests...', 'seravo'),
+          'cache_success'       => __('HTTP cache working', 'seravo'),
+          'cache_failure'       => __('HTTP cache not working', 'seravo'),
+          'success'             => __('Success!', 'seravo'),
+          'failure'             => __('Failure!', 'seravo'),
+          'error'               => __('Error!', 'seravo'),
+          'confirm'             => __('Are you sure? This replaces all information in the selected environment.', 'seravo'),
+          'ajaxurl'             => admin_url('admin-ajax.php'),
+          'ajax_nonce'          => wp_create_nonce('seravo_site_status'),
 
         );
         wp_localize_script('seravo_site_status', 'seravo_site_status_loc', $loc_translation);
@@ -185,10 +188,28 @@ if ( ! class_exists('Site_Status') ) {
       </div>
       <pre id="redis_info"></pre>
       <h3><?php _e('Nginx HTTP Cache', 'seravo'); ?></h3>
-      <div class="front_cache_status_loading">
-        <img src="/wp-admin/images/spinner.gif">
+      <div id="front_cache_status">
+        <p>
+          <?php
+          _e('Here you can test the functionality of front cache. Same results can be achieved via command line by running <code>wp-check-http-cache</code> there.', 'seravo');
+          ?>
+        </p>
+        <button type="button" class="button-primary" id="run-cache-tests"><?php _e('Run Tests', 'seravo'); ?></button>
+        <div class="seravo-cache-test-result-wrapper">
+          <div class="seravo_cache_tests_status front_cache_status">
+            <?php _e('Click "Run Tests" to run the cache tests', 'seravo'); ?>
+          </div>
+          <div class="seravo-cache-test-result">
+            <pre id="seravo_cache_tests"></pre>
+          </div>
+          <div class="seravo_cache_test_show_more_wrapper hidden">
+            <a href="" class="seravo_cache_test_show_more"><?php _e('Toggle Details', 'seravo'); ?>
+              <div class="dashicons dashicons-arrow-down-alt2" id="seravo_arrow_cache_show_more">
+              </div>
+            </a>
+          </div>
+        </div>
       </div>
-      <pre id="front_cache_status"></pre>
       <?php
     }
 

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -51,3 +51,56 @@
 #shadow-reset {
   margin: 0;
 }
+
+.seravo-cache-test-result-wrapper {
+  -moz-transition: border 1s ease-in;
+  -o-transition: border 1s ease-in;
+  -webkit-transition: border 1s ease-in;
+  background-color: white;
+  border-left: solid 0.5em #e8ba1b;
+  box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.12);
+  display: block;
+  margin-top: 2em;
+  max-width: 55em;
+  min-height: 5em;
+  overflow: hidden;
+  transition: border 1s ease-in;
+}
+
+.seravo-cache-test-result {
+  box-shadow: 0 1px 1px 1px rgba(0,0,0,0.2);
+  display: none;
+  margin: 1em;
+  max-height: 25em;
+  overflow: auto;
+  padding: 1em;
+}
+
+.seravo_cache_tests_status {
+  font-size: 15px;
+  font-weight: bold;
+  margin-top: 1.6em;
+  margin-left: 0.5em;
+  padding-bottom: 7px;
+  text-align: center;
+}
+
+.seravo_cache_test_show_more_wrapper {
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  float: right;
+  height: 1em;
+  margin-right: 0.5em;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.seravo_cache_test_show_more,
+.seravo_cache_test_show_more:hover,
+.seravo_cache_test_show_more:active,
+.seravo_cache_test_show_more:focus {
+  box-shadow: none;
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
#### What are the main changes in this PR?
Improves the Redis info looks, replaces the curl with `wp-check-http-cache` and
adds parsing of `/data/slog` for historical info.

##### Why are we doing this? Any context or related work?
Issues #281 and #72 .

#### Screenshots
**Old:**
![](https://user-images.githubusercontent.com/668724/60666699-53be0a80-9e70-11e9-93b5-f8e67abe092f.png)

**New:**
![new-cache-postbox](https://user-images.githubusercontent.com/42264063/69563334-961beb80-0fb9-11ea-8875-4401583c83aa.png)
