### PR TITLE
Reduce amount of SWD API calls (Closes: #304)

### DIFF
--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -137,6 +137,8 @@ if ( ! class_exists('InstanceSwitcher') ) {
       $instances = self::load_shadow_list();
 
       if ( $instances ) {
+        // Query domains only once
+        $domain_list = API::get_site_data('/domains');
         // add menu entries for each shadow
         foreach ( $instances as $key => $instance ) {
           $title = strtoupper($instance['env']);
@@ -145,7 +147,7 @@ if ( ! class_exists('InstanceSwitcher') ) {
             $title .= ' (' . $instance['info'] . ')';
           }
 
-          $domain = self::get_shadow_domain($instance['name']);
+          $domain = self::get_shadow_domain($instance['name'], $domain_list);
           // 'null' from get_shadow_domain indicates API error
           // Hide the shadow entry from instance-switcher
           if ( $domain !== null ) {
@@ -231,8 +233,12 @@ if ( ! class_exists('InstanceSwitcher') ) {
       }
     }
 
-    public static function get_shadow_domain( $identifier ) {
-      $domain_list = API::get_site_data('/domains');
+    public static function get_shadow_domain( $identifier, $domain_list = null ) {
+
+      if ( $domain_list == null ) {
+        $domain_list = API::get_site_data('/domains');
+      }
+
       if ( is_wp_error($domain_list) ) {
         return null;
       }

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -321,8 +321,10 @@ if ( ! class_exists('Site_Status') ) {
                   <select id="shadow-selector">
                     <option value="" disabled selected hidden><?php _e('Select shadow', 'seravo'); ?></option>
                     <?php
+                    // Query domains only once
+                    $domain_list = API::get_site_data('/domains');
                     foreach ( $shadow_list as $shadow => $shadow_data ) {
-                      $shadow_list[$shadow]['domain'] = InstanceSwitcher::get_shadow_domain($shadow_data['name']);
+                      $shadow_list[$shadow]['domain'] = InstanceSwitcher::get_shadow_domain($shadow_data['name'], $domain_list);
                       printf('<option value="%s">%s</option>', $shadow_data['name'], $shadow_data['info']);
                     }
                     ?>


### PR DESCRIPTION
#### What are the main changes in this PR?

Reduces amount of SWD API calls made on couple of places. Most importantly,
instance switcher doesn't query domains for each shadow individually
on every page load when logged in anymore.

##### Why are we doing this? Any context or related work?

Reported in #304.

#### Manual testing steps?

Load page on a site with shadows while logged in and
monitor the amount of API calls made.
