### PR TITLE
Fix PHP related fatal error and array key warnings (Related: #478)

### DIFF
--- a/lib/domain-tables.php
+++ b/lib/domain-tables.php
@@ -98,7 +98,10 @@ class Seravo_Domains_List_Table extends WP_List_Table {
     $expires = $item['expires'];
     if ( ! empty($expires) ) {
       $timestamp = date_create_from_format('Y-m-d\TH:i:sO', $expires);
-      return date_format($timestamp, get_option('date_format') . ' ' . get_option('time_format'));
+
+      if ( $timestamp !== false ) {
+        return date_format($timestamp, get_option('date_format') . ' ' . get_option('time_format'));
+      }
     }
   }
 
@@ -202,7 +205,7 @@ class Seravo_Domains_List_Table extends WP_List_Table {
           $domain = $entry['domain'];
           while ( substr_count($domain, '.') >= 1 ) {
             foreach ( $rawdata as $entry_compare ) {
-              if ( ! $entry_compare['subdomain'] && $domain === $entry_compare['domain'] ) {
+              if ( isset($entry_compare['subdomain']) && ! $entry_compare['subdomain'] && $domain === $entry_compare['domain'] ) {
                 $rawdata[$index]['expires'] = $entry_compare['expires'];
                 $rawdata[$index]['management'] = $entry_compare['management'];
                 break 2;


### PR DESCRIPTION
#### What are the main changes in this PR?
Fix fatal error with timestamp returning false and trying to pass it to `date_format()` function. Also, fix undefined subdomain array key warnings by checking they exist. The most crucial fix is the PHP fatal error fix. 

##### Why are we doing this? Any context or related work?
See #478 
