### PR TITLE
Fix admin panel freeze with too large php-error log

### DIFF
--- a/modules/login-notification.php
+++ b/modules/login-notification.php
@@ -92,6 +92,20 @@ if ( ! class_exists('Login_Notifications') ) {
       // Read and reverse the php error logfile
       $output = Logs::read_log_lines_backwards('/data/log/php-error.log', -1, self::$max_rows);
       if ( ! $output ) {
+        // If output is false rather than an empty array then something went wrong with reading the file
+        if ( ! is_array($output) ) {
+          // Display admin dashboard error message
+          add_action(
+            'wp_dashboard_setup',
+            function() {
+              wp_add_dashboard_widget(
+                'seravo-error-widget',
+                __('Error log read failure', 'seravo'),
+                array( __CLASS__, 'display_admin_log_read_notification' )
+              );
+            }
+          );
+        }
         return 0;
       }
       $output_reversed = array_reverse($output);
@@ -189,6 +203,17 @@ if ( ! class_exists('Login_Notifications') ) {
         __('The PHP error log has more than %1$s entries this week. Please see %2$s for details. This is usually a sign that something is broken in the code. The developer of the site should be notified.', 'seravo'),
         self::$errors,
         $url
+      );
+      echo '<div>' . $msg . '</div>';
+    }
+
+    /**
+    * Display an error if there is problem reading the php-error.log file
+    */
+    public static function display_admin_log_read_notification() {
+      $url = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=logs_page&logfile=php-error.log">php-error.log</a>';
+      $msg = wp_sprintf(
+        __('The PHP error log is abnormally large. This is a sign that something is broken in the code. The developer of the site should be notified.', 'seravo')
       );
       echo '<div>' . $msg . '</div>';
     }

--- a/modules/logs.php
+++ b/modules/logs.php
@@ -353,6 +353,9 @@ if ( ! class_exists('Logs') ) {
       // the newline in the end accouts for an extra line
       $lines--;
 
+      // Set max amount chunks to be read according to to the lines wanted from the log.
+      $chunk_limit = max($lines, 10);
+
       // While we would like more
       while ( $lines > 0 ) {
         // Figure out how far back we should jump
@@ -372,6 +375,12 @@ if ( ! class_exists('Logs') ) {
 
         // Read a chunk
         $chunk = fread($f, $seek);
+
+        $chunk_limit--;
+        // Return false if we run over the chunk cap
+        if ( $chunk_limit === 0 ) {
+          return false;
+        }
 
         // Jump back to where we started reading
         fseek($f, -mb_strlen($chunk, '8bit'), SEEK_CUR);

--- a/modules/logs.php
+++ b/modules/logs.php
@@ -210,6 +210,11 @@ if ( ! class_exists('Logs') ) {
       </div>
       <?php elseif ( ! $result ) : ?>
         <p><?php _e('Log empty', 'seravo'); ?></p>
+        <?php
+        // result -1 is the signal that something went wrong with reading the log
+        elseif ( $result === -1 ) :
+        ?>
+        <p><?php _e('Log is abnormally large and can not be displayed.', 'seravo'); ?></p>
       <?php else : ?>
         <p><?php _e('Scroll to load more lines from the log.', 'seravo'); ?></p>
         <?php
@@ -249,7 +254,12 @@ if ( ! class_exists('Logs') ) {
 
       $rows = self::read_log_lines_backwards($logfile, $offset, $lines, $regex, $cutoff_bytes);
 
-      if ( empty($rows) ) {
+      if ( ! $rows ) {
+        // If $rows is not an empty array, then something went wrong with reading the file
+        if ( ! is_array($rows) ) {
+          // Return -1 as an error signal
+          return -1;
+        }
         return 0;
       }
 
@@ -353,7 +363,7 @@ if ( ! class_exists('Logs') ) {
       // the newline in the end accouts for an extra line
       $lines--;
 
-      // Set max amount chunks to be read according to to the lines wanted from the log.
+      // Set max amount of chunks to be read to match the lines wanted from the log
       $chunk_limit = max($lines, 10);
 
       // While we would like more


### PR DESCRIPTION
Abnormally long lines in the log file cause the admin panel to freeze. 

Now if too many chunks are generated while reading the log file, give up reading the log file to prevent the admin panel from freezing and return false like with too large files.

This does not fix the underlying issue that there is such log files though, and is a band-aid to stop the admin panel from freezing.