### PR TITLE
Enhance wp-test result by removing excessive characters

### DIFF
--- a/lib/upkeep-ajax.php
+++ b/lib/upkeep-ajax.php
@@ -110,6 +110,11 @@ function check_php_config_files() {
 
 function seravo_tests() {
   exec('wp-test', $output, $return_variable);
+
+  // Filter out command prompt stylings
+  $pattern = '/\x1b\[[0-9;]*m/';
+  $output = preg_replace($pattern, '', $output);
+
   $return_arr = array(
     'test_result' => $output,
     'exit_code' => $return_variable,


### PR DESCRIPTION
#### What are the main changes in this PR?
Currently style format codes are produced when running wp-test on Seravo Plugin. I have implemented a regex replace together with @sjaks to remove these excessive styling character codes. 

For instance, section Acceptance Tests had these "[1m" formatting characters:
[1mAcceptance Tests (2) [22m---------------------------------------
