### PR TITLE
Show user last login for subscribers too on profile page (Closes: #7)

### DIFF
--- a/modules/login-notification.php
+++ b/modules/login-notification.php
@@ -22,6 +22,7 @@ if ( ! class_exists('Login_Notifications') ) {
 
     public static function load() {
       add_action('load-index.php', array( __CLASS__, 'retrieve_notification_data' ));
+      add_action('load-profile.php', array( __CLASS__, 'retrieve_notification_data' ));
     }
 
     /**


### PR DESCRIPTION
#### What are the main changes in this PR?
Add hook for showing last login notification on profile page. Subscribers are normally redirected to their profile page after they login to wp-admin. Last login will be shown for them too.

##### Why are we doing this? Any context or related work?
Related issue #7 
