### PR TITLE
Fix the width of the HTTP request bars

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -34,7 +34,7 @@ jQuery(document).ready(function($) {
 
           data.forEach( function(month) {
             if (month.hasOwnProperty('date')) {
-              var bar_size = month.requests / max_requests;
+              var bar_size = month.requests / max_requests * 100;
               if ( bar_size <= 10 ) {
                 var bar_css = 'auto';
               } else {
@@ -46,9 +46,9 @@ jQuery(document).ready(function($) {
                 month.date +
                 ' </a> </td> <td><div style="background: #44A1CB; color: #fff; padding: 3px; width: ' +
                 bar_css +
-                '; display: inline-block;">' +
+                '; display: inline-block;"><div style="white-space: nowrap;">' +
                 month.requests +
-                '</div></td> <td><a href="?report=-' +
+                '</div></div></td> <td><a href="?report=-' +
                 month.date +
                 '.html" target="_blank" class="button hideMobile">' +
                 seravo_site_status_loc.view_report +


### PR DESCRIPTION
Found on /wp-admin/tools.php?page=site_status_page

Previously, the width of the bar was always 'auto', because the ratio was
miscalculated.

Adding the `* 100` to the calculation fixed the issue, but it caused some of
the numbers to wrap. I added a second div, which prevents the wrapping.

Before:
![Screenshot_20200512_112425](https://user-images.githubusercontent.com/16290563/81660236-2a341f00-9443-11ea-836b-55b3af6f4437.png)

After:
![Screenshot_20200512_111655](https://user-images.githubusercontent.com/16290563/81660059-fbb64400-9442-11ea-804b-e2ac2f074a63.png)
