### PR TITLE
Enhance seravo-result-wrapper to have width based on it's parent width

### DIFF
--- a/style/upkeep.css
+++ b/style/upkeep.css
@@ -157,7 +157,6 @@ form[name="seravo_updates_form"].has-errors > .technical_contacts_input {
   box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.12);
   display: block;
   margin-top: 2em;
-  max-width: 55em;
   min-height: 5em;
   overflow: hidden;
   transition: border 1s ease-in;


### PR DESCRIPTION
#### What are the main changes in this PR?
Add a small fix for seravo-result-wrapper having max-width which causes some misconformt on bigger screens. This also enhances the whole view since now the free space is used more effectively. 

#### Screenshots
The current setup is that the max-width is defined
![Screenshot](https://user-images.githubusercontent.com/16706187/87760254-27292680-c818-11ea-8cf5-d65d6f88228e.png)
After the fix seravo-result-wrapper class should have the width based on it's parent width
![better](https://user-images.githubusercontent.com/16706187/87760262-28f2ea00-c818-11ea-97b2-661b1b12daa9.png)
