### PR TITLE
Fix login history only working on one timezone

### DIFF
--- a/style/security.css
+++ b/style/security.css
@@ -6,12 +6,7 @@
 .login_info_th {
   text-align: left;
 }
-.ip_tooltip {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-.username_tooltip {
+.seravo-tooltip {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
#### What are the main changes in this PR?

Sites not using UTC are currently only shown an empty table
on security page login history postbox.

Also the whole parser code was very annoying to read so I simplified it a bit. Using regex is probably not the best way to make it more readable but it now takes care of the whole parsing process and is very easy to understand.

##### Why are we doing this? Any context or related work?

This was a problem on a site.