### PR TITLE
Add debug mode

### DIFF
--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -18,6 +18,12 @@ if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 
+// Use debug mode only in development
+define('SERAVO_PLUGIN_DEBUG', false);
+if ( defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
+  nocache_headers();
+}
+
 if ( ! defined('SERAVO_PLUGIN_URL') ) {
   define('SERAVO_PLUGIN_URL', plugin_dir_url(__FILE__));
 }

--- a/src/lib/ajax/handler.php
+++ b/src/lib/ajax/handler.php
@@ -182,4 +182,12 @@ class AjaxHandler {
     return $this->section;
   }
 
+  /**
+   * Get the data cache time.
+   * @return int|null Seconds to cache data returned by $ajax_func.
+   */
+  public function get_cache_time() {
+    return $this->data_cache_time;
+  }
+
 }

--- a/src/lib/postbox/component/template.php
+++ b/src/lib/postbox/component/template.php
@@ -63,6 +63,7 @@ class Template {
       foreach ( $element as $list_object ) {
         $component->add_child(Component::from_raw('<li>' . $list_object . '</li>'));
       }
+      return $component;
     }
 
     $component->add_child(Component::from_raw('<li>' . $element . '</li>'));

--- a/src/lib/postbox/requirements.php
+++ b/src/lib/postbox/requirements.php
@@ -63,7 +63,7 @@ final class Requirements {
    */
   public $is_multisite = \false;
   /**
-   * @var bool Whether site must be multisite install or not.
+   * @var bool Whether site must not be multisite install.
    */
   public $is_not_multisite = \false;
   /**


### PR DESCRIPTION
#### What are the main changes in this PR?

Adds debug mode in Seravo Plugin. Debug mode can be used for all kinds of purposes but currently it's there to send no-cache header and to print debug info about the new postboxes.

In addition to basic info about the postbox, it measures the amount of time each postbox takes to render.

##### Why are we doing this? Any context or related work?

With the debug info table, we can easily see that all the postboxes have correct configuration. It's important to see that the requirements are correct (they currently are not, we must go through them later), caching is enabled where it can be enabled, data function is used where it can be used, the postbox doesn't slow page load time by too much and the postbox IDs and sections don't have any `-new` or `-2` suffixes.

#### Manual testing steps?

Enable debug mode in: https://github.com/Seravo/seravo-plugin/blob/128f7f12e81ca49d7cce74e19994a9e3234ec42d/seravo-plugin.php#L22 

#### Screenshots

A table like this is appended after postbox content:
![debug-info](https://user-images.githubusercontent.com/42264063/123825793-debf2780-d907-11eb-8999-fb401ff4b155.png)

