### PR TITLE
Deprecate alloptions fix (Closes: #314)

### DIFF
--- a/modules/fixes.php
+++ b/modules/fixes.php
@@ -45,10 +45,16 @@ if ( ! class_exists('Fixes') ) {
       /**
        * Additional hooks to option updates to ensure they get refreshed in the
        * Redis object-cache when they change.
+       *
+       * WP core has implemented a similar fix in 5.3.1,
+       * this has been depreacted since that.
        */
-      add_action('added_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
-      add_action('updated_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
-      add_action('deleted_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
+
+      if ( version_compare(get_bloginfo('version'), '5.3.1', '<') ) {
+        add_action('added_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
+        add_action('updated_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
+        add_action('deleted_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ));
+      }
 
     }
 


### PR DESCRIPTION
#### What are the main changes in this PR?

A similar fix has been implemented in WP core 5.3.1 and has
been tested. Running two of these fixes at once was found
out to be more harmful.

The fix is now only ran with WordPress versions lower than 5.3.1.

##### Why are we doing this? Any context or related work?

Issue #314.
