### PR TITLE
Temporary quick fix for Seravo postbox styles missing

### DIFF
--- a/style/seravo-postbox.css
+++ b/style/seravo-postbox.css
@@ -1,3 +1,26 @@
+.postbox .handlediv {
+  float: right;
+  width: 36px;
+  height: 36px;
+  margin: 0;
+  padding: 0;
+  /* border: 0; */
+  background: 0 0;
+  cursor: pointer;
+}
+
+.js .postbox .hndle, .js .widget .widget-top {
+  cursor: pointer;
+}
+
+.ui-draggable-handle, .ui-sortable-handle {
+  touch-action: none;
+}
+
+.postbox .hndle, .stuffbox .hndle {
+  border-bottom: 1px solid #ccd0d4;
+}
+
 .seravo-postbox .inside {
   padding: 10px 20px 20px 20px;
 }

--- a/style/seravo-postbox.css
+++ b/style/seravo-postbox.css
@@ -1,15 +1,15 @@
-.postbox .handlediv {
+/* Temporary fix for WP 5.5 Start */
+.seravo-postbox .handlediv {
   float: right;
   width: 36px;
   height: 36px;
   margin: 0;
   padding: 0;
-  /* border: 0; */
   background: 0 0;
   cursor: pointer;
 }
 
-.js .postbox .hndle, .js .widget .widget-top {
+.js .seravo-postbox .hndle, .js .widget .widget-top {
   cursor: pointer;
 }
 
@@ -17,9 +17,10 @@
   touch-action: none;
 }
 
-.postbox .hndle, .stuffbox .hndle {
+.seravo-postbox .hndle, .stuffbox .hndle {
   border-bottom: 1px solid #ccd0d4;
 }
+/* Temporary fix for WP 5.5 End */
 
 .seravo-postbox .inside {
   padding: 10px 20px 20px 20px;


### PR DESCRIPTION
#### What are the main changes in this PR?
As described on issue #438 updating to WordPress 5.5 causes Seravo postbox lose their top stylings. This adds manually some css styles so that Seravo postbox top stylings work as intended on WordPress 5.5 versions too. The fix doesn't interfere with later than WordPress 5.5 postbox styles. 

Some more investigation might be required to find out whether the issue can be closed or apply another patch. 
