### PR TITLE
GUI for wp-backup-list-changes-since

### DIFF
--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -112,20 +112,13 @@ jQuery(document).ready(function($) {
   });
 
   jQuery(window).load(function(){
-    jQuery('.ba-slider').each(function(){
-      var cur = jQuery(this);
-      // Adjust the slider
-      var width = cur.width() + 'px';
-      cur.find('.ba-resize img').css('width', width);
-      // Bind dragging events
-      drags(cur.find('.ba-handle'), cur.find('.ba-resize'), cur);
-    });
-  
-    function seravo_load_change_report() {
+
+    function seravo_load_change_report(given_date) {
       jQuery.post(
         seravo_upkeep_loc.ajaxurl,
         { 'action': 'seravo_ajax_upkeep',
           'section': 'seravo_changes',
+          'date': given_date,
           'nonce': seravo_upkeep_loc.ajax_nonce },
         function(rawData) {
           if ( rawData.length == 0 ) {
@@ -135,20 +128,19 @@ jQuery(document).ready(function($) {
             var data = JSON.parse(rawData);
             var data_joined = data['output'].join("\n");
 
-            if ( data['rowCount'] === 0 ) {
+            if ( data['rowCount'] === '0' || data['rowCount'] === 0) {
               // No rows affected
               jQuery(this).html(seravo_upkeep_loc.no_affected_rows).fadeIn('slow');
-              jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
+              jQuery('#changes-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
             } else {
-
               jQuery(this).html(data['rowCount'] + " " + seravo_upkeep_loc.affected_rows).fadeIn('slow');
-              jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
+              jQuery('#changes-wrapper').css('border-left', 'solid 0.5em #038103');
             }
-  
+
             // Display the retrieved data and re-enable the run tests button
             jQuery('#seravo_changes').append(data_joined);
             jQuery('#run-changes-since').prop('disabled', false);
-  
+
             jQuery(this).fadeIn('slow', function() {
               jQuery('#seravo_changes_show_more_wrapper').fadeIn('slow');
             });
@@ -159,29 +151,36 @@ jQuery(document).ready(function($) {
         jQuery('#run-changes-since').prop('disabled', false);
       });
     }
-  
+
     jQuery('#run-changes-since').click(function() {
       jQuery('#seravo_changes').html('');
-      jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
+      jQuery('#changes-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
       jQuery('#seravo_changes_show_more_wrapper').hide();
-  
+
       if ( jQuery('#seravo_arrow_changes_show_more').hasClass('dashicons-arrow-up-alt2') ) {
         jQuery('#changes-result').hide(function() {
           jQuery('#seravo_arrow_changes_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
         });
       }
-  
+
       jQuery('#seravo_changes_status').fadeOut(400, function() {
         jQuery(this).html('<img src="/wp-admin/images/spinner.gif" style="display:inline-block"> ' + seravo_upkeep_loc.running_changes_since).fadeIn(400);
       });
-  
+
       jQuery(this).prop('disabled', true);
-      seravo_load_change_report();
+
+      var datepicker = new Date($('#datepicker').val());
+      var day = datepicker.getDate();
+      var month = datepicker.getMonth() + 1;
+      var year = datepicker.getFullYear();
+
+      var date = year+ "-"+ month+ "-"+ day;
+      seravo_load_change_report(date);
     });
-  
+
     jQuery('#seravo_changes_show_more').click(function(event) {
       event.preventDefault();
-  
+
       if ( jQuery('#seravo_arrow_changes_show_more').hasClass('dashicons-arrow-down-alt2') ) {
         jQuery('#changes-result').slideDown('fast', function() {
           jQuery('#seravo_arrow_changes_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
@@ -192,8 +191,8 @@ jQuery(document).ready(function($) {
         });
       }
     });
-  
-  }); 
+
+  });
 
   function insertEmail() {
     if (validateEmail($emailInput)) {
@@ -442,11 +441,11 @@ jQuery(window).load(function(){
           if ( data['exit_code'] === 0 ) {
             // No failures, if the return value from wp-test was 0
             jQuery(this).html(seravo_upkeep_loc.test_success).fadeIn('slow');
-            jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
+            jQuery('#tests-wrapper').css('border-left', 'solid 0.5em #038103');
           } else {
             // At least 1 failure, if the return value was non-zero
             jQuery(this).html(seravo_upkeep_loc.test_fail).fadeIn('slow');
-            jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
+            jQuery('#tests-wrapper').css('border-left', 'solid 0.5em #e74c3c');
           }
           // Display the retrieved data and re-enable the run tests button
           jQuery('#seravo_tests').append(data_joined);
@@ -465,7 +464,7 @@ jQuery(window).load(function(){
 
   jQuery('#run-wp-tests').click(function() {
     jQuery('#seravo_tests').html('');
-    jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
+    jQuery('#tests-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
     jQuery('#seravo_test_show_more_wrapper').hide();
 
     if ( jQuery('#seravo_arrow_show_more').hasClass('dashicons-arrow-up-alt2') ) {

--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -111,6 +111,90 @@ jQuery(document).ready(function($) {
     });
   });
 
+  jQuery(window).load(function(){
+    jQuery('.ba-slider').each(function(){
+      var cur = jQuery(this);
+      // Adjust the slider
+      var width = cur.width() + 'px';
+      cur.find('.ba-resize img').css('width', width);
+      // Bind dragging events
+      drags(cur.find('.ba-handle'), cur.find('.ba-resize'), cur);
+    });
+  
+    function seravo_load_change_report() {
+      jQuery.post(
+        seravo_upkeep_loc.ajaxurl,
+        { 'action': 'seravo_ajax_upkeep',
+          'section': 'seravo_changes',
+          'nonce': seravo_upkeep_loc.ajax_nonce },
+        function(rawData) {
+          if ( rawData.length == 0 ) {
+            jQuery('#seravo_changes').html(seravo_upkeep_loc.no_data);
+          }
+          jQuery('#seravo_changes_status').fadeOut('slow', function() {
+            var data = JSON.parse(rawData);
+            var data_joined = data['output'].join("\n");
+
+            if ( data['rowCount'] === 0 ) {
+              // No rows affected
+              jQuery(this).html(seravo_upkeep_loc.no_affected_rows).fadeIn('slow');
+              jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
+            } else {
+
+              jQuery(this).html(data['rowCount'] + " " + seravo_upkeep_loc.affected_rows).fadeIn('slow');
+              jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
+            }
+  
+            // Display the retrieved data and re-enable the run tests button
+            jQuery('#seravo_changes').append(data_joined);
+            jQuery('#run-changes-since').prop('disabled', false);
+  
+            jQuery(this).fadeIn('slow', function() {
+              jQuery('#seravo_changes_show_more_wrapper').fadeIn('slow');
+            });
+          });
+        }
+      ).fail(function() {
+        jQuery('#seravo_changes_status').html(seravo_upkeep_loc.run_fail);
+        jQuery('#run-changes-since').prop('disabled', false);
+      });
+    }
+  
+    jQuery('#run-changes-since').click(function() {
+      jQuery('#seravo_changes').html('');
+      jQuery('.seravo-test-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
+      jQuery('#seravo_changes_show_more_wrapper').hide();
+  
+      if ( jQuery('#seravo_arrow_changes_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+        jQuery('#changes-result').hide(function() {
+          jQuery('#seravo_arrow_changes_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+        });
+      }
+  
+      jQuery('#seravo_changes_status').fadeOut(400, function() {
+        jQuery(this).html('<img src="/wp-admin/images/spinner.gif" style="display:inline-block"> ' + seravo_upkeep_loc.running_changes_since).fadeIn(400);
+      });
+  
+      jQuery(this).prop('disabled', true);
+      seravo_load_change_report();
+    });
+  
+    jQuery('#seravo_changes_show_more').click(function(event) {
+      event.preventDefault();
+  
+      if ( jQuery('#seravo_arrow_changes_show_more').hasClass('dashicons-arrow-down-alt2') ) {
+        jQuery('#changes-result').slideDown('fast', function() {
+          jQuery('#seravo_arrow_changes_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+        });
+      } else if ( jQuery('#seravo_arrow_changes_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+        jQuery('#changes-result').hide(function() {
+          jQuery('#seravo_arrow_changes_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+        });
+      }
+    });
+  
+  }); 
+
   function insertEmail() {
     if (validateEmail($emailInput)) {
       emails.push($emailInput.val())
@@ -385,7 +469,7 @@ jQuery(window).load(function(){
     jQuery('#seravo_test_show_more_wrapper').hide();
 
     if ( jQuery('#seravo_arrow_show_more').hasClass('dashicons-arrow-up-alt2') ) {
-      jQuery('.seravo-test-result').hide(function() {
+      jQuery('#test-result').hide(function() {
         jQuery('#seravo_arrow_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
       });
     }
@@ -402,11 +486,11 @@ jQuery(window).load(function(){
     event.preventDefault();
 
     if ( jQuery('#seravo_arrow_show_more').hasClass('dashicons-arrow-down-alt2') ) {
-      jQuery('.seravo-test-result').slideDown('fast', function() {
+      jQuery('#test-result').slideDown('fast', function() {
         jQuery('#seravo_arrow_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
       });
     } else if ( jQuery('#seravo_arrow_show_more').hasClass('dashicons-arrow-up-alt2') ) {
-      jQuery('.seravo-test-result').hide(function() {
+      jQuery('#test-result').hide(function() {
         jQuery('#seravo_arrow_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
       });
     }

--- a/lib/upkeep-ajax.php
+++ b/lib/upkeep-ajax.php
@@ -118,10 +118,32 @@ function seravo_tests() {
 }
 
 function changes_since() {
-  // make sure that day_offset is formatted correctly
-  $day_offset = '2020-07-07';
-  $cmd = 'wp-backup-list-changes-since ' . $day_offset;
-  $result_count = exec($cmd . ' | wc -l');
+  $date = $_POST['date'];
+  $result_count = '';
+
+  // Try catch to check if the date is
+  try {
+    $formal_date = new DateTime($date);
+    unset($formal_date);
+  } catch ( Exception $e ) {
+    $datenow = getdate();
+    $y = $datenow['year'];
+    $m = $datenow['mon'];
+
+    if ( $datenow['mday'] >= 3 ) {
+      $d = $datenow['mday'] - 2;
+      $result_count = __('Invalid date, using 2 days offset <br><br>', 'seravo');
+    } else {
+      // Show since the month beginning
+      $d = 1;
+      $result_count = __('Invalid date, showing since month beginning <br><br>', 'seravo');
+    }
+
+    $date = $y . '-' . $m . '-' . $d;
+  }
+
+  $cmd = 'wp-backup-list-changes-since ' . $date;
+  $result_count .= exec($cmd . ' | wc -l');
   exec($cmd, $output);
 
   $return_array = array(
@@ -132,7 +154,7 @@ function changes_since() {
   return $return_array;
 }
 
-function seravo_ajax_upkeep() {
+function seravo_ajax_upkeep( $date ) {
   check_ajax_referer('seravo_upkeep', 'nonce');
   switch ( sanitize_text_field($_REQUEST['section']) ) {
     case 'seravo_change_php_version':

--- a/lib/upkeep-ajax.php
+++ b/lib/upkeep-ajax.php
@@ -117,6 +117,21 @@ function seravo_tests() {
   return $return_arr;
 }
 
+function changes_since() {
+  // make sure that day_offset is formatted correctly
+  $day_offset = '2020-07-07';
+  $cmd = 'wp-backup-list-changes-since ' . $day_offset;
+  $result_count = exec($cmd . ' | wc -l');
+  exec($cmd, $output);
+
+  $return_array = array(
+    'rowCount' => $result_count,
+    'output' => $output,
+  );
+
+  return $return_array;
+}
+
 function seravo_ajax_upkeep() {
   check_ajax_referer('seravo_upkeep', 'nonce');
   switch ( sanitize_text_field($_REQUEST['section']) ) {
@@ -150,6 +165,10 @@ function seravo_ajax_upkeep() {
 
     case 'seravo_tests':
       echo wp_json_encode(seravo_tests());
+      break;
+
+    case 'seravo_changes':
+      echo wp_json_encode(changes_since());
       break;
 
     default:

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -315,7 +315,7 @@ if ( ! class_exists('Upkeep') ) {
         which finds folder and file changes in backup data since the given date. For example if you have started to have issues on your site, you can
         track down what folders or files have changed.  
         
-         <p>Backups are stored for 30 days so it is advisable to use it as a maximum offset. </p>',
+         <p>Backups are stored for 30 days which is also the maximum since offset.  </p>',
         'seravo'
       );
 ?>

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -40,7 +40,7 @@ if ( ! class_exists('Upkeep') ) {
 
       seravo_add_postbox(
         'backup-list-changes',
-        __('Changes since', 'seravo'),
+        __('Changes Status', 'seravo'),
         array( __CLASS__, 'backup_list_changes' ),
         'tools_page_upkeep_page',
         'normal'
@@ -311,22 +311,25 @@ if ( ! class_exists('Upkeep') ) {
       <p>
       <?php
       _e(
-        'Here you can find folder and file changes since the given date. The tool shows if the file or folder has changed, 
-      created or deleted since the given date.',
+        'This tool can be used to run command <code>wp-backup-list-changes-since</code> 
+        which finds folder and file changes in backup data since the given date. For example if you have started to have issues on your site, you can
+        track down what folders or files have changed.  
+        
+         <p>Backups are stored for 30 days so it is advisable to use it as a maximum offset. </p>',
         'seravo'
       );
 ?>
 </p>
-      <?php _e('Choose a date', 'seravo'); ?> <input type='date'>
+      <?php _e('Choose a since date', 'seravo'); ?> <input type='date' id ='datepicker'>
       <p>
       <button id='run-changes-since' class='button-primary'><?php _e('Run', 'seravo'); ?></button>
     </p>
-      <div class="seravo-test-result-wrapper">
-        <div class="seravo-test-status" id="seravo_changes_status">
+      <div id="changes-wrapper" class="seravo-result-wrapper">
+        <div class="seravo-status" id="seravo_changes_status">
           <?php _e('Click "run" to see changes', 'seravo'); ?>
         </div>
-        <div id="changes-result" class="seravo-test-result">
-          <pre id="seravo_changes"></pre>
+        <div id="changes-result" class="seravo-result">
+          <pre id="seravo_changes" style="display: inline-block;"></pre>
         </div>
         <div id="seravo_changes_show_more_wrapper" class="hidden">
           <a href="" id="seravo_changes_show_more"><?php _e('Toggle Details', 'seravo'); ?>
@@ -655,11 +658,11 @@ if ( ! class_exists('Upkeep') ) {
         ?>
       </p>
       <button type="button" class="button-primary" id="run-wp-tests"><?php _e('Run Tests', 'seravo'); ?></button>
-      <div class="seravo-test-result-wrapper">
-        <div class="seravo-test-status" id="seravo_tests_status">
+      <div id="tests-wrapper" class="seravo-result-wrapper">
+        <div class="seravo-status" id="seravo_tests_status">
           <?php _e('Click "Run Tests" to run the Codeception tests', 'seravo'); ?>
         </div>
-        <div id="test-result" class="seravo-test-result">
+        <div id="test-result" class="seravo-result">
           <pre id="seravo_tests"></pre>
         </div>
         <div id="seravo_test_show_more_wrapper" class="hidden">

--- a/style/upkeep.css
+++ b/style/upkeep.css
@@ -182,7 +182,7 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
 }
 
 /* @TODO: Use classes here, not ID selectors, as we can have many similar elements */
-#seravo_test_show_more_wrapper {
+#seravo_test_show_more_wrapper, #seravo_changes_show_more_wrapper {
   -ms-transform: translateY(-50%);
   -webkit-transform: translateY(-50%);
   float: right;
@@ -197,7 +197,11 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
 #seravo_test_show_more,
 #seravo_test_show_more:hover,
 #seravo_test_show_more:active,
-#seravo_test_show_more:focus {
+#seravo_test_show_more:focus,
+#seravo_changes_show_more,
+#seravo_changes_show_more:hover,
+#seravo_changes_show_more:active,
+#seravo_changes_show_more:focus {
   box-shadow: none;
   color: inherit;
   text-decoration: none;

--- a/style/upkeep.css
+++ b/style/upkeep.css
@@ -148,7 +148,7 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
   padding-left: 18px;
 }
 
-.seravo-test-result-wrapper, .seravo-test-legacy-result-wrapper {
+.seravo-result-wrapper, .seravo-test-legacy-result-wrapper {
   -moz-transition: border 1s ease-in;
   -o-transition: border 1s ease-in;
   -webkit-transition: border 1s ease-in;
@@ -163,7 +163,7 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
   transition: border 1s ease-in;
 }
 
-.seravo-test-result, .seravo-test-legacy-result {
+.seravo-result, .seravo-test-legacy-result {
   box-shadow: 0 1px 1px 1px rgba(0,0,0,0.2);
   display: none;
   margin: 1em;
@@ -172,7 +172,7 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
   padding: 1em;
 }
 
-.seravo-test-status, .seravo-test-legacy-status {
+.seravo-status, .seravo-test-legacy-status {
   font-size: 15px;
   font-weight: bold;
   margin-top: 1.6em;


### PR DESCRIPTION
#### What are the main changes in this PR?
Adding GUI for wp-backup-list-changes-since command and thus providing customers an easy way to see file / folder modifications between backups. We've as well been discussing about bringing the backup restoring feature so this could potentially be one step towards that. Users can track down what have changed between backups and possibly use this to choose which backup they should restore. 

Translations are yet to be done. 

#### Why are we doing this? Any context or related work?
We've been discussing and planning this feature during the sprint. 

#### Screenshots
Here's the basic GUI
![Screenshot](https://user-images.githubusercontent.com/16706187/87282540-0ce00780-c4fd-11ea-938a-afef8d1b8be7.png)

After the run results / affected rows are shown in the toggle box. OBS, the rows affected shows now 5 rows since I modified HTML so this is no real bug. 
![Screenshot(1)](https://user-images.githubusercontent.com/16706187/87282737-3bf67900-c4fd-11ea-9574-8cf95b947e67.png)
