### PR TITLE
Remove speed test button from normal users

### DIFF
--- a/modules/speed-test.php
+++ b/modules/speed-test.php
@@ -14,9 +14,16 @@ if ( ! class_exists('Speed_Test') ) {
   class Speed_Test {
 
     public static function load() {
-      add_action('wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
-      add_action('admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
-      add_action('admin_bar_menu', array( __CLASS__, 'speed_test_button' ), 1001);
+      // Check permissions before registering actions
+      if ( current_user_can(self::custom_capability()) ) {
+        add_action('wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+        add_action('admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ));
+        add_action('admin_bar_menu', array( __CLASS__, 'speed_test_button' ), 1001);
+      }
+    }
+
+    public static function custom_capability() {
+      return apply_filters('seravo_speed_test_capability', 'edit_posts');
     }
 
     // Add speed test button to WP Admin Bar


### PR DESCRIPTION
Check that user has access in same way as it's done with purge cache and shadow instance switcher.

Closes #411