### PR TITLE
Add id and use it on link to redirect directly (Closes: #499)

### DIFF
--- a/modules/sitestatus.php
+++ b/modules/sitestatus.php
@@ -399,7 +399,7 @@ if ( ! class_exists('Site_Status') ) {
         echo '<p>' . __('No Account Manager found. Account Manager is only included in Seravo Enterprise plans.', 'seravo') . '</p>';
       }
 
-      print_item($contact_emails, '<a href="tools.php?page=upkeep_page">' . __('Technical Contacts', 'seravo') . '</a>');
+      print_item($contact_emails, '<a href="tools.php?page=upkeep_page#contacts">' . __('Technical Contacts', 'seravo') . '</a>');
     }
 
     public static function seravo_shadows_postbox() {

--- a/modules/upkeep.php
+++ b/modules/upkeep.php
@@ -176,7 +176,7 @@ if ( ! class_exists('Upkeep') ) {
           <button type="button" class="button" id="slack_webhook_test"><?php _e('Send a Test Notification', 'seravo'); ?></button>
 
           <hr class="seravo-updates-hr">
-          <h3><?php _e('Contacts', 'seravo'); ?></h3>
+          <h3 id='contacts'><?php _e('Contacts', 'seravo'); ?></h3>
           <p><?php _e('Seravo may use the email addresses defined here to send automatic notifications about technical problems with you site. Remember to use a properly formatted email address.', 'seravo'); ?></p>
           <input class="technical_contacts_input" type="email" multiple size="30" placeholder="<?php _e('example@example.com', 'seravo'); ?>" value="" data-emails="<?php echo htmlspecialchars(json_encode($contact_emails)); ?>">
           <button type="button" class="technical_contacts_add button"><?php _e('Add', 'seravo'); ?></button>


### PR DESCRIPTION
#### What are the main changes in this PR?
Update "Technical Contacts" link on Site Status page to redirect directly to Contacts section on upkeep page.

##### Why are we doing this? Any context or related work?
#499 
