### PR TITLE
Fix input element misalignment (Closes: #483)

### DIFF
--- a/style/database.css
+++ b/style/database.css
@@ -32,6 +32,20 @@ span.dashicons-external {
   padding-left: 3px;
 }
 
+label.to_label {
+  display: block;
+  width: 10%;
+  margin-top: 5px;
+  float: left
+}
+
+label.from_label {
+  display: block;
+  width: 10%;
+  margin-top: 5px;
+  float: left
+}
+
 @media only screen and (max-width: 1115px) {
   .label_buttons {
     display: block;


### PR DESCRIPTION
The English language version of the plugin had some issues with the alignment of the input elements. The problem was the words "From" and "To" being different length. Giving the labels a width fixed the issue.

**Screenshots before and after**
<img width="341" alt="before" src="https://user-images.githubusercontent.com/50293640/108818235-bfaf3280-75c1-11eb-8e22-ea659ccde6cb.PNG">
<img width="372" alt="after" src="https://user-images.githubusercontent.com/50293640/108818242-c3db5000-75c1-11eb-9871-94d9e66292c5.PNG">
