### PR TITLE
Fix and improve disk chart

### DIFF
--- a/js/reports-chart.js
+++ b/js/reports-chart.js
@@ -81,7 +81,7 @@ function generateChart(JSONdata) {
   });
 }
 
-function generateDiskDonut(gauge, maximum) {
+function generateDiskDonut(gauge, maximum, unit) {
   var available = Math.round(maximum - gauge);
   var colors = ['#ef7c1a', '#47aedc'];
 
@@ -99,7 +99,7 @@ function generateDiskDonut(gauge, maximum) {
       type: 'donut',
       height: 120,
     },
-    labels: ['Used', 'Available'],
+    labels: [seravo_site_status_loc.used, seravo_site_status_loc.available],
     responsive: [{
       breakpoint: 480
     }],
@@ -108,6 +108,17 @@ function generateDiskDonut(gauge, maximum) {
     },
     dataLabels: {
       enabled: false,
+    },
+    tooltip: {
+      enabled: true,
+      x: {
+        show: false
+      },
+      y: {
+        formatter: function(value){
+          return value.toString() + unit;
+        }
+      },
     }
 };
 

--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -258,20 +258,15 @@ jQuery(document).ready(function($) {
 
       if (section === 'folders_chart') {
         var allData = JSON.parse(rawData);
-        // Calculate the used disk space; deduct the size of backups from the total
-        // space used. allData.data.size is in bytes, so divide into MB.
-        var used_disk = (allData.data.size - allData.dataFolders['/data/backups/'].size) / 1000000;
+        // Calculate the used disk space;
+        // allData.data.size is in bytes, so divide into MB
+        var used_disk = (allData.data.size) / 1000000;
 
         // Read plan's maximum disk space and transform into bytes
         var max_disk = $("#maximum_disk_space").html() * 1000;
 
-        allData.dataFolders = Object.fromEntries(
-          Object.entries(allData.dataFolders)
-            .filter(([key]) => ! key.startsWith('/data/backups/'))
-        )
-
         jQuery('#total_disk_usage').text(Math.round(used_disk) + 'MB');
-        generateDiskDonut(used_disk, max_disk);
+        generateDiskDonut(used_disk, max_disk, "MB");
         generateDiskBars(allData.dataFolders);
       } else if (section === 'front_cache_status') {
         var data = JSON.parse(rawData);

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -167,6 +167,8 @@ if ( ! class_exists('Site_Status') ) {
           'hits'                => __('Hits', 'seravo'),
           'misses'              => __('Misses', 'seravo'),
           'stales'              => __('Stales', 'seravo'),
+          'used'                => __('Used', 'seravo'),
+          'available'           => __('Available', 'seravo'),
           'ajaxurl'             => admin_url('admin-ajax.php'),
           'ajax_nonce'          => wp_create_nonce('seravo_site_status'),
         );
@@ -297,7 +299,7 @@ if ( ! class_exists('Site_Status') ) {
         </div>
       </p>
       <hr>
-      <?php _e('Automatic backups don\'t count against your quota.', 'seravo'); ?>
+      <?php _e('Logs and automatic backups don\'t count against your quota.', 'seravo'); ?>
       <br>
       <?php _e('Use <a href="tools.php?page=security_page">cruft remover</a> to remove unnecessary files.', 'seravo'); ?>
       <?php


### PR DESCRIPTION
The total disk space donut chart only had number values on the tooltips. Since they are always in MB, add the MB sign after the values.

Fixed the logic of calculating the used disk space and showing certain directories. Now directories are shown with the following logic:
- certain directories are always fetched
- directories with more than 100MB are always fetched

But there are directories the sizes of which are not counted in total usage:
- /data/backups
- /data/log
- /data/slog

Also, content of /data/backups are never shown even if their sizes exceed the 100M threshold.

This means the total disk usage is the size of /data minus the three dirs listed above.
