### PR TITLE
Fix deprecated plugins check

### DIFF
--- a/modules/check-site-health.php
+++ b/modules/check-site-health.php
@@ -120,8 +120,7 @@ if ( ! class_exists('Site_Health') ) {
         }
 
         foreach ( self::$bad_plugins as $plugin ) {
-
-          if ( str_contains($line, $plugin) ) {
+          if ( strpos($line, $plugin) !== false ) {
             $error_msg = '<b>' . $plugin . '</b> ' . __('is deprecated');
             self::$potential_issues[$error_msg] = $deprecated_tooltip;
             ++$bad_plugins_found;


### PR DESCRIPTION
#### What are the main changes in this PR?
Use `strpos` instead of `str_contains` as the latter is introduced in PHP 8 and not all sites use it yet. 
