### PR TITLE
Show more details about database tables (Closes: #163)

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -98,6 +98,72 @@ jQuery(document).ready(function($) {
           jQuery('#' + section).html('No data returned for section.');
         }
         var data = JSON.parse(rawData);
+
+        jQuery.each(data["details"]["long_postmeta_values"], function(index, table) {
+          $('<tr>').append(
+            $('<td>').text(table["meta_key"]),
+            $('<td>').text(table["meta_value_length"])
+          ).appendTo('#long_postmeta_values');
+        });
+
+        jQuery.each(data["details"]["cumulative_postmeta_sizes"], function(index, table) {
+          $('<tr>').append(
+            $('<td>').text(table["meta_key"]),
+            $('<td>').text(table["length_sum"])
+          ).appendTo('#cumulative_postmeta_sizes');
+        });
+
+        jQuery.each(data["details"]["common_postmeta_values"], function(index, table) {
+          $('<tr>').append(
+            $('<td>').text(table["meta_key"]),
+            $('<td>').text(table["key_count"])
+          ).appendTo('#common_postmeta_values');
+        });
+
+        jQuery.each(data["details"]["autoload_option_count"], function(index, table) {
+          jQuery('#autoload_option_count').append(
+              "<li>"
+              + table["options_count"]
+              + "</li>"
+            );
+        });
+
+        jQuery.each(data["details"]["total_autoload_option_size"], function(index, table) {
+          jQuery('#total_autoload_option_size').append(
+              "<li>"
+              + table["total_size"] / 1000 + " MB"
+              + "</li>"
+            );
+        });
+
+        jQuery.each(data["details"]["long_autoload_option_values"], function(index, table) {
+          $('<tr>').append(
+            $('<td>').text(table["option_name"]),
+            $('<td>').text(table["option_value_length"])
+          ).appendTo('#long_autoload_option_values');
+        });
+
+        jQuery.each(data["details"]["common_autoload_option_values"], function(index, table) {
+          $('<tr>').append(
+            $('<td>').text(table["option_name_start"]),
+            $('<td>').text(table["option_count"])
+          ).appendTo('#common_autoload_option_values');
+        });
+
+        jQuery('.seravo_database_detail_show_more').click(function(event) {
+          event.preventDefault();
+
+          if ( jQuery('#seravo_arrow_database_detail_show_more').hasClass('dashicons-arrow-down-alt2') ) {
+            jQuery('.seravo-database-detail').slideDown('fast', function() {
+              jQuery('#seravo_arrow_database_detail_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+            });
+          } else if ( jQuery('#seravo_arrow_database_detail_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+            jQuery('.seravo-database-detail').hide(function() {
+              jQuery('#seravo_arrow_database_detail_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+            });
+          }
+        });
+
         if (section === 'seravo_wp_db_info') {
           jQuery('#seravo_wp_db_info').append(data.totals);
           generateDatabaseBars(data.tables.data_folders);

--- a/modules/database.php
+++ b/modules/database.php
@@ -229,6 +229,46 @@ if ( ! class_exists('Database') ) {
             </div>
           </p>
         </div>
+
+        <div class='seravo-database-detail-wrapper'>
+          <div class='seravo_database_detail'>
+            <?php _e('Details about database table sizes', 'seravo'); ?>
+          </div>
+          <div class='seravo-database-detail hidden'>
+            <table class="database_detail_table" id="long_postmeta_values">
+              <?php _e('Longest wp_postmeta values:', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="cumulative_postmeta_sizes">
+              <?php _e('Cumulative size of meta_value per meta_key:', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="common_postmeta_values">
+              <?php _e('Rows per meta_key:', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="autoload_option_count">
+              <?php _e('Autoload options count (read to memory on each WP page load):', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="total_autoload_option_size">
+              <?php _e('Autoload options total size of values:', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="long_autoload_option_values">
+              <?php _e('Longest autoloaded wp_option values:', 'seravo'); ?>
+            </table>
+            <hr>
+            <table class="database_detail_table" id="common_autoload_option_values">
+              <?php _e('Most common autoloaded wp_option values:', 'seravo'); ?>
+            </table>
+          </div>
+          <div class='seravo_database_detail_show_more_wrapper'>
+            <a href='#' class='seravo_database_detail_show_more'><?php _e('Toggle Details', 'seravo'); ?>
+              <div class='dashicons dashicons-arrow-down-alt2' id='seravo_arrow_database_detail_show_more'></div>
+            </a>
+          </div>
+        </div>
         <?php
       endif; // end database info
     }

--- a/style/database.css
+++ b/style/database.css
@@ -65,7 +65,7 @@ span.dashicons-external {
 .chart_container {
   overflow-y: scroll;
   overflow-x: hidden;
-  max-height: 800px;
+  max-height: 400px;
   white-space: pre-line;
   padding-right: 15px;
 }
@@ -73,4 +73,62 @@ span.dashicons-external {
 .arrow_box {
   font-size: 11px;
   padding: 3px;
+}
+
+.database_detail_table {
+  padding: 10px 0px;
+}
+
+.database_detail_table, .database_detail_table td {
+  width: 100%;
+  table-layout: fixed;
+  overflow-wrap: break-word;
+}
+
+.seravo-database-detail-wrapper {
+  -moz-transition: border 1s ease-in;
+  -o-transition: border 1s ease-in;
+  -webkit-transition: border 1s ease-in;
+  background-color: white;
+  border-left: solid 0.5em #44A1CB;
+  box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.12);
+  display: block;
+  margin-top: 2em;
+  max-width: 55em;
+  min-height: 5em;
+  overflow: hidden;
+  transition: border 1s ease-in;
+}
+
+.seravo-database-detail {
+  padding: 1em;
+}
+
+.seravo_database_detail {
+  font-size: 15px;
+  font-weight: bold;
+  margin-top: 1.6em;
+  margin-left: 0.5em;
+  padding-bottom: 7px;
+  text-align: center;
+}
+
+.seravo_database_detail_show_more_wrapper {
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  float: right;
+  height: 1em;
+  margin-right: 0.5em;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.seravo_database_detail_show_more,
+.seravo_database_detail_show_more:hover,
+.seravo_database_detail_show_more:active,
+.seravo_database_detail_show_more:focus {
+  box-shadow: none;
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
Implement a toggle menu under the Database size postbox and show details about database tables and sizes in it.
Implements the same functionality as the command `wp-db-info`.