### PR TITLE
Increase minimum password requirement to strong

### DIFF
--- a/js/passwords.js
+++ b/js/passwords.js
@@ -18,7 +18,9 @@
       var password = this.value;
       var strength = wp.passwordStrength.meter( password, wp.passwordStrength.userInputBlacklist(), password );
       var $submitButton = $('#wp-submit');
-      if ( strength > 2 ) {
+      // Levels: 0=very weak, 1=weak, 2=medium, 4=strong
+      // Require strong passwords
+      if ( strength > 3 ) {
         $submitButton.prop( 'disabled', false );
       } else {
         $submitButton.prop( 'disabled', true );

--- a/js/passwords.js
+++ b/js/passwords.js
@@ -18,9 +18,15 @@
       var password = this.value;
       var strength = wp.passwordStrength.meter( password, wp.passwordStrength.userInputBlacklist(), password );
       var $submitButton = $('#wp-submit');
+
+      if ( typeof seravo_wordpress_password_min_strength === 'undefined' ||
+           Number.isInteger(seravo_wordpress_password_min_strength) ) {
+        seravo_wordpress_password_min_strength = 2;
+      }
+
       // Levels: 0=very weak, 1=weak, 2=medium, 4=strong
       // Require strong passwords
-      if ( strength > 3 ) {
+      if ( strength > seravo_wordpress_password_min_strength ) {
         $submitButton.prop( 'disabled', false );
       } else {
         $submitButton.prop( 'disabled', true );

--- a/modules/passwords.php
+++ b/modules/passwords.php
@@ -49,14 +49,29 @@ if ( ! class_exists('Passwords') ) {
 
       if ( $page === 'profile.php' || $page === 'user-new.php' ) {
         wp_enqueue_style('seravo_passwords');
-      } elseif ( $GLOBALS['pagenow'] === 'wp-login.php' ) {
         wp_enqueue_script('seravo_passwords');
+        add_action('admin_footer', array( __CLASS__, 'set_password_min_strength' ));
+      } elseif ( $GLOBALS['pagenow'] === 'wp-login.php' ) {
+        wp_enqueue_style('seravo_passwords');
+        wp_enqueue_script('seravo_passwords');
+        add_action('admin_footer', array( __CLASS__, 'set_password_min_strength' ));
         // Password changing form
         if ( isset($_GET['action']) && $_GET['action'] === 'rp' ) {
           wp_enqueue_style('seravo_passwords');
+          wp_enqueue_script('seravo_passwords');
+          add_action('admin_footer', array( __CLASS__, 'set_password_min_strength' ));
         }
       }
 
+    }
+
+    public static function set_password_min_strength( $data ) {
+      if ( current_user_can('publish_pages') ) {
+        $min_strength = 3;
+      } else {
+        $min_strength = 2;
+      }
+      echo '<script>var seravo_wordpress_password_min_strength = ' . $min_strength . ';</script>';
     }
 
     public static function calculate_password_hash( $user, $password ) {


### PR DESCRIPTION
This feature was originally introduced in https://github.com/Seravo/seravo-plugin/commit/5218a252d866e1229e44707985b83d940bad3090

Currently the "Update profile" button is disabled if password is weak:
![image](https://user-images.githubusercontent.com/668724/73928375-a9153b00-48db-11ea-84b1-45133e3ec2a9.png)

The button becomes enabled if password is medium:
![image](https://user-images.githubusercontent.com/668724/73928416-ba5e4780-48db-11ea-8af0-fc1351312457.png)

This change lifts the limit and only strong passwords are allowed:
![image](https://user-images.githubusercontent.com/668724/73928447-c813cd00-48db-11ea-99c3-65ca593d7360.png)

To be discussed: is this a good idea? Is medium enough already or not?