### PR TITLE
Hide specified users from user lists

### DIFF
--- a/modules/hide-users.php
+++ b/modules/hide-users.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Plugin name: WP Hide Users
+ * Description: Hides prespecified and given users from a WordPress page
+ */
+
+namespace Seravo;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('HideUsers') ) {
+  class HideUsers {
+
+    public static function load() {
+        add_action('pre_user_query', array( __CLASS__, 'hide_user_from_page' ), 10, 3);
+    }
+
+    public static function hide_user_from_page( $user_query ) {
+        $users_to_hide = self::$hidden_user_array;
+        $current_user_name = wp_get_current_user()->user_login;
+
+        // Exclude the current user from the users that will be hidden
+        $current_user_key = array_search($current_user_name, $users_to_hide);
+        if ( $current_user_key !== false ) {
+            unset($users_to_hide[$current_user_key]);
+        }
+
+        global $wpdb;
+        $array_sql_str = implode("', '", $users_to_hide);
+
+        // Edit SQL query clause just before making a query and skip the given users.
+        // Replaces the default "WHERE 1=1" clause with one of the following format:
+        // "WHERE 1=1 AND wp_user_table.user_login NOT IN ('user1', 'user2', ... )".
+        $user_query->query_where = str_replace(
+          'WHERE 1=1',
+          "WHERE 1=1 AND {$wpdb->users}.user_login NOT IN ('{$array_sql_str }')",
+          $user_query->query_where
+        );
+    }
+
+    // Array of users that will be hidden from WP user front-end, wp-cli output and WP Admin panel.
+    private static $hidden_user_array = array( 'seravotest', 'seravo' );
+
+  }
+
+  HideUsers::load();
+}

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -267,6 +267,12 @@ class Loader {
     if ( defined('WP_CLI') && WP_CLI ) {
       require_once dirname(__FILE__) . '/modules/wp-cli.php';
     }
+
+    /*
+     * Hide Users
+     * Hides prespecified and given users from a WordPress page
+     */
+    require_once dirname(__FILE__) . '/modules/hide-users.php';
   }
 }
 


### PR DESCRIPTION
Hide Seravo-specific WordPress users from user listings by using the `pre_get_users` hook. Users `seravo` and `seravotest` will be hidden as defined in commit b57b33b. The ability to hide certain users from the front-end was discussed in the issue https://github.com/Seravo/wordpress/issues/46.

Works for the Users page in WordPress Admin and the CLI command `wp user list` but the effect should be tested for some user listing plugins. The hidden user can see itself on the lists if they are logged in.