### PR TITLE
Enhance disk space postbox

### DIFF
--- a/js/reports-chart.js
+++ b/js/reports-chart.js
@@ -80,3 +80,112 @@ function generateChart(JSONdata) {
     }
   });
 }
+
+function generateDiskDonut(gauge, maximum) {
+  var available = Math.round(maximum - gauge);
+  var colors = ['#ef7c1a', '#47aedc'];
+
+  if (available < 0) {
+    var available = 0;
+    var colors = ['#cc0000'];
+    jQuery('#disk_use_notification').css("display", "block");
+  }
+
+  // Generate donut chart
+  var options = {
+    series: [Math.round(gauge), available],
+    colors: colors,
+    chart: {
+      type: 'donut',
+      height: 120,
+    },
+    labels: ['Used', 'Available'],
+    responsive: [{
+      breakpoint: 480
+    }],
+    legend: {
+      show: false
+    },
+    dataLabels: {
+      enabled: false,
+    }
+};
+
+  var chart = new ApexCharts(document.querySelector("#donut_single"), options);
+  chart.render();
+}
+
+function generateDiskBars(JSONdata) {
+  var data = [];
+  var labels = [];
+  var human_vals = [];
+
+  var axis = {
+    categories: labels,
+    axisBorder: {
+      show: false
+    },
+    axisTicks: {
+      show: false
+    },
+    labels: {
+      show: false
+    }
+  };
+
+  Object.keys(JSONdata).forEach(function( folder ) {
+    data.push(JSONdata[folder].percentage);
+    labels.push(folder);
+    human_vals.push(JSONdata[folder].human);
+  });
+
+  var options = {
+    series: [{
+      data: data
+    }],
+    colors: ['#44A1CB'],
+    chart: {
+      type: 'bar',
+      height: 420,
+      toolbar: {
+        show: false,
+      }
+    },
+    plotOptions: {
+      bar: {
+        horizontal: true,
+      }
+    },
+    dataLabels: {
+      enabled: true,
+      textAnchor: 'start',
+      style: {
+        colors: ['#444']
+      },
+      formatter: function (val, opt) {
+        return opt.w.globals.labels[opt.dataPointIndex] + ": " + human_vals[opt.dataPointIndex];
+      },
+      offsetX: 0,
+      dropShadow: {
+        enabled: false
+      }
+    },
+    xaxis: axis,
+    yaxis: axis,
+    grid: {
+      show: false,
+      padding: {
+       left: 0,
+       right: 0,
+       top: 0,
+       bottom: 0
+      }
+    },
+    tooltip: {
+      enabled: false
+    }
+  };
+
+  var chart = new ApexCharts(document.querySelector("#bars_single"), options);
+  chart.render();
+}

--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -74,8 +74,21 @@ jQuery(document).ready(function($) {
 
       if (section === 'folders_chart') {
         var allData = JSON.parse(rawData);
-        jQuery('#total_disk_usage').text(allData.data.human);
-        generateChart(allData.dataFolders);
+        // Calculate the used disk space; deduct the size of backups from the total
+        // space used. allData.data.size is in bytes, so divide into MB.
+        var used_disk = (allData.data.size - allData.dataFolders['/data/backups/'].size) / 1000000;
+
+        // Read plan's maximum disk space and transform into bytes
+        var max_disk = $("#maximum_disk_space").html() * 1000;
+
+        allData.dataFolders = Object.fromEntries(
+          Object.entries(allData.dataFolders)
+            .filter(([key]) => ! key.startsWith('/data/backups/'))
+        )
+
+        jQuery('#total_disk_usage').text(Math.round(used_disk) + 'MB');
+        generateDiskDonut(used_disk, max_disk);
+        generateDiskBars(allData.dataFolders);
       } else if (section === 'front_cache_status') {
         var data = JSON.parse(rawData);
         var data_joined = data['test_result'].join("\n");

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -126,12 +126,12 @@ if ( ! class_exists('Site_Status') ) {
     }
 
     public static function enqueue_site_status_scripts( $page ) {
-      wp_register_script('chart-js', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js', null, Helpers::seravo_plugin_version(), true);
+      wp_register_script('apexcharts-js', 'https://cdn.jsdelivr.net/npm/apexcharts', null, Helpers::seravo_plugin_version(), true);
       wp_register_script('seravo_site_status', plugin_dir_url(__DIR__) . '/js/sitestatus.js', '', Helpers::seravo_plugin_version());
       wp_register_style('seravo_site_status', plugin_dir_url(__DIR__) . '/style/sitestatus.css', '', Helpers::seravo_plugin_version());
       if ( $page === 'tools_page_site_status_page' ) {
         wp_enqueue_style('seravo_site_status');
-        wp_enqueue_script('chart-js');
+        wp_enqueue_script('apexcharts-js');
         wp_enqueue_script('color-hash', plugins_url('../js/color-hash.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
         wp_enqueue_script('reports-chart', plugins_url('../js/reports-chart.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
         wp_enqueue_script('seravo_site_status');
@@ -220,18 +220,49 @@ if ( ! class_exists('Site_Status') ) {
 
     public static function seravo_disk_usage() {
       ?>
-      <p><?php _e('The total size of <code>/data</code> is', 'seravo'); ?>
-      <div class="folders_chart_loading">
-        <img src="/wp-admin/images/spinner.gif">
-      </div>
-      <pre id="total_disk_usage"></pre>
+      <p id="disk_usage_heading">
+        <?php
+          $api_response = API::get_site_data();
+          if ( is_wp_error($api_response) ) {
+            die($api_response->get_error_message());
+          }
+          $max_disk = $api_response['plan']['disklimit']; // in GB
+        ?>
+        <div id="donut_single" style="width: 30%; float: right"></div>
+        <div class="disk_usage_desc">
+          <?php _e('Disk space in your plan: ', 'seravo'); ?>
+          <span id="maximum_disk_space"><?php echo $max_disk; ?></span>GB
+          <br>
+          <?php _e('Space in use: ', 'seravo'); ?>
+          <span id="total_disk_usage"></span>
+          <br>
+          <span id="disk_use_notification" style="display: none">
+            <?php _e('Disk space low! ', 'seravo'); ?>
+            <a href='https://help.seravo.com/article/280-seravo-plugin-site-status#diskusage' target='_BLANK'>
+              <?php _e('Read more.', 'seravo'); ?>
+            </a>
+          </span>
+        </div>
+        <div class="folders_chart_loading">
+          <img src="/wp-admin/images/spinner.gif">
+        </div>
       </p>
-      <p><?php _e('Disk usage by directory', 'seravo'); ?>
-      <div class="folders_chart_loading">
-        <img src="/wp-admin/images/spinner.gif">
-      </div>
-      <canvas id="pie_chart" style="width: 10%; height: 4vh;"></canvas>
+      <p>
+        <hr>
+        <br>
+        <b>
+          <?php _e('Disk usage by directory', 'seravo'); ?>
+        </b>
+        <div class="folders_chart_loading">
+          <img src="/wp-admin/images/spinner.gif">
+        </div>
+        <div class="pie_container">
+          <div id="bars_single" style="width: 100%"></div>
+        </div>
       </p>
+      <?php _e('Automatic backups don\'t count against your quota.', 'seravo'); ?>
+      <br>
+      <?php _e('Use <a href="tools.php?page=security_page">cruft remover</a> to remove unnecessary files.', 'seravo'); ?>
       <?php
     }
 

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -104,3 +104,14 @@
   color: inherit;
   text-decoration: none;
 }
+
+.disk_usage_desc {
+  display: block;
+  padding-top: 3vh;
+  height: 9vh;
+  width: 60%;
+}
+
+#disk_use_notification {
+  color: #cc0000;
+}


### PR DESCRIPTION
Use apexcharts.js for disk space postbox, implement a chart for total used disk space and redesign the per-directory chart.

Per-directory chart is now a bar chart that shows the size of certain directories listed in `sitestatus-ajax.php`.
The following logic is also followed:

- any directory under `/data` is shown
- all directories with size less than 1MB is not shown
- size of Seravo backups is not counted in the total used space nor is the directory listed in the bar chart

The donut chart for total disk use provides a simple view on how much of available space is used and the bar chart
provides a quick way to see what parts of the site take a lot of space.

### Screenshots
#### Main view
![Screenshot from 2020-07-13 11-39-42](https://user-images.githubusercontent.com/44066308/87283115-a3142d80-c4fd-11ea-8074-56d7312d584b.png)

#### When disk space is low
![Screenshot from 2020-07-13 11-37-48](https://user-images.githubusercontent.com/44066308/87283182-b58e6700-c4fd-11ea-80eb-d0ca663d6764.png)
