### PR TITLE
Add mail forwards table

### DIFF
--- a/modules/domains.php
+++ b/modules/domains.php
@@ -80,9 +80,14 @@ if ( ! class_exists('Domains') ) {
           'fetch_failed'        => __('DNS fetch failed! Please refresh the page.', 'seravo'),
           'update_no_changes'   => __('The zone was updated without changes.', 'seravo'),
           'changing_primary'    => __('Changing the primary domain...', 'seravo'),
-          'primary_failed'      => __('Error! Primary domain might not have been changed.'),
-          'primary_no_sr'       => __('Primary domain was changed but was not taken in use yet.'),
-          'continue_edit'       => __('Continue'),
+          'primary_failed'      => __('Error! Primary domain might not have been changed.', 'seravo'),
+          'primary_no_sr'       => __('Primary domain was changed but was not taken in use yet.', 'seravo'),
+          'no_forwards'         => __('This domain has no mail forwards', 'seravo'),
+          'forwards_failed'     => __('Couldn\'t fetch mail forwards for this domain.', 'seravo'),
+          'forwards_none'       => __('No forwards were found for this domain.', 'seravo'),
+          'forwards_edit_fail'  => __('Error! The action might have failed.', 'seravo'),
+          'forwards_no_source'  => __('Source field can\'t be empty.', 'seravo'),
+          'continue_edit'       => __('Continue', 'seravo'),
         );
 
         wp_localize_script('seravo_domains', 'seravo_domains_loc', $loc_translation_domains);
@@ -109,7 +114,24 @@ if ( ! class_exists('Domains') ) {
     }
 
     public static function render_mails_postbox() {
-      echo 'Coming soon...';
+      ?>
+      <div class="mail-table">
+        <div class="mail-table-col">
+          <p><?php _e('Mail forwards of the domains routed to this WordPress site are listed below. Fetch the forwards for a domain with the link below the domain name.', 'seravo'); ?></p>
+          <div id="forwards-table-wrapper">
+            <p id="forwards-table-spinner">
+              <img src="/wp-admin/images/spinner.gif">
+              <b><?php _e('Loading mail forwards...', 'seravo'); ?></b>
+            </p>
+          </div>
+        </div>
+        <div class="mail-table-col">
+          <p><?php _e('Mailboxes assigned to this WordPress site are listed below.', 'seravo'); ?></p>
+          <hr style="margin: 15px 0px;">
+          <b>Coming soon...</b>
+        </div>
+      </div>
+      <?php
     }
 
   }

--- a/style/domains.css
+++ b/style/domains.css
@@ -1,3 +1,5 @@
+/** Domains postbox */
+
 @media only screen and (min-width: 1500px) {
   #wpbody-content #dashboard-widgets .postbox-container {
     width: 100%;
@@ -8,7 +10,7 @@
   margin-bottom: 15px !important;
 }
 
-.domains {
+.domains, .mail-forwards {
   border: none !important;
   margin-top: 50px;
 }
@@ -143,4 +145,74 @@ tr.zone-titles > th {
   top: 0;
   background-color: #ededed;
   font-weight: bold;
+}
+
+/** Mails postbox */
+
+.mail-table {
+  padding: 5px 10px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.mail-table-col {
+  min-width: 500px;
+  flex-grow: 1;
+  flex-basis: 0;
+  margin: 10px 10px 20px 10px;
+}
+
+.mail-forwards .forward td {
+  padding: 10px 5px 0 0;
+}
+
+.mail-forwards #domain {
+  width: 35%;
+}
+
+.mail-forwards .forward-actions a {
+  margin-right: 5px;
+}
+
+.mail-forwards .forward-actions {
+  line-height: 2px;
+  font-size: 11px;
+}
+
+.mail-forwards .source-edit {
+  line-height: 15px;
+  font-size: 13px;
+  width: 150px;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid grey;
+  border-radius: 0;
+  min-height: 0;
+  background-color: transparent;
+}
+
+.mail-forwards .source-edit:focus {
+  outline: 0;
+  box-shadow: none;
+}
+
+.mail-forwards .destination-edit {
+  width: 250px;
+  min-height: 100px;
+  overflow: auto;
+}
+
+.mail-forwards .edit-spinner {
+  position: relative;
+  top: 5px;
+  margin-left: 5px;
+}
+
+.mail-forwards .edit-message {
+  font-weight: bold;
+  margin: 10px 0 0 0;
+}
+
+.mail-forwards .delete-spinner {
+  width: 9px;
 }


### PR DESCRIPTION
## What are the main changes in this PR?

Adds mail forwards table to mails postbox on domains page.

The actions available are:
- Fetch forwards for a domain
- Create a new forward for a domain
- Delete a source and its destinations
- Modify the destinations of a source
- Modify the source

##### Why are we doing this? Any context or related work?

Closes: #13 

#### Where should a reviewer start?

These actions must be tested with a domain under Seravo's management.

#### Screenshots
After fetch:
![mails-postbox-1](https://user-images.githubusercontent.com/42264063/85421599-4a481980-b57d-11ea-8423-ca6402a2de36.png)
Editing:
![mails-postbox-2](https://user-images.githubusercontent.com/42264063/85421604-4c11dd00-b57d-11ea-86e4-30134cae377e.png)