### PR TITLE
Make calls to wp-optimize-images run much faster

### DIFF
--- a/modules/optimize-on-upload.php
+++ b/modules/optimize-on-upload.php
@@ -15,7 +15,6 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
   class OptimizeImagesOnUpload {
 
     public static function load() {
-
       /*
        * Run optimizer for all thumbnail sizes. Don't use 'handle_upload' as it
        * fires too early and applies only to the original image. Instead hooking
@@ -45,8 +44,19 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
      *
      */
     public static function optimize_images_on_upload( $filename ) {
-      // @TODO: Enable this again once wp-optimize-images works wlll $arrayName = array('' => , );gain
-      // exec('wp-optimize-images ' . $filename . ' &');
+      $max_width = get_option('seravo-image-max-resolution-width');
+      $max_height = get_option('seravo-image-max-resolution-height');
+
+      // Include --enable and max dimensions so that wp-optimize-images does not
+      // need to invoke 'wp get option' itself and thus save ~1500 ms per image
+      exec(
+        'wp-optimize-images --enable ' .
+        '--set-max-resolution-width=' . intval($max_width) . ' ' .
+        '--set-max-resolution-height=' . intval($max_height) . ' ' .
+        '"' . $filename . '"  > /dev/null &'
+      );
+      // Redirect output AND background command so that PHP execution proceeds
+      // and does not wait for command in exec to complete
       return $filename;
     }
 
@@ -60,7 +70,7 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
   }
 
   // Only load if image optimization is enabled
-  if ( get_option('seravo-enable-optimize-images') == 'on' ) {
+  if ( get_option('seravo-enable-optimize-images') === 'on' ) {
     OptimizeImagesOnUpload::load();
   }
 }


### PR DESCRIPTION
Do so in two ways:

1) Pass 3 extra command line values the PHP process already knows to
   the Python wp-optimize-images command, so that it can avoid doing
   any 'wp option get' itself, and thus save 1-2 seconds per invocation.

```
  $ time wp-optimize-images 1568x2844.png
  ...
  real	0m1.959s

  $ time wp-optimize-images --enable --set-max-resolution-width=4000 \
    --set-max-resolution-height=4000 1568x2844.png
  ...
  real	0m0.204s
```


2) Redirect output and background command so that exec() returns to PHP
   and continues without waiting.

There is no need to synchronize the roll-out of this with the roll-out
of the new version of wp-optimize-images.

This is safe to roll-out at any time, since if the --enable or other
arguments are not yet available in the environment, they the command will
just fail but exec() always continues nevertheless, so there is no draw-
back compared to previous code that had exec() disabled anyway.