### PR TITLE
Implement generic X-Accel-Redirect function and use if for screenshots

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -40,7 +40,7 @@ jQuery(document).ready(function($) {
               } else {
                 var bar_css = bar_size + '%';
               }
-              jQuery( '#http-reports_table' ).prepend('<tr><td><a href="?report=' +
+              jQuery( '#http-reports_table' ).prepend('<tr><td><a href="?x-accel-redirect&report=' +
                 month.date +
                 '.html" target="_blank"> ' +
                 month.date +
@@ -48,7 +48,7 @@ jQuery(document).ready(function($) {
                 bar_css +
                 '; display: inline-block;"><div style="white-space: nowrap;">' +
                 month.requests +
-                '</div></div></td> <td><a href="?report=-' +
+                '</div></div></td> <td><a href="?x-accel-redirect&report=' +
                 month.date +
                 '.html" target="_blank" class="button hideMobile">' +
                 seravo_site_status_loc.view_report +

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -525,7 +525,7 @@ if ( ! class_exists('Upkeep') ) {
             <tr>
               <td>
               <hr class="seravo-updates-hr">
-              <a href="/.seravo/screenshots-ng/debug/' . $name . '.diff.png" class="diff-img-title">' . $name . '</a>
+              <a href="?x-accel-redirect&screenshot=' . $name . '.diff.png" class="diff-img-title">' . $name . '</a>
               <span';
           // Make the difference number stand out if it is non-zero
           if ( $diff > 0.011 ) {
@@ -536,8 +536,8 @@ if ( ! class_exists('Upkeep') ) {
           echo self::seravo_admin_image_comparison_slider(
             array(
               'difference' => $diff,
-              'img_right'  => "/.seravo/screenshots-ng/debug/$name.shadow.png",
-              'img_left'   => "/.seravo/screenshots-ng/debug/$name.png",
+              'img_right'  => "?x-accel-redirect&screenshot=$name.shadow.png",
+              'img_left'   => "?x-accel-redirect&screenshot=$name.png",
             )
           );
           echo '


### PR DESCRIPTION
Instead of passing GoAccess reports or Codeception screenshots via PHP
(thus reserving one PHP worker for the duration of the download) let Nginx
handle it with the X-Accel-Redirect header.

This can be rolled out only once the server side X-Accel-Redirect settings
are in place.