### PR TITLE
Redesign shadows box to table (Closes: #288 #277)

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -143,66 +143,67 @@ jQuery(document).ready(function($) {
     }
   });
 
-  $('#shadow-selector').change(function() {
-    var $shadow = $("[data-shadow=" + $(this).val() + "]");
-    if ($shadow) {
-      $('.shadow-row').addClass('shadow-hidden');
-      $shadow.removeClass('shadow-hidden');
-      $('#shadow-reset').prop('disabled', false);
-      $('#shadow-reset-status').html('');
-      update_data_gui();
-    }
-  });
-  $('.action-link').click(function(event) {
-    event.preventDefault();
-    if (! $(this).hasClass('closed')) {
-      $(this).addClass('closed');
-      $('#shadow-data-actions').addClass('shadow-hidden');
-    } else {
-      $(this).removeClass('closed');
-      $('#shadow-data-actions').removeClass('shadow-hidden');
-      update_data_gui();
-    }
-  });
-
-  function update_data_gui() {
-    var instance = $('#shadow-selector').val();
-    $('#shadow-reset-instance').html(instance);
-    var production_domain = $('input[name=shadow-reset-production]').val();
-    var shadow_domain = $('[data-shadow=' + instance + ']').attr('data-domain');
-    if (shadow_domain) {
-      $('input[name=shadow-reset-sr-from]').val(production_domain);
-      $('input[name=shadow-reset-sr-to]').val('://' + shadow_domain);
-      $('#shadow-reset-sr-alert').removeClass('shadow-hidden');
-      $('#shadow-reset-nosr-alert').addClass('shadow-hidden');
-    } else {
-      $('input[name=shadow-reset-sr-from]').val('');
-      $('input[name=shadow-reset-sr-to]').val('');
-      $('#shadow-reset-sr-alert').addClass('shadow-hidden');
-      $('#shadow-reset-nosr-alert').removeClass('shadow-hidden');
-    }
-    $('#shadow-reset').prop('disabled', false);
-    $('#shadow-reset-status').html('');
-  }
-
-  $('#shadow-reset').click(function(event) {
+  $('.reset').click(function(event) {
+    var shadow_id = $(this).closest('tbody').attr('id');
     var is_user_sure = confirm(seravo_site_status_loc.confirm);
     if ( ! is_user_sure) {
       return;
     }
-    seravo_ajax_reset_shadow($('#shadow-selector').val(),
-      function( status ){
+    // Hide any old alert messages
+    $('.alert').hide();
+    seravo_ajax_reset_shadow(shadow_id,
+      function( status ) {
         if ( status == 'progress' ) {
           event.target.disabled = true;
-          $('#shadow-reset-status').html("<img src=\"/wp-admin/images/spinner.gif\">");
+          // Select only row with a certain shadow id
+          $('#' + shadow_id).find('#shadow-reset-status').html("<img src=\"/wp-admin/images/spinner.gif\">");
         } else if ( status == 'success' ) {
-          $('#shadow-reset-status').html(seravo_site_status_loc.success);
+          $('#' + shadow_id).find('#shadow-reset-status').empty();
+          $('.alert#alert-success').show();
+          $('.closebtn').show();
+          // Check if the shadow has domains and show instructions to search-replace domain if necessary
+          var shadow_domain = $('#' + shadow_id).find('input[name=shadow-domain]').val();
+          if ( ! (shadow_domain.length === 0) ) {
+            $('.alert#alert-success').find('.shadow-reset-sr-alert').show();
+            $('#shadow-primary-domain').text(shadow_domain);
+          }
         } else if ( status == 'failure' ) {
-          $('#shadow-reset-status').html(seravo_site_status_loc.failure);
+          $('#' + shadow_id).find('#shadow-reset-status').empty();
+          $('.alert#alert-failure').show();
+          $('.closebtn').show();
         } else {
-          $('#shadow-reset-status').html(seravo_site_status_loc.error);
+          $('#' + shadow_id).find('#shadow-reset-status').empty();
+          $('.alert#alert-error').show();
+          $('.closebtn').show();
         }
-      });
+      }
+    );
+  });
+
+  $('.closebtn').click(function() {
+    $(this).parent().hide();
+  });
+
+  // Open/fold the row containing additional information
+  $('#shadow-table td.open-folded').on('click', function() {
+    // Get shadow id of the row's shadow
+    var shadow_id = $(this).closest('tbody').attr('id');
+    if ($('#' + shadow_id).find('.fold').hasClass('open')) {
+      // Fold row and turn icon
+      $('#' + shadow_id).find('.fold').removeClass('open');
+      $('#' + shadow_id + ' td.open-icon').addClass('closed-icon').removeClass('open-icon');
+    } else {
+      // Open row and turn icon
+      $('#' + shadow_id).find('.fold').addClass('open');
+      $('#' + shadow_id + ' td.closed-icon').addClass('open-icon').removeClass('closed-icon');
+      // Get production domain and shadow domain
+      var shadow_domain = $('#' + shadow_id).find('input[name=shadow-domain]').val();
+      // Show the right message depending whether the shadow needs search-replace after reset or not
+      // (whether it has domain or not)
+      if ( ! (shadow_domain.length === 0)) {
+        $('#' + shadow_id).find('.shadow-reset-sr-alert').removeClass('shadow-hidden');
+      }
+    }
   });
 
   function seravo_ajax_reset_shadow(shadow, animate) {

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -1,6 +1,45 @@
-#shadow-table th, #shadow-rs-table th {
+#shadow-table, .shadow-rs-table th {
   text-align: left;
   padding-right: 20px;
+  border-collapse: collapse;
+  /*table-layout: fixed;*/
+  width: 100%;
+}
+
+/* Keep 2nd, 3rd and 4th columns (Reset button, load icon and arrow icon) of shadows table
+   only the content width */
+   tr.view > td:nth-child(2), tr.view > td:nth-child(3), tr.view > td:nth-child(4) {
+  width:1%;
+  white-space: nowrap;
+}
+
+
+tr.view:hover {
+  background-color: #007CBA;
+  color: white;
+  transition: 0.5s;
+}
+
+th, td {
+  padding: 5px;
+}
+
+.fold {
+  display: none;
+}
+
+.open {
+  display: table-row;
+}
+
+.closed-icon span:before {
+  font: normal 13px/1 dashicons;
+  content: " \f347";
+}
+
+.open-icon span:before {
+  font: normal 13px/1 dashicons;
+  content: " \f343";
 }
 
 .shadow-row table th {
@@ -25,17 +64,6 @@
   padding-top: 10px;
 }
 
-.action-link span:before {
-  position: relative;
-  top: 1px;
-  font: normal 13px/1 dashicons;
-  content: " \f142";
-}
-
-.action-link.closed span:before {
-  content: " \f140";
-}
-
 #shadow-data-actions {
   padding: 15px;
 }
@@ -50,6 +78,47 @@
 
 #shadow-reset {
   margin: 0;
+}
+
+.alert {
+  display: none;
+  color: #FFFFFF;
+  border-radius: 2px;
+  margin-bottom: 10px;
+  padding: 10px;
+}
+
+.alert > p > a {
+  color: white;
+}
+
+.alert > p > a:hover {
+  color: #00A3E4;
+}
+
+.shadow-reset-sr-alert.alert {
+  padding: 0px;
+}
+
+#alert-success {
+  background-color: #6aa84f;
+}
+
+#alert-failure, #alert-error {
+  background-color: #cc0000;
+}
+
+.closebtn {
+  font-size: large;
+  color: white;
+  float: right;
+  background-color: transparent;
+  border: none;
+  padding: 10px;
+}
+
+.closebtn:hover {
+  color: black;
 }
 
 .seravo-cache-test-result-wrapper {


### PR DESCRIPTION
#### What are the main changes in this PR?
The items in shadows box are rearranged to a table and some of the instruction texts are updated.

Translations are not done.

##### Why are we doing this? Any context or related work?
Shadows box needed redesign to be more user friendly.
Issues: #288 #277

#### Manual testing steps?

1. Create a shadow (if you don't have one already)
2. Make changes to production site
3. Go to Tools --> Site Status --> Shadows
4. Select a shadow from table
5. Read shadow information
6. Click "Reset"
7. See that the shadow was reset from production

#### Screenshots
![Screenshot from 2020-07-03 13-19-28](https://user-images.githubusercontent.com/43380229/86459730-eddcbb00-bd2f-11ea-8b3e-4197d99379ec.png)
![Screenshot from 2020-07-03 13-20-37](https://user-images.githubusercontent.com/43380229/86459810-02b94e80-bd30-11ea-9c9f-a1df685f3ec5.png)
![Screenshot from 2020-07-03 13-21-06](https://user-images.githubusercontent.com/43380229/86459884-195fa580-bd30-11ea-85d5-626b71bdb437.png)
![Screenshot from 2020-07-03 13-21-55](https://user-images.githubusercontent.com/43380229/86459951-35634700-bd30-11ea-9258-fb701d9ecfa0.png)
![Screenshot from 2020-07-03 13-22-53](https://user-images.githubusercontent.com/43380229/86460028-57f56000-bd30-11ea-80bd-0f96a0554f7b.png)

