### PR TITLE
Fix excessive error logging (Closes: #487)

### DIFF
--- a/modules/login-notification.php
+++ b/modules/login-notification.php
@@ -179,8 +179,6 @@ if ( ! class_exists('Login_Notifications') ) {
 
           // Fetch login date and time
           $datetime = \DateTime::createFromFormat('d/M/Y:H:i:s T', $entry['datetime']);
-          error_log($entry['datetime']);
-          error_log($datetime->format('c'));
           $datetime->setTimezone(new \DateTimeZone(wp_timezone_string()));
 
           return array(


### PR DESCRIPTION
#### What are the main changes in this PR?
There were some excessive `error_log()` usage on login-notification.php module that caused empty lines to php-error.log with only timestamp on them. This removes those excessive errors.

##### Why are we doing this? Any context or related work?
See issue #487
