### PR TITLE
Add error feedback on php-compatibility timeout

### DIFF
--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -290,6 +290,17 @@ jQuery(document).ready(function($) {
           });
         }
       }
+      ).fail(function(msg) {
+        if (msg.status === 504) {
+          jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+            jQuery(this).html('<div style="color:red;font-weight:bold">' + seravo_upkeep_loc.compatibility_run_timeout + '</div>').fadeIn(400);
+          });
+        } else {
+          jQuery("#check-php-compatibility-status").fadeOut(400, function() {
+            jQuery(this).html('<div style="color:red;font-weight:bold">' + seravo_upkeep_loc.compatibility_run_error + msg.status + '</div>').fadeIn(400);
+          });
+        }
+      }
     );
   }
 

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -108,6 +108,8 @@ if ( ! class_exists('Upkeep') ) {
           'compatibility_check_error' => __(' errors found. See logs for more information.', 'seravo'),
           'compatibility_check_clear' => __('&#x2705; No errors found! See logs for more information.', 'seravo'),
           'compatibility_run_fail' => __('There was an error starting the compatibility check.', 'seravo'),
+          'compatibility_run_timeout' => __('The compatibility check has taken too long and has timed out. You can run the test from command line. See instructions from the link below.', 'seravo'),
+          'compatibility_run_error' => __('The compatibility check has failed with response code: ', 'seravo'),
           'no_data'       => __('No data returned for the section.', 'seravo'),
           'test_success'  => __('Tests were run without any errors!', 'seravo'),
           'test_fail'     => __('At least one of the tests failed.', 'seravo'),


### PR DESCRIPTION
Add feedback to the user if the php-compatibility ajax check takes too long.

Related #315

TODO: Translations once the code is ok.