### PR TITLE
Fix bugs in Vagrant env (Closes: #323)

### DIFF
--- a/js/backups.js
+++ b/js/backups.js
@@ -18,7 +18,11 @@ jQuery(document).ready(function($) {
 
         jQuery('#' + section + '_loading').fadeOut();
         var data = JSON.parse(rawData);
-        jQuery('#' + section).append(data.join("\n"));
+        if ( data.length > 0 ) {
+          jQuery('#' + section).append(data.join("\n"));
+        } else {
+          jQuery('#' + section).append('<p>' + seravo_backups_loc.no_entries + '</p>');
+        }
       }
     ).fail(function () {
       jQuery('#' + section + '_loading').html('Failed to load. Please try again.');

--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -4,6 +4,10 @@
 function generateButtons (emails) {
   var html = [];
 
+  if ( ! emails ) {
+    return;
+  }
+
   emails.forEach(function (email) {
     if (email) {
       html.push('<button type="button" class="button button-primary email-button"><span class="email-button-content">' + email + '</span><span class="delete-icon dashicons dashicons-no"></span></button>')
@@ -234,32 +238,53 @@ jQuery(document).ready(function($) {
         'section': 'seravo_change_php_version',
         'nonce': seravo_upkeep_loc.ajax_nonce,
         'version': php_version
-      });
-    setTimeout(function() {
-      jQuery.post(
-        seravo_upkeep_loc.ajaxurl, {
-          'action': 'seravo_ajax_upkeep',
-          'section': 'seravo_php_check_version',
-          'nonce': seravo_upkeep_loc.ajax_nonce,
-          'version': php_version
-        }, function(success) {
-          jQuery("#change-php-version-status").fadeOut(400, function() {
-            if (success) {
-              jQuery("#activated-line").fadeIn(400, function() {
-                jQuery(this).show();
-              });
-            } else {
-              jQuery("#activation-failed-line").fadeIn(400, function() {
-                jQuery(this).show();
-              });
-            }
-          });
+      }
+    );
 
-          jQuery("#seravo-php-version").fadeIn(400, function() {
-            $(this).show();
-          });
+    var changed = false;
+    var attempt = 0, max_attempts = 5;
+    function check_php_version() {
+      setTimeout(function() {
+        jQuery.post(
+          seravo_upkeep_loc.ajaxurl, {
+            'action': 'seravo_ajax_upkeep',
+            'section': 'seravo_php_check_version',
+            'nonce': seravo_upkeep_loc.ajax_nonce,
+            'version': php_version
+          }, function(success) {
+            if (success) {
+              changed = success;
+              attempt = max_attempts;
+            }
+          }
+        ).always(function () {
+          if ( ++attempt < max_attempts ) {
+            check_php_version();
+          } else {
+            show_result();
+          }
         });
-    }, 5000);
+      }, 5000);
+    }
+    check_php_version();
+
+    function show_result() {
+      jQuery("#change-php-version-status").fadeOut(400, function() {
+        if ( changed ) {
+          jQuery("#activated-line").fadeIn(400, function() {
+            jQuery(this).show();
+          });
+        } else {
+          jQuery("#activation-failed-line").fadeIn(400, function() {
+            jQuery(this).show();
+          });
+        }
+      });
+
+      jQuery("#seravo-php-version").fadeIn(400, function() {
+        $(this).show();
+      });
+    }
   }
 
   jQuery.post(

--- a/lib/search-replace-ajax.php
+++ b/lib/search-replace-ajax.php
@@ -33,13 +33,13 @@ function seravo_search_replace( $from, $to, $options ) {
 
 function seravo_search_replace_set_flags( $options ) {
   $flags = '';
-  if ( $options['dry_run'] === 'true' ) {
+  if ( ! isset($options['dry_run']) || $options['dry_run'] === 'true' ) {
     $flags .= '--dry-run ';
   }
-  if ( $options['all_tables'] === 'true' ) {
+  if ( isset($options['dry_run']) && $options['all_tables'] === 'true' ) {
     $flags .= '--all-tables ';
   }
-  if ( $options['network'] === 'true' ) {
+  if ( isset($options['network']) && $options['network'] === 'true' ) {
     $flags .= '--network ';
   } elseif ( is_multisite() ) {
     $flags .= '--url="' . get_site_url() . '" ';

--- a/lib/security-ajax.php
+++ b/lib/security-ajax.php
@@ -8,8 +8,13 @@ if ( ! defined('ABSPATH') ) {
 // Returns IP, username and time of successful logins.
 // Number of results are limited by $max.
 function seravo_logins_info( $max = 10 ) {
-  // Get the latest logins from wp-login.log
-  $login_data = file('/data/log/wp-login.log');
+  $logfile = dirname(ini_get('error_log')) . '/wp-login.log';
+  if ( is_readable($logfile) ) {
+    // Get the latest logins from wp-login.log
+    $login_data = file($logfile);
+  } else {
+    $login_data = array();
+  }
 
   // If the wp-login.log has less than $max entries check older log files
   if ( count(preg_grep('/SUCCESS/', $login_data)) < $max ) {
@@ -66,6 +71,11 @@ function seravo_logins_info( $max = 10 ) {
 
   // Re-index the array after unsetting failed logins
   $login_data = array_values($login_data);
+
+  if ( empty($login_data) ) {
+    $login_data = array( '<tr><td colspan="4">' . __('No login data', 'seravo') . '</td></tr>' );
+  }
+
   // Adding column titles and table tags
   $column_titles = '<table class="login_info_table"><tr>' .
     '<th class="login_info_th">' . __('IP address', 'seravo') . '</th>' .

--- a/lib/upkeep-ajax.php
+++ b/lib/upkeep-ajax.php
@@ -28,8 +28,8 @@ function seravo_change_php_version() {
     exec('wp-restart-nginx >> /data/log/php-version-change.log 2>&1 &');
   }
 
-  if ( file_exists('/data/wordpress/.git') ) {
-    exec('cd /data/wordpress/ && git add nginx/*.conf && s-git-commit -m "Set new PHP version" && cd /data/wordpress/htdocs/wordpress/wp-admin');
+  if ( is_executable('/usr/local/bin/s-git-commit') && file_exists('/data/wordpress/.git') ) {
+    exec('cd /data/wordpress/ && git add nginx/*.conf && /usr/local/bin/s-git-commit -m "Set new PHP version" && cd /data/wordpress/htdocs/wordpress/wp-admin');
   }
 }
 
@@ -55,7 +55,7 @@ function seravo_plugin_version_check() {
 
 function seravo_plugin_upstream_version() {
   $upstream_version = get_transient('seravo_plugin_upstream_version');
-  if ( $upstream_version === false ) {
+  if ( $upstream_version === false || empty($upstream_version) ) {
     $upstream_version = exec('curl -s https://api.github.com/repos/seravo/seravo-plugin/tags | grep "name" -m 1 | awk \'{gsub("\"","")}; {gsub(",","")}; {print $2}\'');
     set_transient('seravo_plugin_upstream_version', $upstream_version, 10800);
   }

--- a/modules/backups.php
+++ b/modules/backups.php
@@ -75,6 +75,7 @@ if ( ! class_exists('Backups') ) {
         $loc_translation_backups = array(
           'ajaxurl'    => admin_url('admin-ajax.php'),
           'ajax_nonce' => wp_create_nonce('seravo_backups'),
+          'no_entries' => __('No entries were found', 'seravo'),
         );
         wp_localize_script('seravo_backups', 'seravo_backups_loc', $loc_translation_backups);
       }

--- a/modules/logs.php
+++ b/modules/logs.php
@@ -73,13 +73,6 @@ if ( ! class_exists('Logs') ) {
       // Default log view is the PHP error log as it is the most important one
       $default_logfile = 'php-error.log';
 
-      // Use supplied log name if given
-      if ( isset($_GET['logfile']) ) {
-        $current_logfile = $_GET['logfile'];
-      } else {
-        $current_logfile = $default_logfile;
-      }
-
       $max_num_of_rows = 50;
       if ( isset($_GET['max_num_of_rows']) ) {
           $max_num_of_rows = (int) $_GET['max_num_of_rows'];
@@ -111,7 +104,14 @@ if ( ! class_exists('Logs') ) {
       // Fetch rotated logs for each missing log and append them to $logs
       if ( ! empty($missing_logs) ) {
         foreach ( $missing_logs as $log ) {
-          array_push($logs, implode('', preg_grep('/([0-9]){8}$/', glob('{' . $log . '}-*', GLOB_BRACE))));
+          $found_log = implode('', preg_grep('/([0-9]){8}$/', glob('{' . $log . '}-*', GLOB_BRACE)));
+          if ( ! empty($found_log) ) {
+            if ( $log === '/data/log/' . $default_logfile ) {
+              $found_log_path = explode('/', $found_log);
+              $default_logfile = end($found_log_path);
+            }
+            array_push($logs, $found_log);
+          }
         }
       }
 
@@ -124,6 +124,13 @@ if ( ! class_exists('Logs') ) {
       $logfiles = array();
       foreach ( $logs as $key => $log ) {
         $logfiles[ basename($log) ] = $log;
+      }
+
+      // Use supplied log name if given
+      if ( isset($_GET['logfile']) ) {
+        $current_logfile = $_GET['logfile'];
+      } else {
+        $current_logfile = $default_logfile;
       }
 
       // Set logfile based on supplied log name if it's available

--- a/modules/security.php
+++ b/modules/security.php
@@ -48,15 +48,13 @@ if ( ! class_exists('Security') ) {
         'normal'
       );
 
-      if ( getenv('WP_ENV') === 'production' ) {
-        seravo_add_postbox(
-          'logins_info',
-          __('Recent successful logins', 'seravo'),
-          array( __CLASS__, 'logins_info_postbox' ),
-          'tools_page_security_page',
-          'side'
-        );
-      }
+      seravo_add_postbox(
+        'logins_info',
+        __('Recent successful logins', 'seravo'),
+        array( __CLASS__, 'logins_info_postbox' ),
+        'tools_page_security_page',
+        'side'
+      );
 
       seravo_add_postbox(
         'cruft-files',

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -61,15 +61,15 @@ if ( ! class_exists('Upkeep') ) {
           'tools_page_upkeep_page',
           'side'
         );
-
-        seravo_add_postbox(
-          'change-php-version',
-          __('Change PHP Version', 'seravo'),
-          array( __CLASS__, 'change_php_version_postbox' ),
-          'tools_page_upkeep_page',
-          'side'
-        );
       }
+
+      seravo_add_postbox(
+        'change-php-version',
+        __('Change PHP Version', 'seravo'),
+        array( __CLASS__, 'change_php_version_postbox' ),
+        'tools_page_upkeep_page',
+        'side'
+      );
 
       seravo_add_postbox(
         'seravo-plugin-updater',
@@ -388,7 +388,7 @@ if ( ! class_exists('Upkeep') ) {
           );
           ?>
         </p>
-        <p id="activation-failed-line" class="hidden"><?php _e('PHP version change failed. Using fallback PHP 5.6.', 'seravo'); ?></p>
+        <p id="activation-failed-line" class="hidden"><?php _e('PHP version change failed.', 'seravo'); ?></p>
       </div>
       <?php
     }


### PR DESCRIPTION
#### What are the main changes in this PR?

Improvements to Seravo Plugin compatibility with Vagrant. Some of these are also really small improvements to Seravo Plugin overall:

**[Backups postbox]**
- Show 'no entries' instead of empty postbox.

**[Upkeep page]**
- Fix JS errors breaking the page.
- Don't show PHP-version changing postbox only in production.
- Check if PHP-version change was successful 5 times instead of just once. This is because Vagrant might be a bit slower and the first requests are likely to fail and give false errors (like during nginx restart). Also improve the errors.
- Don't use production-only commands during PHP-version change.
- Fix empty Seravo Plugin upstream version.

**[Search-replace postbox]**
- Fix PHP-notices.

**[Logins info postbox]**
- Don't show logins info postbox only in production.
- Show 'no login data' instead of throwing warnings.
- Find login data also from wp-content/wp-login.log.

**[Logs page]**
- Fix invalid log links.
- Show latest php-error.log found by default.

##### Why are we doing this? Any context or related work?

Issue #323. Not all the bugs reported in there are fixed with this PR but there's a separate issue for them #315.

#### Manual testing steps?

Going through the pages and trying some of the fixed features in both staging and production is probably enough.
