### PR TITLE
Do not render disk donut if available space cannot be retrieved

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -258,15 +258,21 @@ jQuery(document).ready(function($) {
 
       if (section === 'folders_chart') {
         var allData = JSON.parse(rawData);
-        // Calculate the used disk space;
-        // allData.data.size is in bytes, so divide into MB
-        var used_disk = (allData.data.size) / 1000000;
 
-        // Read plan's maximum disk space and transform into bytes
-        var max_disk = $("#maximum_disk_space").html() * 1000;
+        // Try reading plan's maximum disk space
+        var max_disk = $("#maximum_disk_space").html();
 
-        jQuery('#total_disk_usage').text(Math.round(used_disk) + 'MB');
-        generateDiskDonut(used_disk, max_disk, "MB");
+        // Draw total usage donut if plan's available space can be retrieved
+        if (max_disk != null && max_disk != '') {
+          // Transform into megabytes
+          max_disk *= 1000;
+          // Calculate the used disk space;
+          // allData.data.size is in bytes, so divide into MB
+          var used_disk = (allData.data.size) / 1000000;
+
+          jQuery('#total_disk_usage').text(Math.round(used_disk) + 'MB');
+          generateDiskDonut(used_disk, max_disk, "MB");
+        }
         generateDiskBars(allData.dataFolders);
       } else if (section === 'front_cache_status') {
         var data = JSON.parse(rawData);

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -271,12 +271,15 @@ if ( ! class_exists('Site_Status') ) {
         <?php
           $api_response = API::get_site_data();
           if ( is_wp_error($api_response) ) {
-            die($api_response->get_error_message());
+            $max_disk = null;
+            $disk_display = 'none';
+          } else {
+            $max_disk = $api_response['plan']['disklimit']; // in GB
+            $disk_display = 'block';
           }
-          $max_disk = $api_response['plan']['disklimit']; // in GB
         ?>
         <div id="donut_single" style="width: 30%; float: right"></div>
-        <div class="disk_usage_desc">
+        <div style="display: <?php echo $disk_display; ?>" class="disk_usage_desc">
           <?php _e('Disk space in your plan: ', 'seravo'); ?>
           <span id="maximum_disk_space"><?php echo $max_disk; ?></span>GB
           <br>
@@ -289,14 +292,14 @@ if ( ! class_exists('Site_Status') ) {
               <?php _e('Read more.', 'seravo'); ?>
             </a>
           </span>
+          <br>
         </div>
         <div class="folders_chart_loading">
           <img src="/wp-admin/images/spinner.gif">
         </div>
       </p>
       <p>
-        <hr>
-        <br>
+        <hr style="display: <?php echo $disk_display; ?>">
         <b>
           <?php _e('Disk usage by directory', 'seravo'); ?>
         </b>


### PR DESCRIPTION
Handle API error when available disk space cannot be retrieved by
averting from generating the disk donut chart and hiding the
wrapping element.

Fixes bug where other charts couldn't be rendered on the same
Site Status page if generating the disk donut failed.

#### Screenshots

![image](https://user-images.githubusercontent.com/44066308/89865072-b32f3380-dbb5-11ea-9113-363cdc20568c.png)
![image](https://user-images.githubusercontent.com/44066308/89865085-be825f00-dbb5-11ea-8b9a-456c9c6790be.png)
