### PR TITLE
Add a nag and one-click installation for missing object-cache.php

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -354,6 +354,30 @@ jQuery(document).ready(function($) {
     seravo_load_report('front_cache_status');
   });
 
+  jQuery('#enable-object-cache').click(function() {
+    // Manage the props
+    jQuery(this).prop('disabled', true);
+    jQuery('.object_cache_loading').prop('hidden', false);
+
+    jQuery.post(seravo_site_status_loc.ajaxurl, {
+      'action': 'seravo_ajax_site_status',
+      'section': 'object_cache',
+      'nonce': seravo_site_status_loc.ajax_nonce,
+    }, function (rawData) {
+        var result = JSON.parse(rawData)
+
+        if (result['success'] === true) {
+          jQuery('.object_cache_loading').prop('hidden', true)
+          jQuery('#enable-object-cache').remove()
+          jQuery('#object_cache_warning').css('color', 'green')
+          jQuery('#object_cache_warning').html(seravo_site_status_loc.object_cache_success)
+        } else {
+          jQuery('#object_cache_warning').html(seravo_site_status_loc.object_cache_failure)
+          jQuery('.object_cache_loading').prop('hidden', true)
+        }
+    })
+  });
+
   jQuery('.seravo_cache_test_show_more').click(function(event) {
     event.preventDefault();
 

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -145,6 +145,31 @@ function seravo_report_redis_info() {
   return $result;
 }
 
+function seravo_enable_object_cache() {
+  $object_cache_url = 'https://raw.githubusercontent.com/Seravo/wordpress/master/htdocs/wp-content/object-cache.php';
+  $object_cache_path = '/data/wordpress/htdocs/wp-content/object-cache.php';
+  $result = array();
+
+  // Remove all possible object-cache.php.* files
+  foreach ( glob($object_cache_path . '.*') as $file ) {
+    unlink($file);
+  }
+
+  // Get the newest file and write it
+  $object_cache_content = file_get_contents($object_cache_url);
+  $object_cache_file = fopen($object_cache_path, 'w');
+  $write_object_cache = fwrite($object_cache_file, $object_cache_content);
+  fclose($object_cache_file);
+
+  if ( $write_object_cache && $object_cache_content ) {
+    $result['success'] = true;
+  } else {
+    $result['success'] = false;
+  }
+
+  return $result;
+}
+
 function seravo_report_longterm_cache_stats() {
   $access_logs = glob('/data/slog/*_total-access.log');
 
@@ -224,6 +249,10 @@ function seravo_ajax_site_status() {
 
     case 'redis_info':
       echo wp_json_encode(seravo_report_redis_info());
+      break;
+
+    case 'object_cache':
+      echo wp_json_encode(seravo_enable_object_cache());
       break;
 
     case 'longterm_cache':

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -18,6 +18,9 @@ if ( ! class_exists('Site_Status') ) {
     private static $min_width = 500;
     private static $min_height = 500;
 
+    // Object-cache file location
+    const OBJECT_CACHE_PATH = '/data/wordpress/htdocs/wp-content/object-cache.php';
+
     public static function load() {
       add_action('admin_init', array( __CLASS__, 'register_optimize_image_settings' ));
       add_action('admin_init', array( __CLASS__, 'register_sanitize_uploads_settings' ));
@@ -168,6 +171,8 @@ if ( ! class_exists('Site_Status') ) {
           'failed'              => __('Failed to load. Please try again.', 'seravo'),
           'no_reports'          => __('No reports found at /data/slog/html/. Reports should be available within a month of the creation of a new site.', 'seravo'),
           'view_report'         => __('View report', 'seravo'),
+          'object_cache_success'=> __('Object cache is now enabled', 'seravo'),
+          'object_cache_failure'=> __('Enabling object cache failed', 'seravo'),
           'running_cache_tests' => __('Running cache tests...', 'seravo'),
           'cache_success'       => __('HTTP cache working', 'seravo'),
           'cache_failure'       => __('HTTP cache not working', 'seravo'),
@@ -218,6 +223,17 @@ if ( ! class_exists('Site_Status') ) {
     }
 
     public static function seravo_cache_status() {
+      ?>
+      <?php
+        if ( ! file_exists(self::OBJECT_CACHE_PATH) ) {
+       ?>
+      <h3 id='object_cache_warning' style='color: red' > <?php _e('Object cache is currently disabled!', 'seravo'); ?> <h3>
+      <button type='button' class='button-primary' id='enable-object-cache'> <?php _e('Enable', 'seravo'); ?> </button>
+      <div class='object_cache_loading' hidden>
+        <img src='/wp-admin/images/spinner.gif'>
+      </div>
+        <?php
+      }
       ?>
       <p><?php _e('Caching decreases the load time of the website. The cache hit rate represents the efficiency of cache usage. Read about caching from the <a href="https://help.seravo.com/article/36-how-does-caching-work/" target="_BLANK">documentation</a> or <a href="https://seravo.com/tag/cache/" target="_BLANK">blog</a>.', 'seravo'); ?></p>
       <h3><?php _e('Object Cache in Redis', 'seravo'); ?></h3>
@@ -279,11 +295,11 @@ if ( ! class_exists('Site_Status') ) {
         <?php
           $api_response = API::get_site_data();
           if ( is_wp_error($api_response) ) {
-            $max_disk = null;
-            $disk_display = 'none';
+          $max_disk = null;
+          $disk_display = 'none';
           } else {
-            $max_disk = $api_response['plan']['disklimit']; // in GB
-            $disk_display = 'block';
+          $max_disk = $api_response['plan']['disklimit']; // in GB
+          $disk_display = 'block';
           }
         ?>
         <div id="donut_single" style="width: 30%; float: right"></div>


### PR DESCRIPTION
#### What are the main changes in this PR?
Add a nag bar to the site status page onto Cache Status postbox to notify user about missing/disabled object-cache.php and button for easy one-click installation. Also remove any excessive object-cache.php.* named files at the installation process. 

Translations still to be done.

##### Why are we doing this? Any context or related work?
See issue #463

#### Screenshots
Nag for missing/disabled object cache
![Screenshot](https://user-images.githubusercontent.com/16706187/107222601-ce241880-6a1d-11eb-9bb2-aada0404dab9.png)

Successful installation
![Screenshot(1)](https://user-images.githubusercontent.com/16706187/107222609-cf554580-6a1d-11eb-90ab-578a488e8b52.png)

