### PR TITLE
Document how to easily run PHPCS (Closes: #346) and update PHPCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ Some of the features in the Seravo Plugin depend on the API that is available on
 
 In order to have the git repository on your own computer and in your own editor, while still being able to see the code running on a test site (in the production environment) you can use the command below. It will watch all files for changes and automatically rsync them to the remote server:
 ```
-seravo-plugin$ find * | entr rsync -avz -e 'ssh -q -p 12345' * \
-example@example.seravo.com:/data/wordpress/htdocs/wp-content/mu-plugins/seravo-plugin/
+seravo-plugin$ find * | entr rsync -avz -e 'ssh -q -p 12345' * example@example.seravo.com:/data/wordpress/htdocs/wp-content/mu-plugins/seravo-plugin/
 sending incremental file list
 README.md
 
@@ -85,6 +84,29 @@ Remember to update translations of all public facing string by running inside Va
 cd /data/wordpress/htdocs/wp-content/mu-plugins/seravo-plugin
 wp i18n make-pot . languages/seravo.pot
 ```
+
+### Running PHPCS
+
+If you have PHPCS installed locally with all the WordPress standards, simply run `phpcs` yourself or let your code editor run it automatically on every save. Alternatively run PHPCS inside local Vagrant or Docker image, or on the same remote site used for testing:
+
+```
+ssh -q -p 12345 example@example.seravo.com 'cd '/data/wordpress/htdocs/wp-content/mu-plugins/seravo-plugin/ && phpcs
+........S.......WWWWWWWWWWEWWEWWWWW.WWEWWWW.W.WWEWWEWEW..... 60 / 68 (88%)
+......W.                                                     68 / 68 (100%)
+
+FILE: ...press/htdocs/wp-content/mu-plugins/seravo-plugin/lib/helpers.php
+----------------------------------------------------------------------
+FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 2 LINES
+----------------------------------------------------------------------
+ 35 | WARNING | Filesystem function dirname() detected with dynamic
+    |         | parameter
+ 35 | WARNING | Line exceeds 100 characters; contains 118 characters
+ 44 | WARNING | Line exceeds 100 characters; contains 107 characters
+----------------------------------------------------------------------
+...
+```
+
+PHPCS can be installed locally using the same script .travis.yml uses. See `scripts/install-phpcs.sh`.
 
 # Changelog
 

--- a/lib/domain-tables.php
+++ b/lib/domain-tables.php
@@ -66,7 +66,7 @@ class Seravo_Domains_List_Table extends WP_List_Table {
         } else {
           $actions['edit'] = sprintf($action_request, 'edit', __('Edit', 'seravo'));
         }
-      } else if ( $item['management'] === 'Customer' ) {
+      } elseif ( $item['management'] === 'Customer' ) {
         $actions['view'] = sprintf($action_request, 'sniff', __('View', 'seravo'));
         $actions['edit'] = sprintf($action_disabled, __('DNS not managed by Seravo.', 'seravo'), __('Edit', 'seravo'));
       } else {
@@ -338,10 +338,10 @@ class Seravo_Mails_Forward_Table extends WP_List_Table {
       '<p>%s</p>%s',
       $item['domain'],
       $this->row_actions(
-        [
+        array(
           'view' => $view,
           'edit' => $edit,
-        ]
+        )
       )
     );
 
@@ -361,9 +361,9 @@ class Seravo_Mails_Forward_Table extends WP_List_Table {
       if ( $domain['management'] === 'Seravo' ) {
         array_push(
           $data,
-          [
+          array(
             'domain' => $domain['domain'],
-          ]
+          )
         );
       }
     }

--- a/lib/domains-ajax.php
+++ b/lib/domains-ajax.php
@@ -120,7 +120,7 @@ function seravo_admin_change_zone_file() {
                 break;
               }
             }
-          } else if ( substr($line, 0, 1) === '-' && substr($line, 1, 1) !== '-' ) {
+          } elseif ( substr($line, 0, 1) === '-' && substr($line, 1, 1) !== '-' ) {
             // Removed lines (-) can be added as they are
             array_push($zone_diff, $line);
           }
@@ -162,7 +162,7 @@ function seravo_fetch_dns() {
 
 function seravo_set_primary_domain() {
   if ( isset($_REQUEST['domain']) ) {
-    $response = Seravo\API::update_site_data(array( 'domain' => $_REQUEST['domain'] ), '/primary_domain', [ 200 ], 'POST');
+    $response = Seravo\API::update_site_data(array( 'domain' => $_REQUEST['domain'] ), '/primary_domain', array( 200 ), 'POST');
     if ( is_wp_error($response) ) {
       return seravo_respond_error_json($response->get_error_message());
       wp_die();
@@ -196,7 +196,7 @@ function seravo_edit_forwards() {
       foreach ( $destinations as $key => $destination ) {
         if ( strpos($destination, '@') > 0 && strpos($destination, '.') > 0 ) {
           array_push($destinations_parsed, trim($destination));
-        } else if ( empty($destination) ) {
+        } elseif ( empty($destination) ) {
           unset($destinations[$key]);
         }
       }
@@ -263,10 +263,10 @@ function seravo_edit_forwards() {
     if ( $old_source === '' && $new_source !== '' && ! empty($destinations) ) {
       // Create a new source (or replace)
       return create_forward($domain, $new_source, $destinations);
-    } else if ( $old_source !== '' && $new_source === '' && empty($destinations) ) {
+    } elseif ( $old_source !== '' && $new_source === '' && empty($destinations) ) {
       // Delete a source
       return delete_forward($domain, $old_source);
-    } else if ( $old_source !== '' && $new_source !== '' ) {
+    } elseif ( $old_source !== '' && $new_source !== '' ) {
       // Edit an existing source
       if ( $old_source === $new_source ) {
         // Don't modify the source

--- a/lib/seravo-postbox.php
+++ b/lib/seravo-postbox.php
@@ -191,7 +191,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
                     } elseif ( $custom_context === 'column4' ) {
                       $custom_context = 'side';
                     }
-                  } else if ( $column_count === 'one_column' ) {
+                  } elseif ( $column_count === 'one_column' ) {
                     if ( $custom_context !== 'normal' ) {
                       $custom_context = 'normal';
                     }
@@ -230,7 +230,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
       if ( $column_count === 'two_column' ) {
         $container_contexts = array( 'normal', 'side' );
-      } else if ( $column_count === 'one_column' ) {
+      } elseif ( $column_count === 'one_column' ) {
         $container_contexts = array( 'normal' );
       }
 
@@ -240,7 +240,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
       if ( $column_count === 'two_column' ) {
         $container_class = 'two-column-layout';
-      } else if ( $column_count === 'one_column' ) {
+      } elseif ( $column_count === 'one_column' ) {
         $container_class = 'one-column-layout';
       }
 

--- a/modules/passwords.php
+++ b/modules/passwords.php
@@ -69,7 +69,7 @@ if ( ! class_exists('Passwords') ) {
         return $redirect_to;
       }
       // Make the check every 3 months
-      $time_now = current_time('timestamp', true);
+      $time_now = time();
       $pwned_meta = get_user_meta($user->ID, 'seravo_pwned_check', true);
       if ( empty($pwned_meta) || $time_now - (int) $pwned_meta > 90 * DAY_IN_SECONDS ) {
         // Check if the password has been pwned

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -81,6 +81,9 @@
     <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped" />
     <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification" />
     <exclude name="WordPress.Security.NonceVerification" />
+
+    <!-- We have valid use cases for localized dates, so ingore this -->
+    <exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
   </rule>
 
 

--- a/scripts/install-phpcs.sh
+++ b/scripts/install-phpcs.sh
@@ -7,80 +7,21 @@
 set -e
 
 # Configuration for directories and versions
-PHPCS_DIR="${PHPCS_DIR:-"$HOME/.local/bin"}"
-PHPCS_VERSION="${PHPCS_VERSION:-"3.3.2"}"
-WP_SNIFFS_DIR="${WP_SNIFFS_DIR:-"$HOME/.local/phpcs-sniffs/wpcs"}"
-WP_SNIFFS_VERSION="${WP_SNIFFS_VERSION:-"2.1.0"}"
-SECURITY_SNIFFS_DIR="${SECURITY_SNIFFS_DIR:-"$HOME/.local/phpcs-sniffs/security"}"
-SECURITY_SNIFFS_VERSION="${SECURITY_SNIFFS_VERSION:-"2.0.1"}"
-PHP_COMPAT_SNIFFS_DIR="${PHP_COMPAT_SNIFFS_DIR:-"$HOME/.local/phpcs-sniffs/php-compatibility"}"
-PHP_COMPAT_SNIFFS_VERSION="${PHP_COMPAT_SNIFFS_VERSION:-"9.3.5"}"
+PHPCS_DIR="${PHPCS_DIR:-"$HOME/.local/php/CodeSniffer"}"
+BIN_DIR="${BIN_DIR:-"$HOME/.local/bin"}"
 
-# Install PHPCS
-if [ ! -f "${PHPCS_DIR}/phpcs" ] || [ "$1" = "-f" ]
-then
-  echo "--> Installing PHPCS..."
-  mkdir -p "${PHPCS_DIR}"
-  curl -sSL "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${PHPCS_VERSION}/phpcs.phar" -o "${PHPCS_DIR}/phpcs"
-  curl -sSL "https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${PHPCS_VERSION}/phpcbf.phar" -o "${PHPCS_DIR}/phpcbf"
-  chmod +x "${PHPCS_DIR}/phpcs" "${PHPCS_DIR}/phpcbf"
-else
-  echo "--> Binary '${PHPCS_DIR}/phpcs' already exists, aborting installation. If you wish to reinstall, please run the command again with the '-f' option..."
-fi
-
-# Install WordPress Coding Standards
-if [[ ! -d "${WP_SNIFFS_DIR}" || "$1" == "-f" ]]; then
-  echo "--> Installing WordPress coding standards..."
-  mkdir -p "${WP_SNIFFS_DIR}"
-  wget -q "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/${WP_SNIFFS_VERSION}.tar.gz" \
-       -O "${WP_SNIFFS_DIR}/${WP_SNIFFS_VERSION}.tar.gz"
-
-  tar -xf "${WP_SNIFFS_DIR}/${WP_SNIFFS_VERSION}.tar.gz" \
-      -C "${WP_SNIFFS_DIR}" \
-      --strip-components=1 \
-    && rm "${WP_SNIFFS_DIR}/${WP_SNIFFS_VERSION}.tar.gz"
-else
-  echo "--> Directory '${WP_SNIFFS_DIR}' already exists, aborting installation. If you wish to reinstall, please run the command again with the '-f' option..."
-fi
-
-# Install the security standards
-if [[ ! -d "${SECURITY_SNIFFS_DIR}" || "$1" == "-f" ]]; then
-  echo "--> Installing security sniffs..."
-  mkdir -p "${SECURITY_SNIFFS_DIR}"
-  wget -q "https://github.com/FloeDesignTechnologies/phpcs-security-audit/archive/${SECURITY_SNIFFS_VERSION}.tar.gz" \
-       -O "${SECURITY_SNIFFS_DIR}/${SECURITY_SNIFFS_VERSION}.tar.gz"
-
-  tar -xf "${SECURITY_SNIFFS_DIR}/${SECURITY_SNIFFS_VERSION}.tar.gz" \
-      -C "${SECURITY_SNIFFS_DIR}" \
-      --strip-components=1 \
-    && rm "${SECURITY_SNIFFS_DIR}/${SECURITY_SNIFFS_VERSION}.tar.gz"
-else
-  echo "--> Directory '${SECURITY_SNIFFS_DIR}' already exists, aborting installation. If you wish to reinstall, please run the command again with the '-f' option..."
-fi
-
-# Install the PHP compatibility standards
-if [[ ! -d "${PHP_COMPAT_SNIFFS_DIR}" || "$1" == "-f" ]]; then
-  echo "--> Installing PHP compatibility sniffs..."
-  mkdir -p "${PHP_COMPAT_SNIFFS_DIR}"
-  wget -q "https://github.com/PHPCompatibility/PHPCompatibility/archive/${PHP_COMPAT_SNIFFS_VERSION}.tar.gz" \
-       -O "${PHP_COMPAT_SNIFFS_DIR}/${PHP_COMPAT_SNIFFS_VERSION}.tar.gz"
-
-  tar -xf "${PHP_COMPAT_SNIFFS_DIR}/${PHP_COMPAT_SNIFFS_VERSION}.tar.gz" \
-      -C "${PHP_COMPAT_SNIFFS_DIR}" \
-      --strip-components=1 \
-    && rm "${PHP_COMPAT_SNIFFS_DIR}/${PHP_COMPAT_SNIFFS_VERSION}.tar.gz"
-else
-  echo "--> Directory '${PHP_COMPAT_SNIFFS_DIR}' already exists, aborting installation. If you wish to reinstall, please run the command again with the '-f' option..."
-fi
-
-# Activate sniffs
-echo "--> Activating installed sniffs..."
-"${PHPCS_DIR}/phpcs" --config-set installed_paths "${WP_SNIFFS_DIR},${SECURITY_SNIFFS_DIR},${PHP_COMPAT_SNIFFS_DIR}"
-if command -v phpenv; then
-  phpenv rehash
-fi
+mkdir -p "${PHPCS_DIR}" "${BIN_DIR}"
+curl -fsSL https://github.com/squizlabs/PHP_CodeSniffer/archive/3.5.5.tar.gz | tar xz --strip 1 -C "${PHPCS_DIR}"
+ln -sf "${PHPCS_DIR}/bin/phpcs" "${BIN_DIR}/phpcs"
+ln -sf "${PHPCS_DIR}/bin/phpcbf" "${BIN_DIR}/phpcbf"
+curl -fsSL https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip 1 -C "${PHPCS_DIR}/src/Standards"
+curl -fsSL https://github.com/FloeDesignTechnologies/phpcs-security-audit/archive/master.tar.gz | tar xz --strip 1 -C "${PHPCS_DIR}/src/Standards"
+curl -fsSL https://github.com/PHPCompatibility/PHPCompatibility/archive/master.tar.gz | tar xz --strip 1 -C "${PHPCS_DIR}/src/Standards"
+# Clean up cruft files left behind from unpacking tar packages
+find "${PHPCS_DIR}/src/Standards" -maxdepth 1 -type f -delete
+curl -fsSL https://raw.githubusercontent.com/PHPCompatibility/PHPCompatibility/master/PHPCSAliases.php -o "${PHPCS_DIR}/src/Standards/PHPCSAliases.php"
 
 # Show installed sniffs
-"${PHPCS_DIR}/phpcs" -i
+"${BIN_DIR}/phpcs" -i
 
 echo "Success: PHPCS has been installed to ${PHPCS_DIR}."


### PR DESCRIPTION
- Rewrite PHPCS installation script to be simpler and more of a direct
  copy of that in Seravo's development environments.

- Upgrade PHP CodeSniffer from 3.3.2 to 3.5.5 and fix the new issues it
  detected:

  * Update phpcs.xml to ignore date() warnings, since we on purpose want
    to show the localized time to users.

  * Run phpcbf to automatically fix a bunch of issues, including use
    time() instead of current_time('timestamp', true) as standard
    recommend. Both output the exact same thing:

```
      $ wp shell
      wp> current_time('timestamp', true);
      => int(1593535321)
      wp> time();
      => int(1593535324)
```
