### PR TITLE
Rewrite more widgets on upkeep and sitestatus pages

### DIFF
--- a/src/lib/postbox/component/component.php
+++ b/src/lib/postbox/component/component.php
@@ -39,9 +39,9 @@ class Component {
 
   /**
    * Add a child which will be rendered after the content.
-   * @param \Seravo\Postbox\Component $child Child component to be added.
+   * @param mixed $child $child Child component to be added.
    */
-  public function add_child( Component $child ) {
+  public function add_child( $child ) {
     if ( $child === null ) {
       return;
     }

--- a/src/lib/postbox/component/template.php
+++ b/src/lib/postbox/component/template.php
@@ -49,6 +49,25 @@ class Template {
   }
 
   /**
+   * Display HTML list view.
+   * @param string|array $element Element or elements to add onto list.
+   * @return \Seravo\Postbox\Component List view component.
+   */
+  public static function list_view( $element ) {
+    $component = new Component('', '<ul class="postbox-ul">', '</ul>');
+
+    if ( is_array($element) ) {
+      foreach ( $element as $list_object ) {
+        $component->add_child(Component::from_raw('<li>' . $list_object . '</li>'));
+      }
+    }
+
+    $component->add_child(Component::from_raw('<li>' . $element . '</li>'));
+
+    return $component;
+  }
+
+  /**
     * Display link
     * @param string $content Text to wrap the link around.
     * @param string $href Link URL.

--- a/src/modules/database.php
+++ b/src/modules/database.php
@@ -20,7 +20,6 @@ if ( ! defined('ABSPATH') ) {
 }
 
 require_once SERAVO_PLUGIN_SRC . 'lib/search-replace-ajax.php';
-require_once SERAVO_PLUGIN_SRC . 'lib/db-cleanup-ajax.php';
 require_once SERAVO_PLUGIN_SRC . 'lib/database-ajax.php';
 
 if ( ! class_exists('Database') ) {

--- a/src/modules/sitestatus.php
+++ b/src/modules/sitestatus.php
@@ -427,6 +427,12 @@ if ( ! class_exists('Site_Status') ) {
     public static function get_site_info() {
       $info = \Seravo\Upkeep::seravo_admin_get_site_info();
 
+      if ( is_wp_error($info) ) {
+        $data['error'] = __('An API error occured. Please try again later', 'seravo');
+        error_log($info->get_error_message());
+        return $data;
+      }
+
       $plans = array(
         'demo'       => __('Demo', 'seravo'),
         'mini'       => __('WP Mini', 'seravo'),
@@ -466,7 +472,7 @@ if ( ! class_exists('Site_Status') ) {
         $data['country'] = __('Site Location', 'seravo') . ': ' . $countries[$info['country']];
       }
       // Check for contacts
-      $contacts = isset($info['contact_emails']) ? implode(', ', $info['contact_emails']) : array();
+      $contacts = isset($info['contact_emails']) ? implode(', ', $info['contact_emails']) : __('No contacts found', 'seravo');
       $data['contacts'] = '<a href="tools.php?page=upkeep_page#contacts">' . __('Technical Contacts', 'seravo') . '</a>: ' . $contacts;
 
       return $data;

--- a/style/common.css
+++ b/style/common.css
@@ -25,6 +25,11 @@
     height: 20px;
   }
 
+  .postbox-ul {
+    list-style-type: disc;
+    padding-left: 18px;
+  }
+
   div#seravo-error-widget.postbox,
   div#seravo-low-disk-space-widget.postbox {
       border-left: 0.2em solid #e8ba1b;

--- a/vendor/composer/installers/.github/workflows/continuous-integration.yml
+++ b/vendor/composer/installers/.github/workflows/continuous-integration.yml
@@ -1,0 +1,70 @@
+name: "Continuous Integration"
+
+on:
+  - push
+  - pull_request
+
+env:
+  COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --prefer-dist"
+  SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT: "1"
+
+jobs:
+  tests:
+    name: "CI"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - "5.3"
+          - "5.4"
+          - "5.5"
+          - "5.6"
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+        dependencies: [locked]
+        include:
+          - php-version: "5.3"
+            dependencies: lowest
+          - php-version: "8.1"
+            dependencies: lowest
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: "Handle lowest dependencies update"
+        if: "contains(matrix.dependencies, 'lowest')"
+        run: "echo \"COMPOSER_FLAGS=$COMPOSER_FLAGS --prefer-lowest\" >> $GITHUB_ENV"
+
+      - name: "Install latest dependencies"
+        run: |
+          # Remove PHPStan as it requires a newer PHP
+          composer remove phpstan/phpstan phpstan/phpstan-phpunit --dev --no-update
+          composer update ${{ env.COMPOSER_FLAGS }}
+
+      - name: "Run tests"
+        run: "vendor/bin/simple-phpunit --verbose"


### PR DESCRIPTION
#### What are the main changes in this PR?
Rewrite 3 more widgets
- Site Info
- Tests Status
- Updates Status

Also, add a new template function for creating list elements. The function can take a set (array) or individual item when creating the list view. Fixes #548 as well by making sure that WP_Errors are caught if API errors for some reason.

#### Wrap up & testing
Test the basic functionality for all 3 widgets. However, Update Status should probably be tested more extensively as there were lots of stuff on the original implementation (might have missed something or some formats wrong etc.). 