### PR TITLE
Fix dashicon align inside buttons (Closes: #386)

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -52,7 +52,7 @@ jQuery(document).ready(function($) {
                 month.date +
                 '.html" target="_blank" class="button hideMobile">' +
                 seravo_site_status_loc.view_report +
-                '<span aria-hidden="true" class="dashicons dashicons-external" style="line-height: unset; padding-left: 3px;"></span></a></td></tr>'
+                '<span aria-hidden="true" class="dashicons dashicons-external" style="line-height: 1.4; padding-left: 3px;"></span></a></td></tr>'
               );
             }
 

--- a/modules/database.php
+++ b/modules/database.php
@@ -167,7 +167,7 @@ if ( ! class_exists('Database') ) {
       <p class="adminer_button">
         <a href="<?php echo esc_url($adminer_url); ?>" class="button" target="_blank">
           <?php _e('Open Adminer', 'seravo'); ?>
-          <span aria-hidden="true" class="dashicons dashicons-external"></span>
+          <span aria-hidden="true" class="dashicons dashicons-external" style="line-height: 1.4; padding-left: 3px;"></span>
         </a>
       </p>
       <?php

--- a/style/database.css
+++ b/style/database.css
@@ -28,7 +28,7 @@
 }
 
 span.dashicons-external {
-  line-height: unset;
+  line-height: 1.4;
   padding-left: 3px;
 }
 


### PR DESCRIPTION
Set the vertical align of dashicon icons to middle so that they are inline with button text.

Now all buttons with icons are like the one at the bottom. Other ones are examples of the previous look.
![Screenshot from 2020-07-08 14-04-13](https://user-images.githubusercontent.com/44066308/86912606-f6fdcb80-c125-11ea-9c02-bbf1787db7ef.png)
