### PR TITLE
Use XML-RPC block by default and whitelist Jetpack

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -44,6 +44,36 @@ if ( ! class_exists('Helpers') ) {
       return round($size, $precision) . [ 'B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB' ][ $i ];
     }
 
+    /**
+     * Get IP range limits from CIDR range format. Index 0
+     * is lower limit and index 1 upper limit.
+     *
+     * Example result:
+     *  [0] => 3221250250,
+     *  [1] => 3221254346,
+     *
+     * @param string IPv4 range in CIDR format (eg. xxx.xxx.xxx.xxx/20)
+     * @return array Upper and lower limits in ip2long format.
+     * @version 1.0
+     * @see https://gist.github.com/tott/7684443
+     **/
+    public static function cidr_to_range( $cidr ) {
+      $cidr = explode('/', $cidr);
+      $range = array();
+      $range[0] = (ip2long($cidr[0])) & ((-1 << (32 - (int) $cidr[1])));
+      $range[1] = $range[0] + pow(2, (32 - (int) $cidr[1])) - 1;
+      return $range;
+    }
+
+    public static function ip_in_range( $range, $ip ) {
+      foreach ( $range as $limits ) {
+        if ( $ip >= $limits[0] && $ip <= $limits[1] ) {
+          return true;
+        }
+      }
+      return false;
+    }
+
   }
 
 }

--- a/modules/security.php
+++ b/modules/security.php
@@ -216,9 +216,10 @@ if ( ! class_exists('Security') ) {
       );
 
       /* Real settings below */
-      add_settings_field(
+      self::add_settings_field_with_desc(
         'seravo-disable-xml-rpc',
         __('Disable XML-RPC', 'seravo'),
+        __('Disabling XML-RPC doesn\'t affect the Jetpack plugin. Jetpack IPs are whitelisted by default.', 'seravo'),
         array( __CLASS__, 'seravo_security_xmlrpc_field' ),
         'tools_page_security_page',
         'seravo_security_settings'
@@ -396,6 +397,17 @@ if ( ! class_exists('Security') ) {
       if ( $recursive == 0 ) {
         return true; // when not called recursively
       }
+    }
+
+    public static function add_settings_field_with_desc( $id, $title, $description, $callback, $page, $section = 'default', $args = array() ) {
+      add_settings_field(
+        $id,
+        $title . '<br><i class="seravo_field_description">' . $description . '</i>',
+        $callback,
+        $page,
+        $section,
+        $args
+      );
     }
   }
   Security::load();

--- a/style/security.css
+++ b/style/security.css
@@ -16,3 +16,7 @@
   overflow: hidden;
   white-space: nowrap;
 }
+.seravo_field_description {
+  font-weight: normal;
+  font-size: 0.8em;
+}


### PR DESCRIPTION
#### What are the main changes in this PR?
- XML-RPC blocking is now enabled by default
- Jetpack is whitelisted from XML-RPC blocking

##### Why are we doing this? Any context or related work?
Closes: #297 
