### PR TITLE
Add search-replace extension for multisites

### DIFF
--- a/modules/wp-cli.php
+++ b/modules/wp-cli.php
@@ -40,4 +40,70 @@ class Seravo_WP_CLI extends \WP_CLI_Command {
   }
 }
 
+/**
+ * Extends wp-cli search-replace feature.
+ *
+ * Will be called after running regular search-replace,
+ * even if --skip-plugins is specified.
+ */
+function search_replace_extension() {
+  // Positionals <old> <new> [<table>...]>
+  $positionals = \WP_CLI::get_runner()->__get('arguments');
+  $options = \WP_CLI::get_runner()->__get('assoc_args');
+
+  if ( count($positionals) != 3 ) {
+    // User gave specific tables to run search-replace on,
+    // nothing else should be replaced
+    return;
+  }
+
+  $from = $positionals[1];
+  $to = $positionals[2];
+
+  $dry_run = \WP_CLI\Utils\get_flag_value($options, 'dry-run');
+  $regex = \WP_CLI\Utils\get_flag_value($options, 'regex', false);
+
+  if ( $dry_run === true || $regex === true ) {
+    // No need to do anything on dry-run and
+    // shouldn't mess with regex for now
+    return;
+  }
+
+  if ( is_multisite() === true ) {
+    // This is a multisite, check whether
+    // we need to replace DOMAIN_CURRENT_SITE
+    if ( defined('DOMAIN_CURRENT_SITE') ) {
+      $old = DOMAIN_CURRENT_SITE;
+      $new = DOMAIN_CURRENT_SITE;
+
+      if ( $from === $old ) {
+        $new = $to;
+      } else if ( $from === ('://' . $old) ) {
+        $new = ltrim($to, '://');
+      }
+
+      if ( $old !== $new ) {
+        // Replace DOMAIN_CURRENT_SITE in wp-config.php
+        $wp_config = '/data/wordpress/htdocs/wp-config.php';
+        $replace_regex = '/define.*DOMAIN_CURRENT_SITE.*;/';
+        $replace_with = "define( 'DOMAIN_CURRENT_SITE', '$new' );";
+
+        // Read wp-config.php, make the change, write it back
+        $content = file_get_contents($wp_config);
+        $new_content = preg_replace($replace_regex, $replace_with, $content);
+
+        if ( $new_content !== $content ) {
+          file_put_contents($wp_config, $new_content);
+
+          if ( is_executable('/usr/local/bin/s-git-commit') && file_exists('/data/wordpress/.git') ) {
+            // Commit wp-config.php changes
+            exec('cd /data/wordpress/ && git add htdocs/wp-config.php && /usr/local/bin/s-git-commit -m "Update DOMAIN_CURRENT_SITE" && cd /data/wordpress/htdocs/wordpress/wp-admin');
+          }
+        }
+      }
+    }
+  }
+}
+
 \WP_CLI::add_command('seravo', 'Seravo\Seravo_WP_CLI');
+\WP_CLI::add_hook('after_invoke:search-replace', 'Seravo\search_replace_extension');


### PR DESCRIPTION
#### What are the main changes in this PR?
Extends wp-cli `wp search-replace` to replace `DOMAIN_CURRENT_SITE` on multisites when needed.

Prevents multisites from breaking on automatic domain changes or manual search-replace.

```
$ wp option get home
https://joosua.fi
$ grep -F htdocs/wp-config.php -e DOMAIN_CURRENT_SITE 
define( 'DOMAIN_CURRENT_SITE', 'joosua.fi' );

$ wp search-replace 'joosua.fi' 'wordpress.joosua.me' --quiet
$ wp cache flush
Success: The cache was flushed.

$ wp option get home
https://wordpress.joosua.me
$ grep -F htdocs/wp-config.php -e DOMAIN_CURRENT_SITE 
define( 'DOMAIN_CURRENT_SITE', 'wordpress.joosua.me' );
```