### PR TITLE
Check that logfile can be opened before writing (Related: #492)

### DIFF
--- a/modules/thirdparty-fixes.php
+++ b/modules/thirdparty-fixes.php
@@ -111,17 +111,20 @@ if ( ! class_exists('ThirdpartyFixes') ) {
 
         global $wpdb;
         $handle = fopen($logfile, 'a');
-        $sid = isset($_SERVER['HTTP_X_SERAVO_REQUEST_ID']) ? $_SERVER['HTTP_X_SERAVO_REQUEST_ID'] : 'none';
-        fwrite($handle, '### ' . date(\DateTime::ISO8601) . ' sid:' . $sid . ' total:' . $wpdb->num_queries . chr(10));
-        foreach ( $wpdb->queries as $q ) {
-            fwrite($handle, "SQL: $q[0]" . chr(10));
-            fwrite($handle, "Time: $q[1] s" . chr(10));
-            fwrite($handle, "Calling functions: $q[2]" . chr(10));
-            fwrite($handle, "Query begin: $q[3]" . chr(10));
-            fwrite($handle, 'Custom data: ' . print_r($q[4], true) . chr(10) . '--' . chr(10));
+
+        if ( $handle !== false ) {
+          $sid = isset($_SERVER['HTTP_X_SERAVO_REQUEST_ID']) ? $_SERVER['HTTP_X_SERAVO_REQUEST_ID'] : 'none';
+          fwrite($handle, '### ' . date(\DateTime::ISO8601) . ' sid:' . $sid . ' total:' . $wpdb->num_queries . chr(10));
+          foreach ( $wpdb->queries as $q ) {
+              fwrite($handle, "SQL: $q[0]" . chr(10));
+              fwrite($handle, "Time: $q[1] s" . chr(10));
+              fwrite($handle, "Calling functions: $q[2]" . chr(10));
+              fwrite($handle, "Query begin: $q[3]" . chr(10));
+              fwrite($handle, 'Custom data: ' . print_r($q[4], true) . chr(10) . '--' . chr(10));
+          }
+          fwrite($handle, '### EOF' . chr(10));
+          fclose($handle);
         }
-        fwrite($handle, '### EOF' . chr(10));
-        fclose($handle);
     }
 
     /**


### PR DESCRIPTION
#### What are the main changes in this PR?
Check that the file pointer is truly returned when opening the logfile. This fixes situations where fopen returns false and fwrite attempts multiple times to write on to those false values. 

##### Why are we doing this? Any context or related work?
See #492 
