### PR TITLE
Show users with WP-CLI

### DIFF
--- a/modules/hide-users.php
+++ b/modules/hide-users.php
@@ -19,6 +19,10 @@ if ( ! class_exists('HideUsers') ) {
     }
 
     public static function hide_user_from_page( $user_query ) {
+        if ( defined('WP_CLI') ) {
+            return;
+        }
+
         $users_to_hide = self::$hidden_user_array;
         $current_user_name = wp_get_current_user()->user_login;
 


### PR DESCRIPTION
Add a condition to hidden users module so that hidden users are shown with WP-CLI commands.

For instance, `wp user list` now shows all users but the ones defined to be hidden, won't show up in the web front-end.

Improves user management in the command-line.