### PR TITLE
Add common css file

### DIFF
--- a/style/common.css
+++ b/style/common.css
@@ -1,1 +1,113 @@
-.class {}
+/*
+ * Description: Common css file for any Seravo Plugin page to apply
+ * styles for postboxes, widgets etc.
+ */
+
+ /* Dashboard widgets and postboxes */
+
+  div#seravo-error-widget.postbox,
+  div#seravo-low-disk-space-widget.postbox {
+      border-left: 0.2em solid #e8ba1b;
+  }
+
+ /* Tooltip css */
+
+  .tooltip {
+    position: relative;
+    padding-left: 5px;
+    content: "\f348";
+  }
+
+  .tooltip .tooltiptext {
+    font-size: 0.6em;
+    visibility: hidden;
+    width: 130px;
+    background-color: #555555;
+    color: #fff;
+    text-align: center;
+    border-radius: 5px;
+    padding: 8px;
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -60px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    line-height: 1.3;
+    font-family: sans-serif;
+  }
+
+  .tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #555555 transparent transparent transparent;
+  }
+
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  .dashicons-info {
+    color: #b1b2b3;
+  }
+
+  /* Result wrapper components */
+
+  .seravo-result-wrapper {
+  -moz-transition: border 1s ease-in;
+  -o-transition: border 1s ease-in;
+  -webkit-transition: border 1s ease-in;
+  background-color: white;
+  border-left: solid 0.5em #e8ba1b;
+  box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.12);
+  display: block;
+  margin-top: 2em;
+  max-width: 55em;
+  min-height: 5em;
+  overflow: hidden;
+  transition: border 1s ease-in;
+}
+
+.seravo-result {
+  box-shadow: 0 1px 1px 1px rgba(0,0,0,0.2);
+  display: none;
+  margin: 1em;
+  max-height: 30em;
+  padding: 1em;
+}
+
+.seravo_result_wrapper_title {
+  font-size: 15px;
+  font-weight: bold;
+  margin-top: 1.6em;
+  margin-left: 0.5em;
+  padding-bottom: 7px;
+  text-align: center;
+}
+
+.seravo_show_more_wrapper {
+  -ms-transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+  float: right;
+  height: 1em;
+  margin-right: 0.5em;
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.seravo_show_more,
+.seravo_show_more:hover,
+.seravo_show_more:active,
+.seravo_show_more:focus {
+  box-shadow: none;
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
#### What are the main changes in this PR?
Add common css file that contains dashboard error widgets, tooltip and "Toggle more" wrapper related css styles. Result wrapper css might need re-working when applying the styles for the new design. 

There are still some files, like `password.css`, that contain only a few styles. Should we move those under the common as well?
