### PR TITLE
Include quarantine directories in cruft remover

### DIFF
--- a/lib/cruftfiles-ajax.php
+++ b/lib/cruftfiles-ajax.php
@@ -27,6 +27,7 @@ function find_cruft_dir( $name ) {
   $user = getenv('WP_USER');
   exec('find /data/wordpress -type d -name ' . $name, $data_dirs);
   exec('find /home/' . $user . ' -maxdepth 1 -type d -name ' . $name, $home_dirs);
+  exec('find /data -type d -name quarantine-\*', $data_dirs);
   $dirs = array_merge($data_dirs, $home_dirs);
   return $dirs;
 }


### PR DESCRIPTION
Makes cruft remover detect directories with name quarantine-*
inside `/data` path. Quarantine directories can often grow
large and they are mostly cruft that can be removed by the user.
