### PR TITLE
Modify Cache Status postbox content to be more informative

### DIFF
--- a/js/cache-status-charts.js
+++ b/js/cache-status-charts.js
@@ -1,0 +1,115 @@
+function generateRedisHitChart(hits, misses) {
+
+  var options = {
+    series: [{
+      name: 'Keyspace hits',
+      data: [hits]
+    }, {
+      name: 'Keyspace misses',
+      data: [misses]
+    }],
+    chart: {
+      type: 'bar',
+      height: 150,
+      stacked: true,
+      stackType: '100%',
+      toolbar: {
+        show: false
+      }
+    },
+    plotOptions: {
+      bar: {
+        horizontal: true,
+      },
+    },
+    stroke: {
+      width: 1,
+      colors: ['#fff']
+    },
+    yaxis: {
+      show: false
+    },
+    tooltip: {
+      y: {
+        formatter: function (val) {
+          return val
+        }
+      },
+      x: {
+        show: false
+      }
+    },
+    fill: {
+      opacity: 1
+    },
+    legend: {
+      position: 'bottom',
+      horizontalAlign: 'left',
+      offsetX: 0
+    },
+    colors: ['#6aa84f', '#ef7c1a']
+  };
+
+  var redis_hit_chart = new ApexCharts(document.querySelector("#redis-hit-rate-chart"), options);
+  redis_hit_chart.render();
+};
+
+
+function generateHTTPHitChart(hits, misses, stales) {
+
+  var options = {
+    series: [{
+      name: 'Hits',
+      data: [hits]
+    }, {
+      name: 'Misses',
+      data: [misses]
+    }, {
+      name: 'Stales',
+      data: [stales]
+    }],
+    chart: {
+      type: 'bar',
+      height: 150,
+      stacked: true,
+      stackType: '100%',
+      toolbar: {
+        show: false
+      }
+    },
+    plotOptions: {
+      bar: {
+        horizontal: true,
+      },
+    },
+    stroke: {
+      width: 1,
+      colors: ['#fff']
+    },
+    yaxis: {
+      show: false
+    },
+    tooltip: {
+      y: {
+        formatter: function (val) {
+          return val
+        }
+      },
+      x: {
+        show: false
+      }
+    },
+    fill: {
+      opacity: 1
+    },
+    legend: {
+      position: 'bottom',
+      horizontalAlign: 'left',
+      offsetX: 0
+    },
+    colors: ['#6aa84f', '#ef7c1a', '#47aedc']
+  };
+
+  var http_hit_chart = new ApexCharts(document.querySelector("#http-hit-rate-chart"), options);
+  http_hit_chart.render();
+};

--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -107,7 +107,24 @@ jQuery(document).ready(function($) {
         jQuery(this).fadeIn('slow', function() {
           jQuery('.seravo_cache_test_show_more_wrapper').fadeIn('slow');
         });
-      } else {
+      } else if (section === 'redis_info') {
+        var data = JSON.parse(rawData);
+        var expired_keys = data[0];
+        var evicted_keys = data[1];
+        var keyspace_hits = data[2];
+        var keyspace_misses = data[3];
+        generateRedisHitChart(keyspace_hits, keyspace_misses);
+        jQuery('#redis-expired-keys').text(expired_keys);
+        jQuery('#redis-evicted-keys').text(evicted_keys);
+      } else if (section === 'longterm_cache') {
+        var data = JSON.parse(rawData);
+        var hits = data[0];
+        var misses = data[1];
+        var stales = data[2];
+        var bypasses = data[3];
+        generateHTTPHitChart(hits, misses, stales);
+        jQuery('#http-cache-bypass').text(bypasses);
+      } else {
         var data = JSON.parse(rawData);
         jQuery('#' + section).text(data.join("\n"));
       }

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -118,21 +118,11 @@ function seravo_report_redis_info() {
   $stats = $redis->info('stats');
 
   $result = array(
-    'Expired keys: ' . $stats['expired_keys'],
-    'Evicted keys: ' . $stats['evicted_keys'],
-    'Keyspace hits: ' . $stats['keyspace_hits'],
-    'Keyspace misses: ' . $stats['keyspace_misses'],
+    $stats['expired_keys'],
+    $stats['evicted_keys'],
+    $stats['keyspace_hits'],
+    $stats['keyspace_misses'],
   );
-
-  $hits = $stats['keyspace_hits'];
-  $misses = $stats['keyspace_misses'];
-
-  if ( isset($hits) && isset($misses) ) {
-    $total = $hits + $misses;
-    if ( $total > 0 ) {
-      array_push($result, 'Keyspace hit rate: ' . round(($hits / $total) * 100) . '%');
-    }
-  }
 
   return $result;
 }
@@ -163,17 +153,11 @@ function seravo_report_longterm_cache_stats() {
     }
   }
 
-  $all_misses = $hit + $miss + $stale;
-  if ( $all_misses == 0 ) {
-    $all_misses = 1;
-  }
-
   return array(
-    'Hits: ' . $hit,
-    'Misses: ' . $miss,
-    'Stales: ' . $stale,
-    'Bypasses: ' . $bypass,
-    'Hit rate: ' . round($hit / $all_misses * 100) . '%',
+    $hit,
+    $miss,
+    $stale,
+    $bypass,
   );
 }
 

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -184,3 +184,55 @@ th, td {
 #disk_use_notification {
   color: #cc0000;
 }
+
+#redis-hit-rate-chart,
+#http-hit-rate-chart {
+  margin-left: -15px;
+  margin-top: -30px;
+}
+
+.tooltip {
+  position: relative;
+  padding-left: 5px;
+  content: "\f348";
+}
+
+.tooltip .tooltiptext {
+  font-size: 0.6em;
+  visibility: hidden;
+  width: 130px;
+  background-color: #555555;
+  color: #fff;
+  text-align: center;
+  border-radius: 5px;
+  padding: 8px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -60px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  line-height: 1.3;
+  font-family: sans-serif;
+}
+
+.tooltip .tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555555 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}
+
+.dashicons-info {
+  color: #b1b2b3;
+}


### PR DESCRIPTION
#### What are the main changes in this PR?
Cache hit rates are presented with horizontal bar graphs.
Titles and instruction texts are rewritten. Some links to documentation and blog to help the user to interpret the provided values are added.

Translations are not done yet.

##### Why are we doing this? Any context or related work?
The content of Cache Status postbox has been hard to interpret and understand. The changes in this PR make the postbox content more approachable and provide the users links to external sources to learn more about the topic.

#### Manual testing steps?
1. Go to Tools --> Site status
2. Look at Cache Status postbox
3. Read the contents of the postbox
4.  Check the links
5. Hover your mouse over bar graphs and info-icons

#### Screenshots
![Screenshot from 2020-07-13 15-38-32](https://user-images.githubusercontent.com/43380229/87305315-f0ed5d80-c51e-11ea-95ba-da44409669eb.png)
