### PR TITLE
Fix timezone error

### DIFF
--- a/lib/security-ajax.php
+++ b/lib/security-ajax.php
@@ -29,7 +29,7 @@ function seravo_logins_info( $max = 10 ) {
   // If the wp-login.log has less than $max entries check older log files
   if ( count($login_data) < $max ) {
     // Check the second newest log file (not gzipped yet)
-    $login_data2_filename = glob('/data/log/wp-login.log-[0-9]*[?!\.gz]');
+    $login_data2_filename = glob('/data/log/wp-login.log-[0-9]*[!\.gz]');
     // There should be only a maximum of one file matching previous criterion, but
     // count the files just in case and choose the biggest index
     $login_data2_count = count($login_data2_filename) - 1;

--- a/modules/login-notification.php
+++ b/modules/login-notification.php
@@ -178,8 +178,9 @@ if ( ! class_exists('Login_Notifications') ) {
           $domain = gethostbyaddr($ip);
 
           // Fetch login date and time
+          $timezone = get_option('timezone_string');
           $datetime = \DateTime::createFromFormat('d/M/Y:H:i:s T', $entry['datetime']);
-          $datetime->setTimezone(new \DateTimeZone(wp_timezone_string()));
+          $datetime->setTimezone(new \DateTimeZone(empty($timezone) ? 'UTC' : $timezone));
 
           return array(
             'date'   => $datetime->format(get_option('date_format')),


### PR DESCRIPTION
#### What are the main changes in this PR?

- Fixes wp-login.log regex
-  Removes usage of `wp_timezone_string` so older core versions work