### PR TITLE
Fix strings to match all relevant total access log rows

### DIFF
--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -140,13 +140,14 @@ function seravo_report_longterm_cache_stats() {
     if ( $file ) {
       while ( ! feof($file) ) {
         $line = fgets($file);
-        if ( strpos($line, '"Seravo" HIT') ) {
+        // " is needed to match the log file
+        if ( strpos($line, '" HIT') ) {
           $hit++;
-        } elseif ( strpos($line, '"Seravo" MISS') ) {
+        } elseif ( strpos($line, '" MISS') ) {
           $miss++;
-        } elseif ( strpos($line, '"Seravo" STALE') ) {
+        } elseif ( strpos($line, '" STALE') ) {
           $stale++;
-        } elseif ( strpos($line, '"Seravo" BYPASS') ) {
+        } elseif ( strpos($line, '" BYPASS') ) {
           $bypass++;
         }
       }


### PR DESCRIPTION
#### What are the main changes in this PR?
Strings are fixed to match all log rows instead of just rows with string "Seravo".

##### Why are we doing this? Any context or related work?
Before, only the total access log rows with text "Seravo" were matched. However, all the rows with relevant data should be matched to get the real HTTP hit rate.