### PR TITLE
Make Database pie chart a bit easier to read

### DIFF
--- a/js/reports-chart.js
+++ b/js/reports-chart.js
@@ -11,6 +11,8 @@ function generateChart(JSONdata) {
   });
   // Generate chart
   var ctx = document.getElementById('pie_chart');
+  ctx.height = 500;
+  ctx.width = 500;
   var myPieChart = new Chart(ctx, {
     type: 'pie',
     data: {
@@ -24,7 +26,7 @@ function generateChart(JSONdata) {
       ]
     },
     options: {
-      maintainAspectRatio: true,
+      maintainAspectRatio: false,
       resposive: true,
       tooltips: {
         callbacks: {

--- a/modules/database.php
+++ b/modules/database.php
@@ -220,7 +220,7 @@ if ( ! class_exists('Database') ) {
             <div id="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
             <pre><div id="seravo_wp_db_info"></div></pre>
             <div class="pie_container">
-              <canvas id="pie_chart" style="width: 10%; height: 4vh;"></canvas>
+              <canvas id="pie_chart"></canvas>
             </div>
           </p>
         </div>


### PR DESCRIPTION
Make the Database Size chart found under the Database page a bit larger especially on fullHD monitors since before it was really small.

This is a temporary measure to make the sizing even a bit better until a better solution is found.

Sizing not made perfect since there is issues in the upstream of chart.js. Relates: #380

Before:
![Screenshot from 2020-07-02 10-38-41](https://user-images.githubusercontent.com/44066308/86330440-5c4a4c00-bc50-11ea-9283-83dbe84d6829.png)

After:
![Screenshot from 2020-07-02 10-37-06](https://user-images.githubusercontent.com/44066308/86330636-a16e7e00-bc50-11ea-9511-e5d1b4293444.png)


