### PR TITLE
Fix SQL log warnings and formatting

### DIFF
--- a/modules/thirdparty-fixes.php
+++ b/modules/thirdparty-fixes.php
@@ -112,17 +112,19 @@ if ( ! class_exists('ThirdpartyFixes') ) {
         global $wpdb;
         $handle = fopen($logfile, 'a');
 
-        if ( $handle !== false ) {
+        if ( $wpdb->num_queries > 0 && $handle !== false ) {
           $sid = isset($_SERVER['HTTP_X_SERAVO_REQUEST_ID']) ? $_SERVER['HTTP_X_SERAVO_REQUEST_ID'] : 'none';
           fwrite($handle, '### ' . date(\DateTime::ISO8601) . ' sid:' . $sid . ' total:' . $wpdb->num_queries . chr(10));
           foreach ( $wpdb->queries as $q ) {
-              fwrite($handle, "SQL: $q[0]" . chr(10));
+              $sql = trim(preg_replace('/[\t\n\r\s]+/', ' ', $q[0]));
+              $data = str_replace("\n", '', print_r($q[4], true));
+              fwrite($handle, "SQL: $sql" . chr(10));
               fwrite($handle, "Time: $q[1] s" . chr(10));
               fwrite($handle, "Calling functions: $q[2]" . chr(10));
               fwrite($handle, "Query begin: $q[3]" . chr(10));
-              fwrite($handle, 'Custom data: ' . print_r($q[4], true) . chr(10) . '--' . chr(10));
+              fwrite($handle, 'Custom data: ' . $data . chr(10) . '--' . chr(10));
           }
-          fwrite($handle, '### EOF' . chr(10));
+          fwrite($handle, '### EOF' . chr(10) . chr(10));
           fclose($handle);
         }
     }


### PR DESCRIPTION
#### What are the main changes in this PR?
SQL logging now makes sure there's any queries preventing these PHP-warnings (with `WP_DEBUG`):
` Warning: Invalid argument supplied for foreach() in /data/wordpress/htdocs/wp-content/mu-plugins/seravo-plugin/modules/thirdparty-fixes.php on line 118`
and useless sql.log entries:
```
...
### EOF
### 2021-03-25T13:24:13+0000 sid:xxxxxx total:0
### EOF
### 2021-03-25T13:24:13+0000 sid:xxxxxx total:0
### EOF
### 2021-03-25T13:24:13+0000 sid:xxxxxx total:0
...
```

Also now removes excess formatting from queries which had a lot of newlines, tabs, spaces etc.
They didn't look good in sql.log and made the reading just harder:

OLD:
```
### 2021-03-25T13:26:08+0000 sid:0b5b86c40b89686ddd051d25b3f18cc5 total:1
SQL: 
		SELECT comment_approved, COUNT( * ) AS total
		FROM wp_comments
		
		GROUP BY comment_approved
	
Time: 0.00067687034606934 s
Calling functions: require_once('wp-admin/admin.php'), require('wp-admin/menu.php'), wp_count_comments, get_comment_count
Query begin: 1616678768.5494
Custom data: Array
(
)

--
### EOF
```

NEW:
```
### 2021-03-25T13:28:08+0000 sid:ee339db9763ff068e197f61e6db29c07 total:1
SQL: SELECT comment_approved, COUNT( * ) AS total FROM wp_comments GROUP BY comment_approved
Time: 0.00056195259094238 s
Calling functions: require_once('wp-admin/admin.php'), require('wp-admin/menu.php'), wp_count_comments, get_comment_count
Query begin: 1616678888.7851
Custom data: Array()
--
### EOF
```