### PR TITLE
Fix PHP<7.0 compatibility issue with SVG support module

### DIFF
--- a/modules/svg-support.php
+++ b/modules/svg-support.php
@@ -5,7 +5,7 @@
 
 namespace Seravo;
 
-require_once dirname(__FILE__, 2) . '/vendor/autoload.php';
+require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';
 
 // Deny direct access to this file
 if ( ! defined('ABSPATH') ) {

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -1,7 +1,7 @@
 <?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName
 /**
  * Plugin Name: Seravo Plugin
- * Version: 1.9.24
+ * Version: 1.9.25
  * Plugin URI: https://github.com/Seravo/seravo-plugin
  * Description: Enhances WordPress with Seravo.com specific features and integrations.
  * Author: Seravo Oy


### PR DESCRIPTION
PHP below version 7.0 does not support the `levels` parameter of `dirname`.

This fix uses a compatible way to traverse up the directories.