### PR TITLE
Check if PHP compatibility log file exists

### DIFF
--- a/modules/logs.php
+++ b/modules/logs.php
@@ -117,6 +117,14 @@ if ( ! class_exists('Logs') ) {
         }
       }
 
+      // Check if PHP compatibility log exists and generate new if not
+      $php_compatibility_log = '/data/log/php-compatibility.log';
+
+      if ( ! file_exists($php_compatibility_log) ) {
+        file_put_contents($php_compatibility_log, '');
+        array_push($logs, $php_compatibility_log);
+      }
+
       if ( empty($logs) ) {
           echo '<div class="notice notice-warning" style="padding:1em;margin:1em;">' .
           __('No logs found in <code>/data/log/</code>.', 'seravo') . '</div>';
@@ -124,6 +132,7 @@ if ( ! class_exists('Logs') ) {
 
       // Create an array of the logfiles with basename of log as key
       $logfiles = array();
+
       foreach ( $logs as $key => $log ) {
         $logfiles[ basename($log) ] = $log;
       }


### PR DESCRIPTION
#### What are the main changes in this PR?
Command `wp-php-compatibility-check` has not been run on all sites thus when moving from upkeep page using the link "compatibility scan result" it shows the default `php-error.log` file. This can be confusing for the users if they start interpreting the php-error.log as compatibility log. This fixes the issue by checking whether log file exists and creates blank if not. 

##### Why are we doing this? Any context or related work?
There's internal issue about the fix / enhancement.
