### PR TITLE
Remove changes status feature from load function (Closes: #494)

### DIFF
--- a/js/upkeep.js
+++ b/js/upkeep.js
@@ -111,8 +111,6 @@ jQuery(document).ready(function($) {
     });
   });
 
-  jQuery(window).load(function(){
-
     function seravo_load_change_report(given_date) {
       jQuery.post(
         seravo_upkeep_loc.ajaxurl,
@@ -191,8 +189,6 @@ jQuery(document).ready(function($) {
         });
       }
     });
-
-  });
 
   function insertEmail() {
     if (validateEmail($emailInput)) {


### PR DESCRIPTION
#### What are the main changes in this PR?
Remove the changes status ajax and JS side functions from under the window load function. This should fix the changes status feature not working. On the other hand, the JS window load function is excessive and unnecessary on this instance as well. 

##### Why are we doing this? Any context or related work?
See #494 
