### PR TITLE
Fix mail forwards language incompatibility

### DIFF
--- a/js/domains.js
+++ b/js/domains.js
@@ -504,7 +504,8 @@ jQuery(document).ready(function($) {
 
     set_forwards: function(domain, forwards) {
 
-      $("[data-forwards='" + domain + "']").find("[data-colname='Forwards']").html(forwards);
+      var column_name = seravo_domains_loc.forwards;
+      $("[data-forwards='" + domain + "']").find("[data-colname='" + column_name + "']").html(forwards);
 
       $('.forward-actions .edit').click(function(e) {
         e.preventDefault();

--- a/modules/domains.php
+++ b/modules/domains.php
@@ -88,6 +88,7 @@ if ( ! class_exists('Domains') ) {
           'forwards_edit_fail'  => __('Error! The action might have failed.', 'seravo'),
           'forwards_no_source'  => __('Source field can\'t be empty.', 'seravo'),
           'continue_edit'       => __('Continue', 'seravo'),
+          'forwards'            => __('Forwards', 'seravo'),
         );
 
         wp_localize_script('seravo_domains', 'seravo_domains_loc', $loc_translation_domains);


### PR DESCRIPTION
The mail forwards were not rendered correctly, because "Forwards" was
hard-coded and it happened to be a translatable string.