### PR TITLE
Fix wp-user and wp-plugin logging

### DIFF
--- a/modules/wp-plugin-log.php
+++ b/modules/wp-plugin-log.php
@@ -80,12 +80,17 @@ if ( ! class_exists('PluginLog') ) {
     public static function write_log( $message ) {
       $time_local = gmdate('j/M/Y:H:i:s O');
 
-      $current_user = wp_get_current_user();
-
-      $username = $current_user->user_login;
-
       $log_fp = fopen('/data/log/wp-settings.log', 'a');
-      fwrite($log_fp, "$time_local User $username $message\n");
+
+      $current_user = wp_get_current_user();
+      $user_id = $current_user->ID;
+      // eg ID is 0 when the change is made using WP CLI
+      if ( $user_id === 0 ) {
+        fwrite($log_fp, "$time_local WP-CLI $message\n");
+      } else {
+        $username = $current_user->user_login;
+        fwrite($log_fp, "$time_local User $username $message\n");
+      }
       fclose($log_fp);
     }
   }

--- a/modules/wp-user-log.php
+++ b/modules/wp-user-log.php
@@ -107,7 +107,13 @@ if ( ! class_exists('UserLog') ) {
 
       // If ID is 0, there is no current user. eg role set on registration or wp-test
       if ( wp_get_current_user()->ID === 0 ) {
-        self::write_log('User (ID:' . $user_id . ') role changed to ' . $role);
+        $new_user_data = get_userdata($user_id);
+        $username = $new_user_data->user_login;
+
+        // Hide seravotest user from the logs
+        if ( $username != 'seravotest' ) {
+          self::write_log('User ' . $username . ' (ID:' . $user_id . ') role changed to ' . $role);
+        }
       } else {
         self::write_log_user('changed role of user (ID:' . $user_id . ') to ' . $role);
       }


### PR DESCRIPTION
Make it clear when plugin and theme changes were made from WP-CLI.

Log username of the user whose role is being changed.

Exclude seravotest user from the wp-user.log