### PR TITLE
Add a feature for checking site health

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -392,6 +392,92 @@ jQuery(document).ready(function($) {
     }
   });
 
+  function seravo_site_checks() {
+    jQuery.post(seravo_site_status_loc.ajaxurl, {
+      'action': 'seravo_ajax_site_status',
+      'section': 'seravo_site_checks',
+      'nonce': seravo_site_status_loc.ajax_nonce,
+    }, function (rawData) {
+        var result = JSON.parse(rawData)
+        var success = result['success']
+        var issues = result['issues']
+
+        if ( issues.length === 0 ) {
+          // No issues
+          jQuery('.seravo-site-check-result-wrapper').css('border-left', 'solid 0.5em #038103')
+          jQuery('.site_check_status_loading').html(seravo_site_status_loc.site_checks_success)
+        } else {
+          // Issues
+          jQuery('.seravo-site-check-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b')
+          jQuery('.seravo_site_check_show_more_wrapper').hide()
+          jQuery('.site_check_status_loading').html(seravo_site_status_loc.site_checks_issues)
+        }
+
+        if ( issues.length > 0 ) {
+          jQuery('#seravo_site_check').append("<h4 style='color: red;'>" + seravo_site_status_loc.site_checks_fail + '</h4>')
+
+          for (var index in issues) {
+            if ( index == issues.length- 1 ) {
+                // Border-bottom needs to be applied to the last item
+                jQuery('#seravo_site_check').append('<div class="seravo-site-check-issue-box" style="border-bottom: 1px solid #ccd0d4">' + issues[index]+ '</div>')
+              } else {
+                jQuery('#seravo_site_check').append('<div class="seravo-site-check-issue-box">' + issues[index]+ '</div>')
+              }
+          }
+          jQuery('#seravo_site_check').append('<br>')
+        }
+
+        // wrap the data and disable spinner etc.
+        jQuery('#seravo_site_check').append("<h4 style='color: green;'>" + seravo_site_status_loc.site_checks_pass + '</h4>')
+
+        for (var index in success) {
+          if ( index == success.length- 1 ) {
+              // Border-bottom needs to be applied to the last item
+              jQuery('#seravo_site_check').append('<div class="seravo-site-check-success-box" style="border-bottom: 1px solid #ccd0d4">' + success[index] + '</div>')
+            } else {
+              jQuery('#seravo_site_check').append('<div class="seravo-site-check-success-box">' + success[index] + '</div>')
+            }
+          }
+
+        // Reload the components
+        jQuery('#run-site-checks').prop('disabled', false)
+        jQuery('.seravo_site_check_show_more_wrapper').show();
+    })
+  }
+
+  jQuery('#run-site-checks').click(function() {
+    jQuery('#seravo_site_check').html('');
+    jQuery('.seravo-site-check-result-wrapper').css('border-left', 'solid 0.5em #e8ba1b');
+    jQuery('.seravo_site_check_show_more_wrapper').hide();
+
+    if ( jQuery('#seravo_arrow_check_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+      jQuery('.seravo-site-check-result').hide(function() {
+        jQuery('#seravo_arrow_check_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+      });
+    }
+
+    jQuery('.seravo_site_check_status').fadeOut(400, function() {
+      jQuery(this).html('<div class="site_check_status_loading"><img src="/wp-admin/images/spinner.gif" style="display:inline-block"> ' + seravo_site_status_loc.running_site_checks + '</div>').fadeIn(400);
+    });
+
+    jQuery(this).prop('disabled', true);
+    seravo_site_checks();
+  });
+
+  jQuery('.seravo_site_check_show_more').click(function(event) {
+    event.preventDefault();
+
+    if ( jQuery('#seravo_arrow_check_show_more').hasClass('dashicons-arrow-down-alt2') ) {
+      jQuery('.seravo-site-check-result').slideDown('fast', function() {
+        jQuery('#seravo_arrow_check_show_more').removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+      });
+    } else if ( jQuery('#seravo_arrow_check_show_more').hasClass('dashicons-arrow-up-alt2') ) {
+      jQuery('.seravo-site-check-result').hide(function() {
+        jQuery('#seravo_arrow_check_show_more').removeClass('dashicons-arrow-up-alt2').addClass('dashicons-arrow-down-alt2');
+      });
+    }
+  });
+
   $('.reset').click(function(event) {
     var shadow_id = $(this).closest('tbody').attr('id');
     var is_user_sure = confirm(seravo_site_status_loc.confirm);

--- a/lib/sitestatus-ajax.php
+++ b/lib/sitestatus-ajax.php
@@ -233,6 +233,17 @@ function seravo_reset_shadow() {
   wp_die();
 }
 
+function seravo_site_checks() {
+  $results = Site_Health::check_site_status();
+  $issues = $results[0];
+  $success = $results[1];
+
+  return array(
+    'success' => $success,
+    'issues' => $issues,
+  );
+}
+
 function seravo_ajax_site_status() {
   check_ajax_referer('seravo_site_status', 'nonce');
 
@@ -267,6 +278,10 @@ function seravo_ajax_site_status() {
 
     case 'seravo_reset_shadow':
       seravo_reset_shadow();
+      break;
+
+    case 'seravo_site_checks':
+      echo wp_json_encode(seravo_site_checks());
       break;
 
     default:

--- a/modules/check-site-health.php
+++ b/modules/check-site-health.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Description: Class for checking some general settings and potential issues
+ * regarding WordPress installation
+ */
+
+namespace Seravo;
+
+if ( ! defined('ABSPATH') ) {
+    die('Access denied!');
+}
+
+if ( ! class_exists('Site_Health') ) {
+  class Site_Health {
+    private static $potential_issues;
+    private static $no_issues;
+    private static $bad_plugins = array(
+      'https-domain-alias',
+      'wp-palvelu-plugin',
+    );
+
+    private static function exec_command( $command ) {
+        $output = array();
+        exec($command, $output);
+
+        return $output;
+    }
+
+    private static function check_https() {
+        /* Logic from check-https module
+         *Get the siteurl and home url and check if https is enabled, if not, show warning
+        */
+      $siteurl = get_option('siteurl');
+      $home = get_option('home');
+      if ( strpos($siteurl, 'https') !== 0 || strpos($home, 'https') !== 0 ) {
+        array_push(self::$potential_issues, __('HTTPS is disabled', 'seravo'));
+      } else {
+        array_push(self::$no_issues, __('HTTPS is enabled', 'seravo'));
+      }
+    }
+
+    private static function check_recaptcha() {
+        $output = self::exec_command('wp plugin list');
+        $captcha_found = false;
+
+        foreach ( $output as $plugin ) {
+        // check that captcha is found and it's not inactive
+        if ( strpos($plugin, 'captcha') && strpos($plugin, 'inactive') === false ) {
+            array_push(self::$no_issues, __('Recaptcha is enabled', 'seravo'));
+            $captcha_found = true;
+            break;
+          }
+        }
+
+        if ( ! $captcha_found ) {
+          array_push(self::$potential_issues, __('Recaptcha is disabled', 'seravo'));
+        }
+    }
+
+    private static function check_inactive_themes() {
+        $output = self::exec_command('wp theme list');
+        $inactive_themes = 0;
+
+        foreach ( $output as $line ) {
+        if ( strpos($line, 'inactive') ) {
+            $inactive_themes++;
+          }
+        }
+
+        if ( $inactive_themes > 0 ) {
+        /* translators:
+        * %1$s number of inactive themes
+        */
+          $themes_msg = wp_sprintf(_n('Found %1$s inactive theme', 'Found %1$s inactive themes', $inactive_themes, 'seravo'), number_format_i18n($inactive_themes));
+          array_push(self::$potential_issues, $themes_msg);
+        } else {
+          array_push(self::$no_issues, __('No inactive themes', 'seravo'));
+        }
+    }
+
+    private static function check_plugins() {
+        // check inactive plugins and all plugin related issues
+        $output = self::exec_command('wp plugin list');
+        $inactive_plugins = 0;
+        $bad_plugins_found = 0;
+
+        foreach ( $output as $line ) {
+
+        if ( strpos($line, 'inactive') ) {
+          $inactive_plugins++;
+        }
+
+        foreach ( self::$bad_plugins as $plugin ) {
+
+          if ( str_contains($line, $plugin) ) {
+            $error_msg = '<b>' . $plugin . '</b> ' . __('is deprecated');
+            array_push(self::$potential_issues, $error_msg);
+            $bad_plugins_found++;
+            }
+          }
+        }
+
+        if ( $bad_plugins_found === 0 ) {
+          array_push(self::$no_issues, __('No deprecated features or plugins'));
+        }
+
+        if ( $inactive_plugins > 0 ) {
+        /* translators:
+        * %1$s number of inactive plugins
+        */
+          $plugins_msg = wp_sprintf(_n('Found %1$s inactive plugin', 'Found %1$s inactive plugins', $inactive_plugins, 'seravo'), number_format_i18n($inactive_plugins));
+          array_push(self::$potential_issues, $plugins_msg);
+        } else {
+          array_push(self::$no_issues, __('No inactive plugins', 'seravo'));
+        }
+    }
+
+    private static function check_php_errors() {
+        $php_info = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=logs_page&logfile=php-error.log" target="_blank">php-error.log</a>';
+        $php_errors = Login_Notifications::retrieve_error_count();
+
+        if ( $php_errors > 0 ) {
+        /* translators:
+        * %1$s number of errors in the log
+        * %2$s url to php-error.log */
+          $php_errors_msg = wp_sprintf(_n('%1$s error on %2$s', '%1$s errors on %2$s', $php_errors, 'seravo'), number_format_i18n($php_errors), $php_info);
+          array_push(self::$potential_issues, $php_errors_msg);
+        } else {
+          array_push(self::$no_issues, __('No php errors on log', 'seravo'));
+        }
+    }
+
+    private static function check_wp_test() {
+      exec('wp-test', $output, $return_variable);
+
+      if ( $return_variable === 0 ) {
+        array_push(self::$no_issues, __('Command <code>wp-test</code> runs successfully', 'seravo'));
+      } else {
+        array_push(self::$potential_issues, __('Command <code>wp-test</code> fails'));
+      }
+    }
+
+    public static function check_site_status() {
+        self::$potential_issues = array();
+        self::$no_issues = array();
+
+        self::check_https();
+        self::check_recaptcha();
+
+        self::check_inactive_themes();
+        self::check_plugins();
+
+        self::check_php_errors();
+        self::check_wp_test();
+
+        $result_array = array( self::$potential_issues, self::$no_issues );
+        return $result_array;
+    }
+  }
+}
+

--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -7,6 +7,7 @@ if ( ! defined('ABSPATH') ) {
 }
 
 require_once dirname(__FILE__) . '/../lib/sitestatus-ajax.php';
+require_once dirname(__FILE__) . '/check-site-health.php';
 
 if ( ! class_exists('Site_Status') ) {
   class Site_Status {
@@ -100,6 +101,15 @@ if ( ! class_exists('Site_Status') ) {
         'tools_page_site_status_page',
         'side'
       );
+
+      seravo_add_postbox(
+        'site-checks',
+        __('Site checks', 'seravo'),
+        array( __CLASS__, 'site_checks' ),
+        'tools_page_site_status_page',
+        'side'
+      );
+
     }
 
     public static function register_optimize_image_settings() {
@@ -176,6 +186,11 @@ if ( ! class_exists('Site_Status') ) {
           'running_cache_tests' => __('Running cache tests...', 'seravo'),
           'cache_success'       => __('HTTP cache working', 'seravo'),
           'cache_failure'       => __('HTTP cache not working', 'seravo'),
+          'running_site_checks' => __('Running site checks', 'seravo'),
+          'site_checks_success' => __('No issues were found', 'seravo'),
+          'site_checks_issues'  => __('Potential issues were found', 'seravo'),
+          'site_checks_pass'    => __('Passed tests', 'seravo'),
+          'site_checks_fail'    => __('Potential issues', 'seravo'),
           'success'             => __('Success!', 'seravo'),
           'failure'             => __('Failure!', 'seravo'),
           'error'               => __('Error!', 'seravo'),
@@ -697,6 +712,40 @@ if ( ! class_exists('Site_Status') ) {
       echo('<button type="button" class="button-primary" id="run-speed-test">' . __('Run Test', 'seravo') . '</button>');
       echo('<div id="speed-test-results"></div>');
       echo('<div id="speed-test-error"></div>');
+    }
+
+    public static function site_checks() {
+      //$results = Site_Health::check_health();
+      //$issues = $results[0];
+      //$no_issues = $results[1];
+      ?>
+      <div id='site_check_status'>
+
+      <?php
+      echo('<p>' . __(
+        'Site checks provide a report about your site health and show potential issues. Checks include for example
+      php related errors, inactive themes and plugins.',
+        'seravo'
+      ) . '</p>');
+      echo "<button type='button' class='button-primary' id='run-site-checks'>" . __('Run site checks', 'seravo') . '</button>';
+
+      ?>
+      <div class='seravo-site-check-result-wrapper'>
+          <div class='seravo_site_check_status'>
+            <?php _e('Click "Run site checks" to run the tests', 'seravo'); ?>
+          </div>
+          <div class='seravo-site-check-result'>
+            <pre id='seravo_site_check'></pre>
+          </div>
+          <div class='seravo_site_check_show_more_wrapper hidden'>
+            <a href='' class='seravo_site_check_show_more'><?php _e('Toggle Details', 'seravo'); ?>
+              <div class='dashicons dashicons-arrow-down-alt2' id='seravo_arrow_check_show_more'>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+        <?php
     }
 
   }

--- a/style/sitestatus.css
+++ b/style/sitestatus.css
@@ -126,7 +126,23 @@ th, td {
   color: black;
 }
 
-.seravo-cache-test-result-wrapper {
+.seravo-site-check-success-box {
+  overflow: hidden;
+  padding: 10px;
+  border: 1.5px solid#ccd0d4;
+  border-left: solid 0.3em #038103;
+  border-bottom: none;
+}
+.seravo-site-check-issue-box {
+  overflow: hidden;
+  padding: 10px;
+  border: 1.5px solid#ccd0d4;
+  border-left: solid 0.3em red;
+  border-bottom: none;
+}
+
+.seravo-cache-test-result-wrapper,
+.seravo-site-check-result-wrapper {
   -moz-transition: border 1s ease-in;
   -o-transition: border 1s ease-in;
   -webkit-transition: border 1s ease-in;
@@ -141,7 +157,8 @@ th, td {
   transition: border 1s ease-in;
 }
 
-.seravo-cache-test-result {
+.seravo-cache-test-result,
+.seravo-site-check-result {
   box-shadow: 0 1px 1px 1px rgba(0,0,0,0.2);
   display: none;
   margin: 1em;
@@ -150,7 +167,8 @@ th, td {
   padding: 1em;
 }
 
-.seravo_cache_tests_status {
+.seravo_cache_tests_status,
+.seravo_site_check_status {
   font-size: 15px;
   font-weight: bold;
   margin-top: 1.6em;
@@ -159,7 +177,8 @@ th, td {
   text-align: center;
 }
 
-.seravo_cache_test_show_more_wrapper {
+.seravo_cache_test_show_more_wrapper,
+.seravo_site_check_show_more_wrapper {
   -ms-transform: translateY(-50%);
   -webkit-transform: translateY(-50%);
   float: right;
@@ -171,9 +190,13 @@ th, td {
 }
 
 .seravo_cache_test_show_more,
+.seravo_site_check_show_more,
 .seravo_cache_test_show_more:hover,
+.seravo_site_check_show_more:hover,
 .seravo_cache_test_show_more:active,
-.seravo_cache_test_show_more:focus {
+.seravo_site_check_show_more:active,
+.seravo_cache_test_show_more:focus,
+.seravo_site_check_show_more:focus {
   box-shadow: none;
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
#### What are the main changes in this PR?
The feature adds a postbox to site status page on which users can run site checks. Site checks provides a report about good / pass and potential issues. 

Currently the checks include:
- HTTPS
- Recaptcha
- Deprecated plugins / features (currently wp-palvelu-plugin and https-domain-alias)
- Inactive plugins and themes
- Command `wp-test` status
- PHP error count

The checks are easily extendable as the check-site-health.php class can be extended by adding new logic. Note, translations are still to be done. 

##### Why are we doing this? Any context or related work?
See #66 

#### Screenshots
![Screenshot](https://user-images.githubusercontent.com/16706187/109479587-339a8080-7a83-11eb-9dc8-238f514608d4.png)

![Screenshot(1)](https://user-images.githubusercontent.com/16706187/109479574-309f9000-7a83-11eb-8805-834e67a1e227.png)


