### PR TITLE
Adjust speed test button in adminbar

### DIFF
--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -566,13 +566,12 @@ if ( ! class_exists('Site_Status') ) {
 
     public static function speed_test() {
       $target_location = isset($_GET['speed_test_target']) ? $_GET['speed_test_target'] : '';
-      _e('Speed test measures the time how long it takes for PHP to produce the HTML output for the WordPress page.', 'seravo');
-      echo('<br><label for="speed_test_url" class="speed_test_form" for="sr-from"> ' . get_home_url() . '/</label> <input class="speed_test_input" type="text" id="speed_test_url" value="' . $target_location . '"><br>');
-      echo('<button type="button" class="button-primary" id="run-speed-test">' . __('Run Speed Test', 'seravo') . '</button>');
+      echo ('<p>' . __('Speed test measures the time how long it takes for PHP to produce the HTML output for the WordPress page.', 'seravo') . '</p>');
+      echo('<br><label for="speed_test_url" class="speed_test_form" for="sr-from"> ' . get_home_url() . '/</label> <input class="speed_test_input" type="text" placeholder="Front Page by Default" id="speed_test_url" value="' . $target_location . '"><br>');
+      echo('<button type="button" class="button-primary" id="run-speed-test">' . __('Run Test', 'seravo') . '</button>');
       echo('<div id="speed-test-results"></div>');
       echo('<div id="speed-test-error"></div>');
     }
-
 
   }
 

--- a/modules/speed-test.php
+++ b/modules/speed-test.php
@@ -22,22 +22,32 @@ if ( ! class_exists('Speed_Test') ) {
     // Add speed test button to WP Admin Bar
     public static function speed_test_button( $admin_bar ) {
       $target_location = ltrim($_SERVER['REQUEST_URI'], '/');
+      $url = get_home_url() . '/wp-admin/tools.php?page=site_status_page';
 
       if ( substr($target_location, 0, 9) === 'wp-admin/' ) {
         $admin_bar->add_menu(
           array(
-            'id'    => 'speed-test',
-            'title' => '<span class="ab-icon seravo-speed-test-icon"></span><span class="ab-label seravo-speed-test-text" title="' .
-              sprintf(__('Test the speed of the current page. Note: This does not function within wp-admin!', 'seravo')) . '">' . __('Speed Test', 'seravo') . '</span>',
+            'id'    => 'speed-test-blocked',
+            'title' => '<span class="ab-icon seravo-speed-test-icon blocked"></span><span class="ab-label seravo-speed-test-text blocked">' .
+              __('Speed Test', 'seravo') . '</span>',
+          )
+        );
+
+        $admin_bar->add_menu(
+          array(
+            'parent'  => 'speed-test-blocked',
+            'id'      => 'speed-test-menu',
+            'title'   => 'Speedtest cannot be run for wp-admin pages',
           )
         );
       } else {
-        $url = get_home_url() . '/wp-admin/tools.php?page=site_status_page&speed_test_target=' . $target_location;
+        $url .= '&speed_test_target=' . $target_location;
         $admin_bar->add_menu(
           array(
             'id'    => 'speed-test',
-            'title' => '<span class="ab-icon seravo-speed-test-icon"></span><span class="ab-label seravo-speed-test-text" title="' .
-            sprintf(__('Test the speed of the current page.', 'seravo')) . '">' . __('Speed Test', 'seravo') . '</span>',
+            'title' => '<span class="ab-icon seravo-speed-test-icon title="derp"></span><span class="ab-label seravo-speed-test-text" title="' .
+              __('Test the speed of the current page', 'seravo') . '">' .
+              __('Speed Test', 'seravo') . '</span>',
             'href'  => $url,
           )
         );

--- a/style/speed-test.css
+++ b/style/speed-test.css
@@ -10,22 +10,18 @@
   content: "\f226";
 }
 
-#wpadminbar #wp-admin-bar-speed-test .spin {
-  animation: speed-test-spin 1.2s infinite;
-  animation-timing-function: linear;
+#wpadminbar #wp-admin-bar-speed-test-blocked .ab-item .seravo-speed-test-icon:before {
+  content: "\f226";
 }
 
-@media screen and (max-width:782px) {
-  #wp-admin-bar-speed-test {
-    display: block !important;
-  }
-  #wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon {
-    margin-top: 0px;
-  }
-  #wpadminbar #wp-admin-bar-speed-test .ab-item .seravo-speed-test-icon:before {
-    height: 45px;
-    line-height: 53px;
-    top: -3px;
-    width: 52px;
-  }
+#wpadminbar #wp-admin-bar-speed-test-blocked .ab-item .seravo-speed-test-icon {
+  transform-origin: center center;
+}
+
+#wp-admin-bar-speed-test-blocked .ab-item:hover {
+  cursor: default;
+}
+
+#wp-admin-bar-speed-test-menu .ab-item:hover {
+  cursor: default;
 }


### PR DESCRIPTION
Speed test button is changed to lead to the site status page where the speed test is. Added an explanation text to the speed test block to say that the test can not be ran within wp-admin.

Closes #398