### PR TITLE
Fix HTTP cache status title

### DIFF
--- a/js/sitestatus.js
+++ b/js/sitestatus.js
@@ -291,7 +291,7 @@ jQuery(document).ready(function($) {
           jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #038103');
         } else {
           jQuery('.seravo_cache_tests_status').fadeIn('slow', function() {
-            jQuery(this).html(seravo_site_status_loc.cache_success).fadeIn('slow');
+            jQuery(this).html(seravo_site_status_loc.cache_failure).fadeIn('slow');
           });
           jQuery('.seravo-cache-test-result-wrapper').css('border-left', 'solid 0.5em #e74c3c');
         }


### PR DESCRIPTION
The result title didn't make much sense as HTTP cache clearly isn't working.

![confusing title](https://user-images.githubusercontent.com/42264063/112486078-3cc9f500-8d84-11eb-8dd4-221ddd6df863.png)
