### PR TITLE
Change log location to a fixed folder

### DIFF
--- a/modules/wp-login-log.php
+++ b/modules/wp-login-log.php
@@ -64,13 +64,8 @@ if ( ! class_exists('LoginLog') ) {
       $http_user_agent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
 
       // Finally write the log to disk
-      $log_directory = dirname(ini_get('error_log'));
-      if ( empty($log_directory) ) {
-        // If there is no log directory, just log one directory above WordPress
-        // and hope that directory is writeable but not accessible from the web
-        $log_directory = '..';
-      }
-      $log_fp = fopen($log_directory . '/wp-login.log', 'a');
+
+      $log_fp = fopen('/data/log/wp-login.log', 'a');
       fwrite($log_fp, "$remote_addr - $remote_user [$time_local] \"$request\" $status_code 1000 \"$http_referer\" \"$http_user_agent\" $login_status \n");
       fclose($log_fp);
 

--- a/modules/wp-plugin-log.php
+++ b/modules/wp-plugin-log.php
@@ -78,20 +78,13 @@ if ( ! class_exists('PluginLog') ) {
     }
 
     public static function write_log( $message ) {
-      $log_directory = dirname(ini_get('error_log'));
-
-      if ( empty($log_directory) ) {
-        // If there is no log directory, just log one directory above WordPress
-        // and hope that directory is writeable but not accessible from the web
-        $log_directory = '..';
-      }
       $time_local = gmdate('j/M/Y:H:i:s O');
 
       $current_user = wp_get_current_user();
 
       $username = $current_user->user_login;
 
-      $log_fp = fopen($log_directory . '/wp-settings.log', 'a');
+      $log_fp = fopen('/data/log/wp-settings.log', 'a');
       fwrite($log_fp, "$time_local User $username $message\n");
       fclose($log_fp);
     }


### PR DESCRIPTION
Logs were ending up in random places.

This fix sets a fixed location for the logs to '/data/log/' folder.

Closes #378

