### PR TITLE
Use a bar chart as database chart (Closes: #397)

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function($) {
         jQuery('#sr-button').prop('disabled', false);
       }
     ).fail(function () {
-      jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
+      jQuery('.' + section + '_loading').html('Failed to load. Please try again.');
     });
   }
 
@@ -100,14 +100,14 @@ jQuery(document).ready(function($) {
         var data = JSON.parse(rawData);
         if (section === 'seravo_wp_db_info') {
           jQuery('#seravo_wp_db_info').append(data.totals);
-          generateChart(data.tables.data_folders);
+          generateDatabaseBars(data.tables.data_folders);
         } else {
           jQuery('#' + section).text(data.join("\n"));
         }
-        jQuery('#' + section + '_loading').fadeOut();
+        jQuery('.' + section + '_loading').fadeOut();
       }
     ).fail(function () {
-      jQuery('#' + section + '_loading').html('Failed to load. Please try again.');
+      jQuery('.' + section + '_loading').html('Failed to load. Please try again.');
     });
   }
 

--- a/modules/database.php
+++ b/modules/database.php
@@ -81,11 +81,11 @@ if ( ! class_exists('Database') ) {
     public static function enqueue_database_scripts( $page ) {
 
       wp_register_style('seravo_database', plugin_dir_url(__DIR__) . '/style/database.css', '', Helpers::seravo_plugin_version());
-      wp_register_script('chart-js', 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js', '', Helpers::seravo_plugin_version(), true);
+      wp_register_script('apexcharts-js', 'https://cdn.jsdelivr.net/npm/apexcharts', '', Helpers::seravo_plugin_version(), true);
 
       if ( $page === 'tools_page_database_page' ) {
         wp_enqueue_style('seravo_database');
-        wp_enqueue_script('chart-js');
+        wp_enqueue_script('apexcharts-js');
         wp_enqueue_script('color-hash', plugins_url('../js/color-hash.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
         wp_enqueue_script('reports-chart', plugins_url('../js/reports-chart.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
         wp_enqueue_script('seravo_database', plugins_url('../js/database.js', __FILE__), array( 'jquery' ), Helpers::seravo_plugin_version(), false);
@@ -217,10 +217,15 @@ if ( ! class_exists('Database') ) {
       <?php if ( exec('which wp') ) : ?>
         <div class="section_chart_mobile">
           <p>
-            <div id="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
-            <pre><div id="seravo_wp_db_info"></div></pre>
-            <div class="pie_container">
-              <canvas id="pie_chart" style="width: 10%; height: 4vh;"></canvas>
+            <div class="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
+            <div id="seravo_wp_db_info"></div>
+            <hr>
+            <b>
+              <?php _e('Table sizes', 'seravo'); ?>
+            </b>
+            <div class="seravo_wp_db_info_loading"><img src="/wp-admin/images/spinner.gif"></div>
+            <div class="chart_container">
+              <div id="bars_single"></div>
             </div>
           </p>
         </div>

--- a/style/database.css
+++ b/style/database.css
@@ -52,12 +52,6 @@ span.dashicons-external {
 }
 
 @media only screen and (max-width: 376px) {
-  .pie_container {
-    margin: -90px;
-    overflow-wrap: break-word;
-    padding-top: 90px;
-    white-space: pre-line;
-  }
   .section_chart_mobile {
     padding-bottom: 25%;
   }
@@ -66,4 +60,17 @@ span.dashicons-external {
     margin: auto;
     width: 253px!important;
   }
+}
+
+.chart_container {
+  overflow-y: scroll;
+  overflow-x: hidden;
+  max-height: 800px;
+  white-space: pre-line;
+  padding-right: 15px;
+}
+
+.arrow_box {
+  font-size: 11px;
+  padding: 3px;
 }


### PR DESCRIPTION
Change database chart library to Apex Charts.
Use a bar chart instead of a pie chart.

If there are many plugins, for instance, the number of database tables can be really big,
so there is now a wrapper that makes the list scrollable if the number becomes too large.

Database table names are also aligned as far left as Apex Charts allows because table names can be long and be cut off.
Because of possible long names and the scroll bar introduced in this commit, there are now Apex Charts tooltips that have
the same information as the bar themselves.

The bar chart is clean and I don't think there is need for other types of visual elements here.

The chart provides an easy way to see which tables are the largest and shows the exact size of all of them.

![Screenshot from 2020-07-16 10-31-45](https://user-images.githubusercontent.com/44066308/87640580-95ee7d00-c74f-11ea-8130-79f93b093943.png)

