### PR TITLE
Make chart legends non toggleable

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -137,6 +137,11 @@ jQuery(document).ready(function($) {
               }
           }
       },
+      legend: {
+        onItemClick: {
+          toggleDataSeries: false
+        },
+      }
   };
 
     speedChart = new ApexCharts(document.querySelector("#speed-test-results"), options);


### PR DESCRIPTION
Turning off either of the legends while the speed test is running breaks the apex chart.

Making them non-toggleable fixes this issue.

Closes #402
