### PR TITLE
Prevent reading huge log files

### DIFF
--- a/modules/logs.php
+++ b/modules/logs.php
@@ -324,6 +324,11 @@ if ( ! class_exists('Logs') ) {
 
       $filesize = filesize($filepath);
 
+      // Prevent reading huge files (over 256MB)
+      if ( $filesize >= 268435456 ) {
+        return false;
+      }
+
       // buffer size is 4096 bytes
       $buffer = 4096;
 


### PR DESCRIPTION
#### What are the main changes in this PR?

Prevents reading of log files over 256MB.

##### Why are we doing this? Any context or related work?

Multiple issues about wp-admin not working with huge log files.