### PR TITLE
Add GUI for speed test

### DIFF
--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -227,3 +227,54 @@ function seravo_ajax_site_status() {
   wp_die();
 
 }
+
+function seravo_speed_test() {
+  check_ajax_referer('seravo_site_status', 'nonce');
+  // Take location for the speed test from the ajax call. If there is not one, use WP home
+  $url = isset($_POST['location']) ? get_home_url() . '/' . trim($_POST['location']) : get_home_url();
+
+  // Make sure there is one / at the end of the url
+  $url = rtrim($url, '/') . '/';
+
+  // use filter_var to make sure the resulting url is a valid url
+  if ( ! filter_var($url, FILTER_VALIDATE_URL) ) {
+    wp_send_json_error(__('Error: Invalid url', 'seravo'));
+  }
+
+  // Check whether to test cached version or not. Default not.
+  if ( isset($_POST['cached']) ) {
+    $cached = $_POST['cached'] === 'true' ? true : false;
+  } else {
+    $cached = false;
+  }
+
+  // Prepare curl settings which are same for all requests
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0); // equals the command line -k option
+
+  if ( ! $cached ) {
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'Pragma: no-cache' ));
+  }
+
+  $response = curl_exec($ch);
+  $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+  if ( curl_error($ch) || $httpcode !== 200 ) {
+    $error = __('Error! HTTP response code: ', 'seravo');
+    wp_send_json_error($error . $httpcode);
+  }
+  $curl_info_arr = curl_getinfo($ch);
+
+  $result= array(
+    $curl_info_arr['total_time'],
+    $curl_info_arr['namelookup_time'],
+    $curl_info_arr['connect_time'],
+    $curl_info_arr['pretransfer_time'],
+    $curl_info_arr['starttransfer_time'],
+  );
+
+  // abort if total duration already over 120 seconds?
+
+  wp_send_json_success($result);
+  wp_die();
+}

--- a/modules/speed-test.php
+++ b/modules/speed-test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Description: Adds Speed Test button to the WP admin bar
+ */
+
+namespace Seravo;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('Speed_Test') ) {
+  class Speed_Test {
+
+    public static function load() {
+      add_action('wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+      add_action('admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+      add_action('admin_bar_menu', array( __CLASS__, 'speed_test_button' ), 1001);
+    }
+
+    // Add speed test button to WP Admin Bar
+    public static function speed_test_button( $admin_bar ) {
+      $target_location = ltrim($_SERVER['REQUEST_URI'], '/');
+
+      if ( substr($target_location, 0, 9) === 'wp-admin/' ) {
+        $admin_bar->add_menu(
+          array(
+            'id'    => 'speed-test',
+            'title' => '<span class="ab-icon seravo-speed-test-icon"></span><span class="ab-label seravo-speed-test-text" title="' .
+              sprintf(__('Test the speed of the current page. Note: This does not function within wp-admin!', 'seravo')) . '">' . __('Speed Test', 'seravo') . '</span>',
+          )
+        );
+      } else {
+        $url = get_home_url() . '/wp-admin/tools.php?page=site_status_page&speed_test_target=' . $target_location;
+        $admin_bar->add_menu(
+          array(
+            'id'    => 'speed-test',
+            'title' => '<span class="ab-icon seravo-speed-test-icon"></span><span class="ab-label seravo-speed-test-text" title="' .
+            sprintf(__('Test the speed of the current page.', 'seravo')) . '">' . __('Speed Test', 'seravo') . '</span>',
+            'href'  => $url,
+          )
+        );
+      }
+    }
+
+    /**
+     * Load required scripts and styles for this module
+     */
+    public static function enqueue_scripts() {
+      wp_enqueue_style('seravo_speed_test', plugins_url('../style/speed-test.css', __FILE__), null, Helpers::seravo_plugin_version(), 'all');
+    }
+  }
+  /* Caching happens in general only in production */
+  if ( Helpers::is_production() ) {
+    Speed_Test::load();
+  }
+}

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -144,6 +144,11 @@ class Loader {
     require_once dirname(__FILE__) . '/modules/purge-cache.php';
 
     /*
+     * Add a speed test button to the WP adminbar
+     */
+    require_once dirname(__FILE__) . '/modules/speed-test.php';
+
+    /*
      * Hide the domain alias from search engines
      */
     require_once dirname(__FILE__) . '/modules/noindex-domain-alias.php';

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -236,3 +236,10 @@ th, td {
 .dashicons-info {
   color: #b1b2b3;
 }
+.speed_test_input {
+  width: 50%;
+}
+
+.speed_test_form {
+  padding: 10px;
+}

--- a/style/speed-test.css
+++ b/style/speed-test.css
@@ -1,0 +1,31 @@
+#wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon {
+  transform-origin: center center;
+}
+
+#wp-admin-bar-speed-test .ab-item:hover {
+  cursor: pointer;
+}
+
+#wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon:before {
+  content: "\f226";
+}
+
+#wpadminbar #wp-admin-bar-speed-test .spin {
+  animation: speed-test-spin 1.2s infinite;
+  animation-timing-function: linear;
+}
+
+@media screen and (max-width:782px) {
+  #wp-admin-bar-speed-test {
+    display: block !important;
+  }
+  #wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon {
+    margin-top: 0px;
+  }
+  #wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon:before {
+    height: 45px;
+    line-height: 53px;
+    top: -3px;
+    width: 52px;
+  }
+}


### PR DESCRIPTION
#### What are the main changes in this PR?

Under Tools -> Site Status there is now block for Speed Test to run tests to different urls within the wordpress site. The test runs multiple curl commands from within the server to see the speed of generating the html from php. The tests are run with both with and without cache enabled.

The chart uses ApexCharts library, which is the same library as the one used in #391. 

There is button in the wordpress admin bar to test the speed of current page using the above mentioned GUI.

#### Why are we doing this? Any context or related work?
Before the speed test was only available from the CLI. With this the feature is more easily available to more people.

#### Screenshots
The result chart of a successful speed test:
![pr 1](https://user-images.githubusercontent.com/45056796/87290856-356cff00-c507-11ea-8e12-d4aaa0002e41.jpg)

Button for the speed test in the admin bar:
![pr 2](https://user-images.githubusercontent.com/45056796/87291156-985e9600-c507-11ea-9a0f-21d78195e6e1.jpg)