### PR TITLE
Disable weak password option (Closes: #322)

### DIFF
--- a/js/passwords.js
+++ b/js/passwords.js
@@ -24,5 +24,9 @@
         $submitButton.prop( 'disabled', true );
       }
     });
+    $('#pw-weak').change(function() {
+      var $submitButton = $('#wp-submit');
+      $submitButton.prop( 'disabled', true );
+    });
   });
 })(jQuery);

--- a/modules/passwords.php
+++ b/modules/passwords.php
@@ -45,6 +45,10 @@ if ( ! class_exists('Passwords') ) {
         wp_enqueue_style('seravo_passwords');
       } elseif ( $GLOBALS['pagenow'] === 'wp-login.php' ) {
         wp_enqueue_script('seravo_passwords');
+        // Password changing form
+        if ( isset($_GET['action']) && $_GET['action'] === 'rp' ) {
+          wp_enqueue_style('seravo_passwords');
+        }
       }
 
     }

--- a/style/passwords.css
+++ b/style/passwords.css
@@ -1,6 +1,6 @@
 /* Disable the built-in WordPress profile page option 'Confirm use of weak password'
    by hiding the entire row, so users can never revert to it.
 */
-tr.pw-weak {
+tr.pw-weak, div.pw-weak {
   display: none !important;
 }


### PR DESCRIPTION
#### What are the main changes in this PR?

Updates the weak password disabling to affect lost-password screen too. This both hides the checkbox and disables the button if it was enabled for some reason.

##### Why are we doing this? Any context or related work?

Issue #322. The old fix didn't affect lost-password screen as the weak password option didn't exists there at the time. 

#### Manual testing steps?

In the issue #322.
