### PR TITLE
Do not limit the number of shown large dirs and fix styling

### DIFF
--- a/js/reports-chart.js
+++ b/js/reports-chart.js
@@ -146,7 +146,7 @@ function generateDiskBars(JSONdata) {
     colors: ['#44A1CB'],
     chart: {
       type: 'bar',
-      height: 420,
+      height: labels.length * 40,
       toolbar: {
         show: false,
       }
@@ -154,6 +154,9 @@ function generateDiskBars(JSONdata) {
     plotOptions: {
       bar: {
         horizontal: true,
+        dataLabels: {
+          position: 'bottom',
+        },
       }
     },
     dataLabels: {
@@ -182,7 +185,12 @@ function generateDiskBars(JSONdata) {
       }
     },
     tooltip: {
-      enabled: false
+      enabled: true,
+      custom: function({series, seriesIndex, dataPointIndex, w}) {
+        return '<div class="arrow_box">' +
+          '<span>' + w.globals.labels[dataPointIndex] + ": " + human_vals[dataPointIndex] + '</span>' +
+          '</div>'
+      },
     }
   };
 

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -52,7 +52,7 @@ function seravo_report_folders() {
   // size larger than $dir_threshold
   exec(
     '(
-    du --separate-dirs -b --threshold=' . $dir_threshold . ' /data/*/ | head -n 5 &&
+    du --separate-dirs -b --threshold=' . $dir_threshold . ' /data/*/ &&
     du -sb /data/wordpress/htdocs/wp-content/uploads/ &&
     du -sb /data/wordpress/htdocs/wp-content/themes/ &&
     du -sb /data/wordpress/htdocs/wp-content/plugins/ &&

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -288,10 +288,11 @@ if ( ! class_exists('Site_Status') ) {
         <div class="folders_chart_loading">
           <img src="/wp-admin/images/spinner.gif">
         </div>
-        <div class="pie_container">
+        <div class="bars_container">
           <div id="bars_single" style="width: 100%"></div>
         </div>
       </p>
+      <hr>
       <?php _e('Automatic backups don\'t count against your quota.', 'seravo'); ?>
       <br>
       <?php _e('Use <a href="tools.php?page=security_page">cruft remover</a> to remove unnecessary files.', 'seravo'); ?>

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -243,3 +243,15 @@ th, td {
 .speed_test_form {
   padding: 10px;
 }
+
+.bars_container {
+  max-height: 700px;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  padding-right: 15px;
+}
+
+.arrow_box {
+  font-size: 11px;
+  padding: 3px;
+}


### PR DESCRIPTION
Before only 5 of the largest directories were included in the chart. Remove this limit because there is no reason to have it in place and users cannot see all the culprits for low disk space. Since now the number of directories can be really big, there is now a wrapper that makes the list scrollable if it becomes too large. The dir names can be really long, so they are now aligned so far to the left as possible. Because of the scroll bar, dir paths didn't always fit the screen very well and were cut off. Apex Charts tooltips have been enabled and configured now.

**Just a few dirs**
![Screenshot from 2020-07-15 11-34-24](https://user-images.githubusercontent.com/44066308/87523116-2618bd80-c68f-11ea-9870-237148edf711.png)


**Tons of dirs**
![Screenshot from 2020-07-15 11-33-04](https://user-images.githubusercontent.com/44066308/87523130-2ca73500-c68f-11ea-8212-90924e7d5d22.png)

Test dirs were created with
```
$ wget https://speed.hetzner.de/100MB.bin
$ for i in {1..50}; do mkdir d$i ; done
$ for i in {1..50}; do cp 100MB.bin d$i/tiedosto ; done
```