### PR TITLE
Don't force HTTP 401 for unauthorized AJAX calls

### DIFF
--- a/modules/fixes.php
+++ b/modules/fixes.php
@@ -114,9 +114,14 @@ if ( ! class_exists('Fixes') ) {
      * Return better http status code (401 unauthorized) after failed login.
      * Then failed login attempts (brute forcing) can be noticed in access.log
      * WP core ticket: https://core.trac.wordpress.org/ticket/25446
+     *
+     * Doesn't force http 401 for AJAX calls as some AJAX actions don't
+     * need authorization.
      */
     public static function change_http_code_to_unauthorized() {
-      status_header(401);
+      if ( ! defined('DOING_AJAX') ) {
+        status_header(401);
+      }
     }
 
     public static function send_no_cache_headers() {


### PR DESCRIPTION
#### What are the main changes in this PR?

Stops forcing HTTP 401 for unauthorized AJAX calls. Some plugins require
unauthorized use of admin-ajax and they require a HTTP 200 response.

##### Why are we doing this? Any context or related work?

Issue: #347 