### PR TITLE
Bugfix: fix database autoload size correctly (Closes: #431)

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -192,7 +192,7 @@ jQuery(document).ready(function($) {
         jQuery.each(data["details"]["total_autoload_option_size"], function(index, table) {
           jQuery('#total_autoload_option_size').append(
               "<li>"
-              + table["total_size"] / 1000 + " MB"
+              + table["total_size"] / 1000000 + " MB"
               + "</li>"
             );
         });


### PR DESCRIPTION
Before the autoload table size was incorrectly calculated in the Database details list. Calculate it correctly and show as MB.