### PR TITLE
Temporarily disable real-time image optimizations

### DIFF
--- a/modules/optimize-on-upload.php
+++ b/modules/optimize-on-upload.php
@@ -45,7 +45,8 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
      *
      */
     public static function optimize_images_on_upload( $filename ) {
-      exec('wp-optimize-images ' . $filename . ' &');
+      // @TODO: Enable this again once wp-optimize-images works wlll $arrayName = array('' => , );gain
+      // exec('wp-optimize-images ' . $filename . ' &');
       return $filename;
     }
 


### PR DESCRIPTION
The new version of wp-optimize-images is either slow or has some bugs
in exec() spawning or performance. Disable this for some time to get
until the new tool is optimized.