### PR TITLE
Remove all use of deprecated wpp_shadow cookie (should be seravo_shadow)

### DIFF
--- a/js/instance-switcher.js
+++ b/js/instance-switcher.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', function() {
       // instance[0] = #abc123, instance[1] = abc123
       if (instance && instance[1] && instance[1].length === 6) {
         // Set the cookies, 43200 seconds is 12 hours
-        document.cookie = "wpp_shadow=" + instance[1] + "; Max-Age=43200; Path=/";
         document.cookie = "seravo_shadow=" + instance[1] + "; Max-Age=43200; Path=/";
         // Clear potential old shadow query string
         new_location = new_location.replace(/[a-z]+_shadow=[a-z0-9]+/, '');
@@ -46,7 +45,6 @@ document.addEventListener('DOMContentLoaded', function() {
     var target = jQuery(this).attr('href');
     if (target === '#exit') {
       // Then using cookies to access shadow, clear them
-      document.cookie = "wpp_shadow=; Max-Age=0; Path=/";
       document.cookie = "seravo_shadow=; Max-Age=0; Path=/";
       // Clear potential old shadow query string
       new_location = new_location.replace(/[a-z]+_shadow=[a-z0-9]+/, '');

--- a/modules/instance-switcher.php
+++ b/modules/instance-switcher.php
@@ -127,7 +127,7 @@ if ( ! class_exists('InstanceSwitcher') ) {
           'id'    => $id,
           'title' => '<span class="ab-icon seravo-instance-switcher-icon"></span>' .
                     '<span class="ab-label seravo-instance-switcher-text">' . __('Now in', 'seravo') . ': ' . $current_title . '</span>',
-          'href'  => ! empty($_COOKIE['wpp_shadow']) ? $current_url . 'wpp_shadow=' . $_COOKIE['wpp_shadow'] : '#',
+          'href'  => ! empty($_COOKIE['seravo_shadow']) ? $current_url . 'seravo_shadow=' . $_COOKIE['seravo_shadow'] : '#',
           'meta'  => [
             'class' => $menuclass,
           ],


### PR DESCRIPTION
We have been using seravo_shadow as the cookie name for 2 years at least.
All references to deprecated legacy wpp_shadow cookie must be removed.

This probably also fixes cases where the instance switcher was reading
the old cookie and not at all the correct seravo_shadow cookie.