### PR TITLE
Use strict comparison when checking for option existence

### DIFF
--- a/modules/check-default-options.php
+++ b/modules/check-default-options.php
@@ -22,7 +22,7 @@ $options = array(
 );
 
 foreach ( $options as $option ) {
-  if ( ! get_option($option) ) {
+  if ( get_option($option) === false ) {
     update_option($option, 'on');
   }
 }


### PR DESCRIPTION
The plugin uses an empty string as a false value. It means that the
user explicitly stated that they don't want the feature.

Do not override empty strings.

Closes: #514 