### PR TITLE
Add support for SVG images

### DIFF
--- a/modules/svg-support.php
+++ b/modules/svg-support.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * Support SVG images
+ */
+
+namespace Seravo;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('SVGSupport') ) {
+
+  class SVGSupport {
+    public static function load() {
+      add_filter('upload_mimes', array( __CLASS__, 'add_to_mime_types' ));
+    }
+
+    // Add SVG to allowed mime types
+    public static function add_to_mime_types( $mimes ) {
+      $mimes['svg'] = 'image/svg+xml';
+      $mimes['svgz'] = 'image/svg+xml';
+      return $mimes;
+    }
+  }
+
+  SVGSupport::load();
+}

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -288,6 +288,14 @@ class Loader {
      * Hides prespecified and given users from a WordPress page
      */
     require_once dirname(__FILE__) . '/modules/hide-users.php';
+
+    /*
+     * Add support for SVG images
+     * Allow only administrators to upload SVG
+     */
+    if ( current_user_can('administrator') ) {
+      require_once dirname(__FILE__) . '/modules/svg-support.php';
+    }
   }
 }
 


### PR DESCRIPTION
#### What are the main changes in this PR?
After this change, administrators can upload SVG images to media library. SVG is not sanitized.

##### Why are we doing this? Any context or related work?
Related issue: #356

#### Manual testing steps?
1. Login as an administrator.
2. Try to add SVG image to media library.
4. Log in as a non-admin user.
5. Try to add SVG image to media library.
