### PR TITLE
Ensure seravo prefix or namespace usage on modules (Closes: #466)

### DIFF
--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -315,7 +315,7 @@ jQuery(document).ready(function($) {
     jQuery.post(
       seravo_upkeep_loc.ajaxurl, {
         'action': 'seravo_ajax_upkeep',
-        'section': 'check_php_config_files',
+        'section': 'seravo_check_php_config_files',
         'nonce': seravo_upkeep_loc.ajax_nonce
       });
 

--- a/lib/upkeep-ajax.php
+++ b/lib/upkeep-ajax.php
@@ -87,7 +87,7 @@ function seravo_default_config_file() {
   return true;
 }
 
-function check_php_config_files() {
+function seravo_check_php_config_files() {
   $dir = '/data/wordpress/nginx';
 
   exec('grep -l "^set \$mode php" ' . $dir . '/*.conf | tail -1', $config_file);
@@ -121,7 +121,7 @@ function seravo_tests() {
   return $return_arr;
 }
 
-function changes_since() {
+function seravo_changes_since() {
   $date = $_POST['date'];
   $result_count = '';
 
@@ -185,8 +185,8 @@ function seravo_ajax_upkeep( $date ) {
       echo seravo_default_config_file();
       break;
 
-    case 'check_php_config_files':
-      echo check_php_config_files();
+    case 'seravo_check_php_config_files':
+      echo seravo_check_php_config_files();
       break;
 
     case 'seravo_tests':
@@ -194,7 +194,7 @@ function seravo_ajax_upkeep( $date ) {
       break;
 
     case 'seravo_changes':
-      echo wp_json_encode(changes_since());
+      echo wp_json_encode(seravo_changes_since());
       break;
 
     default:


### PR DESCRIPTION
#### What are the main changes in this PR?
Ensure that all the modules under the lib/ or modules/ use proper naming conventions like using Seravo namespace or seravo_ prefix on function names. Since we have been using seravo_ prefix on function names on ajax side anyway, I didn't make any major namespace related modifications. 

Some notices, I didn't force Seravo_Domains_List_table class (lib/domain-tables.php) to use Seravo namespace since the instance of this class is only used on domains-ajax.php where seravo_ prefix is already used on handling. The namespace usage would have also caused quite a lot refactoring on lib/ and modules/ regarding the domain view. JS modules have been left out since the issue doesn't really consider them and I think they are not so important when it comes to this namespace / prefix thing. 

##### Why are we doing this? Any context or related work?
See issue #466 

