### PR TITLE
Add plugin and theme logging

### DIFF
--- a/modules/logs.php
+++ b/modules/logs.php
@@ -94,6 +94,7 @@ if ( ! class_exists('Logs') ) {
         '/data/log/update.log',
         '/data/log/wp-login.log',
         '/data/log/wp-theme-security.log',
+        '/data/log/wp-settings.log',
       );
       // Skip runit.log and bootstrap.log and other logs that are not relevant
       // for customers and only list the ones a UI user might be interested in.

--- a/modules/wp-plugin-log.php
+++ b/modules/wp-plugin-log.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Plugin name: WP Plugin Log
+ * Description: Logs plugin and theme activations, deactivations, updates, installations
+ * and deletions. Theme deletion is not logged as there is no hook for it.
+ */
+
+namespace Seravo;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('PluginLog') ) {
+  class PluginLog {
+
+    public static function load() {
+      add_action('activate_plugin', array( __CLASS__, 'on_try_activate_plugin' ), 10, 2);
+      add_action('activated_plugin', array( __CLASS__, 'on_activate_plugin' ), 10, 2);
+      add_action('deactivate_plugin', array( __CLASS__, 'on_try_deactivate_plugin' ), 10, 2);
+      add_action('deactivated_plugin', array( __CLASS__, 'on_deactivate_plugin' ), 10, 2);
+      add_action('switch_theme', array( __CLASS__, 'on_switch_theme' ), 10, 1);
+      add_action('upgrader_process_complete', array( __CLASS__, 'on_upgrader_process_complete' ), 10, 2);
+      add_action('delete_plugin', array( __CLASS__, 'on_delete_plugin' ));
+    }
+
+    public static function on_upgrader_process_complete( $upgrader = null, $arr_data = null ) {
+      // Check to make sure there's correct variables passed to this function
+      if ( empty($upgrader) || empty($arr_data) ) {
+        return;
+      } elseif ( $arr_data['type'] !== null && $arr_data['action'] !== null ) {
+        $type = $arr_data['type'];
+        $action = $arr_data['action'];
+      } else {
+        return;
+      }
+
+      if ( $type === 'theme' ) {
+        if ( $action === 'install' ) {
+          self::write_log('installed theme ' . $upgrader->theme_info());
+        } elseif ( $action === 'update' ) {
+          self::write_log('updated theme ' . $upgrader->theme_info());
+        }
+      } elseif ( $type === 'plugin' ) {
+        if ( $action === 'install' ) {
+          self::write_log('installed plugin ' . $upgrader->plugin_info());
+        } elseif ( $action === 'update' ) {
+          self::write_log('updated plugin ' . $upgrader->plugin_info());
+        }
+      }
+
+      return;
+    }
+
+    public static function on_delete_plugin( $plugin = '' ) {
+      self::write_log('deleted plugin ' . $plugin);
+    }
+
+    public static function on_try_activate_plugin( $plugin, $network_activation ) {
+      self::write_log('is trying to activate plugin ' . $plugin);
+    }
+
+    public static function on_activate_plugin( $plugin, $network_activation ) {
+      self::write_log('activated plugin ' . $plugin);
+    }
+
+    public static function on_try_deactivate_plugin( $plugin, $network_activation ) {
+      self::write_log('is trying to deactivate plugin ' . $plugin);
+    }
+
+    public static function on_deactivate_plugin( $plugin, $network_activation ) {
+      self::write_log('deactivated plugin ' . $plugin);
+    }
+
+    public static function on_switch_theme( $theme ) {
+      self::write_log('switched to theme ' . $theme);
+    }
+
+    public static function write_log( $message ) {
+      $log_directory = dirname(ini_get('error_log'));
+
+      if ( empty($log_directory) ) {
+        // If there is no log directory, just log one directory above WordPress
+        // and hope that directory is writeable but not accessible from the web
+        $log_directory = '..';
+      }
+      $time_local = gmdate('j/M/Y:H:i:s O');
+
+      $current_user = wp_get_current_user();
+
+      $username = $current_user->user_login;
+
+      $log_fp = fopen($log_directory . '/wp-settings.log', 'a');
+      fwrite($log_fp, "$time_local User $username $message\n");
+      fclose($log_fp);
+    }
+  }
+
+  PluginLog::load();
+}

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -159,6 +159,11 @@ class Loader {
     require_once dirname(__FILE__) . '/modules/wp-login-log.php';
 
     /*
+     * Log plugin and theme activations, deactivations, installations and deletions.
+     */
+    require_once dirname(__FILE__) . '/modules/wp-plugin-log.php';
+
+    /*
      * Enforce strong passwords
      */
     require_once dirname(__FILE__) . '/modules/passwords.php';


### PR DESCRIPTION
Log plugin and theme activations, deactivations, installations, updates and deletions in /data/log/wp-settings.log file. Tracks date and time and the user who is making the change. 

Currently theme deletions are not logged as there is no hook for it.

Related issue: #329
