### PR TITLE
Make speedtest button scroll to speedtest postbox

### DIFF
--- a/modules/speed-test.php
+++ b/modules/speed-test.php
@@ -48,7 +48,7 @@ if ( ! class_exists('Speed_Test') ) {
           )
         );
       } else {
-        $url .= '&speed_test_target=' . $target_location;
+        $url .= '&speed_test_target=' . $target_location . '#seravo-postbox-speed-test';
         $admin_bar->add_menu(
           array(
             'id'    => 'speed-test',


### PR DESCRIPTION
Appended `#seravo-postbox-speed-test` to speedtest button on admin bar. It took me a while to understand what the button does as the speedtest postbox was at the bottom of the page. The button now scrolls down to speedtest postbox.