### PR TITLE
Use SeravoBot user agent when requesting jetpack ips

### DIFF
--- a/lib/security-restrictions.php
+++ b/lib/security-restrictions.php
@@ -129,7 +129,7 @@ if ( ! class_exists('Security_Restrictions') ) {
       if ( ($data === false) || count($data) < 1 ) {
         $whitelist = array();
         // Retrieve data from API
-        $response = wp_remote_get(esc_url_raw($url));
+        $response = wp_remote_get(esc_url_raw($url), array( 'user-agent' => 'Seravo/1.0; https://seravo.com' ));
         $data = json_decode(wp_remote_retrieve_body($response));
 
         if ( ! empty($data) ) {


### PR DESCRIPTION
For whatever reason, jetpack.com responses randomly with 429,
when the user agent is WordPress/x.x.x.

Also, include https://seravo.com as url in the user agent, so
Jetpack knows who to contact in case of problems.