### PR TITLE
Fix HTTP stats latest months logic

### DIFF
--- a/modules/dashboard-widgets.php
+++ b/modules/dashboard-widgets.php
@@ -264,7 +264,7 @@ if ( ! class_exists('Dashboard_Widgets') ) {
         $report_month_counter = 0;
         $months = array();
 
-        foreach ( $reports as $report ) {
+        foreach ( array_reverse($reports) as $report ) {
           if ( $report_month_counter === 4 ) {
             // show only limited amount of monthly http requests
             break;
@@ -286,7 +286,7 @@ if ( ! class_exists('Dashboard_Widgets') ) {
           );
         }
 
-        foreach ( array_reverse($months) as $month ) {
+        foreach ( $months as $month ) {
           $month_date = $month['month'];
           $total_requests = $month['requests'];
 


### PR DESCRIPTION
#### What are the main changes in this PR?
WP-admin dashboard widget with HTTP stats had a bug in the logic. Instead of showing the latest 4 months as intended, it was showing the first 4 months of the year. This is just a minor fix. 

##### Why are we doing this? Any context or related work?
For the widget see #5 
