### PR TITLE
Fix not showing HTTP cache working status (Closes: #470)

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -285,10 +285,14 @@ jQuery(document).ready(function($) {
         var data_joined = data['test_result'].join("\n");
 
         if ( data['success'] === true ) {
-          jQuery('.seravo_cache_tests_status').html(seravo_site_status_loc.cache_success).fadeIn('slow');
+          jQuery('.seravo_cache_tests_status').fadeIn('slow', function() {
+            jQuery(this).html(seravo_site_status_loc.cache_success).fadeIn('slow');
+          });
           jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
         } else {
-          jQuery('.seravo_cache_tests_status').html(seravo_site_status_loc.cache_failure).fadeIn('slow');
+          jQuery('.seravo_cache_tests_status').fadeIn('slow', function() {
+            jQuery(this).html(seravo_site_status_loc.cache_success).fadeIn('slow');
+          });
           jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
         }
 


### PR DESCRIPTION
#### What are the main changes in this PR?
Fix the permanent "Running cache tests..." and show the HTTP cache status.

##### Why are we doing this? Any context or related work?
See issue #470 

#### Screenshots
![Screenshot(2)](https://user-images.githubusercontent.com/16706187/107224679-6ae7b580-6a20-11eb-8748-635a2b8cda8a.png)
