### PR TITLE
Cache status chart texts to translation

### DIFF
--- a/js/cache-status-charts.js
+++ b/js/cache-status-charts.js
@@ -2,10 +2,10 @@ function generateRedisHitChart(hits, misses) {
 
   var options = {
     series: [{
-      name: 'Keyspace hits',
+      name: seravo_site_status_loc.keyspace_hits,
       data: [hits]
     }, {
-      name: 'Keyspace misses',
+      name: seravo_site_status_loc.keyspace_misses,
       data: [misses]
     }],
     chart: {
@@ -59,13 +59,13 @@ function generateHTTPHitChart(hits, misses, stales) {
 
   var options = {
     series: [{
-      name: 'Hits',
+      name: seravo_site_status_loc.hits,
       data: [hits]
     }, {
-      name: 'Misses',
+      name: seravo_site_status_loc.misses,
       data: [misses]
     }, {
-      name: 'Stales',
+      name: seravo_site_status_loc.stales,
       data: [stales]
     }],
     chart: {

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -162,9 +162,13 @@ if ( ! class_exists('Site_Status') ) {
           'avg_cached_latency'  => __('Avg cached latency: ', 'seravo'),
           'latency'             => __('Latency', 'seravo'),
           'cached_latency'      => __('Cached latency', 'seravo'),
+          'keyspace_hits'       => __('Keyspace hits', 'seravo'),
+          'keyspace_misses'     => __('Keyspace misses', 'seravo'),
+          'hits'                => __('Hits', 'seravo'),
+          'misses'              => __('Misses', 'seravo'),
+          'stales'              => __('Stales', 'seravo'),
           'ajaxurl'             => admin_url('admin-ajax.php'),
           'ajax_nonce'          => wp_create_nonce('seravo_site_status'),
-
         );
         wp_localize_script('seravo_site_status', 'seravo_site_status_loc', $loc_translation);
       }


### PR DESCRIPTION
#### What are the main changes in this PR?
The texts of cache status charts are added for translation.

##### Why are we doing this? Any context or related work?
All texts in plugin should be translated in Finnish.
