### PR TITLE
Add option to dry-run

### DIFF
--- a/src/lib/ajax/templates/auto-command.php
+++ b/src/lib/ajax/templates/auto-command.php
@@ -16,7 +16,7 @@ use \Seravo\Postbox\Template;
 class AutoCommand extends CommandRunner {
 
   /**
-   * Constructor for AjaxHandler. Will be called on new instance.
+   * Constructor for AutoCommand. Will be called on new instance.
    * @param string $section Unique section inside the postbox.
    * @param string|null $command Command to be executed.
    * @param int $cache_time Seconds to cache response for (default is 300).

--- a/src/lib/ajax/templates/button-command.php
+++ b/src/lib/ajax/templates/button-command.php
@@ -21,7 +21,12 @@ class ButtonCommand extends CommandRunner {
   private $button_text;
 
   /**
-   * Constructor for AjaxHandler. Will be called on new instance.
+   * @var string|null Text to be shown on the dryrun button.
+   */
+  private $dryrun_button_text;
+
+  /**
+   * Constructor for ButtonCommand. Will be called on new instance.
    * @param string $section Unique section inside the postbox.
    * @param string|null $command Command to be executed.
    * @param int $cache_time Seconds to cache response for (default is 300).
@@ -45,10 +50,21 @@ class ButtonCommand extends CommandRunner {
    */
   public function build_component( Component $base, $section ) {
     $button_content = $this->button_text !== null ? $this->button_text : __('Run', 'seravo');
+    $dryrun_button_content = $this->dryrun_button_text !== null ? $this->dryrun_button_text : __('Dry-run', 'seravo');
 
-    $button = Template::button($button_content, $section . '-button');
-    $spinner = Template::spinner($section . '-spinner');
-    $spinner_button = Template::side_by_side($button, $spinner);
+    if ( $this->is_dryrun_enabled() ) {
+      $spinner_button = Template::n_by_side(
+        array(
+          Template::button($dryrun_button_content, $section . '-dryrun-button', 'button-primary'),
+          Template::button($button_content, $section . '-button', 'button-primary', true),
+          Template::spinner($section . '-spinner'),
+        )
+      );
+    } else {
+      $button = Template::button($button_content, $section . '-button');
+      $spinner = Template::spinner($section . '-spinner');
+      $spinner_button = Template::side_by_side($button, $spinner);
+    }
 
     $component = new Component('', "<div class=\"seravo-ajax-button-command\" data-section=\"{$section}\">", '</div>');
     $component->add_child($spinner_button);
@@ -58,11 +74,28 @@ class ButtonCommand extends CommandRunner {
   }
 
   /**
+   * Set the command to be executed.
+   * @param string $command Command for exec.
+   * @param int $cache_time Seconds to cache response for (default is 300).
+   * @param bool $allow_failure Whether exit code other than 0 should respond with an error.
+   * @param bool $dryrun Whether dry-running is enabled.
+   */
+  public function set_command( $command, $cache_time = 300, $allow_failure = false, $dryrun = false ) {
+    if ( $dryrun ) {
+      $cache_time = 0;
+    }
+
+    parent::set_command($command, $cache_time, $allow_failure);
+    $this->enable_dryrun($dryrun);
+  }
+
+  /**
    * Set text for the command execute button.
    * @param string $text Text on the button.
    */
-  public function set_button_text( $text ) {
+  public function set_button_text( $text, $dryrun_text = null ) {
     $this->button_text = $text;
+    $this->dryrun_button_text = $dryrun_text;
   }
 
 }

--- a/src/lib/ajax/templates/command-runner.php
+++ b/src/lib/ajax/templates/command-runner.php
@@ -21,6 +21,11 @@ class CommandRunner extends AjaxHandler {
   private $command;
 
   /**
+   * @var bool Whether dryrun is enabled.
+   */
+  private $dryrun = false;
+
+  /**
    * @var bool Whether exit code other than 0 should respond with an error.
    */
   private $allow_failure = false;
@@ -62,6 +67,10 @@ class CommandRunner extends AjaxHandler {
       return AjaxResponse::unknown_error_response();
     }
 
+    if ( $this->is_dryrun_enabled() && isset($_GET['dryrun']) && $_GET['dryrun'] === 'true' ) {
+      $this->command = $command . ' --dry-run';
+    }
+
     $output = null;
     $retval = null;
     exec($this->command, $output, $retval);
@@ -89,9 +98,13 @@ class CommandRunner extends AjaxHandler {
   /**
    * Set the command to be executed.
    * @param string $command Command for exec.
+   * @param int $cache_time Seconds to cache response for (default is 300).
+   * @param bool $allow_failure Whether exit code other than 0 should respond with an error.
    */
-  public function set_command( $command ) {
+  public function set_command( $command, $cache_time = 300, $allow_failure = false ) {
     $this->command = $command;
+    $this->allow_failure = $allow_failure;
+    $this->set_cache_time($cache_time);
   }
 
   /**
@@ -108,6 +121,22 @@ class CommandRunner extends AjaxHandler {
    */
   public function set_empty_message( $message ) {
     $this->empty_message = $message;
+  }
+
+  /**
+   * Enables dry-run option for the handler.
+   * @param bool $enabled Whether dryrun is enabled.
+   */
+  public function enable_dryrun( $enabled ) {
+    $this->dryrun = $enabled;
+  }
+
+  /**
+   * Check if dry-running is enabled for the handler.
+   * @return bool Whether dry-run is enabled.
+   */
+  public function is_dryrun_enabled() {
+    return $this->dryrun;
   }
 
 }

--- a/src/lib/postbox/component/template.php
+++ b/src/lib/postbox/component/template.php
@@ -65,8 +65,9 @@ class Template {
    * @param string $class Specified button class to use.
    * @return \Seravo\Postbox\Component Button component.
    */
-  public static function button( $content, $id, $class = 'button-primary' ) {
-    return Component::from_raw('<button id="' . $id . '" class="' . $class . '">' . $content . '</button>');
+  public static function button( $content, $id, $class = 'button-primary', $disabled = false ) {
+    $disabled = $disabled ? ' disabled' : '';
+    return Component::from_raw('<button id="' . $id . '" class="' . $class . '"' . $disabled . '>' . $content . '</button>');
   }
 
   /**
@@ -110,8 +111,8 @@ class Template {
 
   /**
    * Get wrapper component to show two components side by side.
-   * @param \Seravo\Postbox\Component Left component.
-   * @param \Seravo\Postbox\Component Right component.
+   * @param \Seravo\Postbox\Component $left Left component.
+   * @param \Seravo\Postbox\Component $right Right component.
    * @return \Seravo\Postbox\Component Side-by-side component.
    */
   public static function side_by_side( Component $left, Component $right ) {
@@ -125,6 +126,25 @@ class Template {
     $right_div = new Component('', '<div>', '</div>');
     $right_div->add_child($right);
     $wrapper->add_child($right_div);
+
+    $component->add_child($wrapper);
+    return $component;
+  }
+
+  /**
+   * Get wrapper component to show multiple components side by side.
+   * @param \Seravo\Postbox\Component[] $components Components from left to right.
+   * @return \Seravo\Postbox\Component Side-by-side component.
+   */
+  public static function n_by_side( $components ) {
+    $component = new Component();
+    $wrapper = new Component('', '<div class="side-by-side-container">', '</div>');
+
+    foreach ( $components as $child_component ) {
+      $div = new Component('', '<div>', '</div>');
+      $div->add_child($child_component);
+      $wrapper->add_child($div);
+    }
 
     $component->add_child($wrapper);
     return $component;

--- a/src/lib/postbox/postbox.php
+++ b/src/lib/postbox/postbox.php
@@ -183,7 +183,7 @@ class Postbox {
       $this->component = Template::error_paragraph($error);
     } else {
       // Call the $build_func
-      \call_user_func($this->build_func, $this->component, $this->data);
+      \call_user_func($this->build_func, $this->component, $this, $this->data);
     }
 
     $this->component->print_html();

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -109,6 +109,7 @@ return array(
     'Seravo\\Ajax\\AutoCommand' => $baseDir . '/src/lib/ajax/templates/auto-command.php',
     'Seravo\\Ajax\\ButtonCommand' => $baseDir . '/src/lib/ajax/templates/button-command.php',
     'Seravo\\Ajax\\CommandRunner' => $baseDir . '/src/lib/ajax/templates/command-runner.php',
+    'Seravo\\Ajax\\DryRunCommand' => $baseDir . '/src/lib/ajax/templates/dryrun-command.php',
     'Seravo\\Helpers' => $baseDir . '/src/lib/helpers.php',
     'Seravo\\Postbox\\AutoCommand' => $baseDir . '/src/lib/postbox/templates/auto-command.php',
     'Seravo\\Postbox\\ButtonCommand' => $baseDir . '/src/lib/postbox/templates/button-command.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -132,6 +132,7 @@ class ComposerStaticInit7f722af553c36d468cd317a3e32759ad
         'Seravo\\Ajax\\AutoCommand' => __DIR__ . '/../..' . '/src/lib/ajax/templates/auto-command.php',
         'Seravo\\Ajax\\ButtonCommand' => __DIR__ . '/../..' . '/src/lib/ajax/templates/button-command.php',
         'Seravo\\Ajax\\CommandRunner' => __DIR__ . '/../..' . '/src/lib/ajax/templates/command-runner.php',
+        'Seravo\\Ajax\\DryRunCommand' => __DIR__ . '/../..' . '/src/lib/ajax/templates/dryrun-command.php',
         'Seravo\\Helpers' => __DIR__ . '/../..' . '/src/lib/helpers.php',
         'Seravo\\Postbox\\AutoCommand' => __DIR__ . '/../..' . '/src/lib/postbox/templates/auto-command.php',
         'Seravo\\Postbox\\ButtonCommand' => __DIR__ . '/../..' . '/src/lib/postbox/templates/button-command.php',


### PR DESCRIPTION
#### What are the main changes in this PR?

Adds option to dry-run with ButtonCommand. Also adds bunch of other fixes.


### Example usage:
```
$db_cleanup = new Postbox\Postbox('backups-db-cleanup');
$db_cleanup->set_title(__('DB Cleanup test', 'seravo'));
$db_cleanup->set_build_func(array(__CLASS__, 'build_db_optimize'));
$db_cleanup->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
// Init optimize-db ajax handler
$db_cleanup->add_ajax_handler(new Ajax\ButtonCommand('cleanup-db'));
$db_cleanup->get_ajax_handler('cleanup-db')->set_command('wp-db-cleanup', 0, true, true);
$db_cleanup->get_ajax_handler('cleanup-db')->set_button_text(__('Cleanup database', 'seravo'), __('Dry-run', 'seravo'));
$db_cleanup->get_ajax_handler('cleanup-db')->set_empty_message(__('Nothing to cleanup!', 'seravo'));
$page->register_postbox($db_cleanup);
```