### PR TITLE
Disable Redirection redirect cache

### DIFF
--- a/modules/thirdparty-fixes.php
+++ b/modules/thirdparty-fixes.php
@@ -24,6 +24,33 @@ if ( ! class_exists('ThirdpartyFixes') ) {
     public function __construct() {
       // Jetpack whitelisting
       add_filter('jpp_allow_login', array( $this, 'jetpack_whitelist_seravo' ), 10, 1);
+
+      // Set options for Redirection plugin
+      // defined twice because Redirection code and documentation has conflicts,
+      // ie. just to be sure...
+      add_filter('red_default_options', array( $this, 'redirection_options_filter' ), 10, 1);
+      add_filter('red_save_options', array( $this, 'redirection_options_filter' ), 10, 1);
+      add_filter('redirection_default_options', array( $this, 'redirection_options_filter' ), 10, 1);
+      add_filter('redirection_save_options', array( $this, 'redirection_options_filter' ), 10, 1);
+    }
+
+    /**
+     * Set default options for Redirection plugin
+     *
+     * This disables redirect cache, at seems to cause redirect loops
+     * quite often, and we don't like that. Our infrastructure does
+     * caching anyways.
+     *
+     * @param array $options User-provided (or default) options
+     * @return array Updated options with our customizations
+     * @since 1.9.15
+     * @see <https://redirection.me/developer/wordpress-hooks/>
+     **/
+    public function redirection_options_filter( $options ) {
+      $updated = array(
+        'redirect_cache' => -1,
+      );
+      return array_merge($options, $updated);
     }
 
     /**


### PR DESCRIPTION
Prevent Redirection plugin from ever enabling redirect caching.

While doing site upkeep we've noticed many times issues with redirects
getting cached too aggressively, which in turn sometimes causes redirect
loops (and eventually blocks access to site).

We hook up using filters provided by Redirection plugin, and always set
`redirect_cache` to disabled status (0). This is fine, as our
infrastructure does caching anyways, and ensures best results for end
user.

#### What are the main changes in this PR?

##### Why are we doing this? Any context or related work?
I'll provide backlink from another issue.

#### Where should a reviewer start?
Ensure that this
1) doesn't break anything
2) disables redirect caching

#### Manual testing steps?
1) setup test site
2) install Redirection plugin (NOTE: you need probably to go through setup via wp-admin)
3) enable Redirection plugin
4) check `redirect_cache` status, should be `-1`, eg. `wp eval '$options=red_get_options(); echo($options["redirect_cache"] . "\n");'`
5) try to enable redirection caching via settings, value should be still "Never cache" (-1) after you save settings (NOTE: you need to refresh the page to see what plugin gets from db)

#### Screenshots
N/A