### PR TITLE
Add background commands with polling

### DIFF
--- a/js/postbox/seravo-ajax.js
+++ b/js/postbox/seravo-ajax.js
@@ -105,7 +105,7 @@ jQuery(document).ready(
   }
 );
 
-function seravo_ajax_request(method, postbox_id, section, on_success, on_error, data) {
+function seravo_ajax_request(method, postbox_id, section, on_success, on_error, data, retry = 0) {
   var request_data = {
     'action': 'seravo_ajax_' + postbox_id,
     'section': section,
@@ -128,8 +128,19 @@ function seravo_ajax_request(method, postbox_id, section, on_success, on_error, 
         response = jQuery.parseJSON(response);
 
         if (response !== null && 'success' in response && response['success'] === true) {
-          // Success
-          on_success(response);
+          if ('poller_id' in response) {
+            // Polling requested
+            setTimeout(
+              function () {
+                seravo_poller(method, postbox_id, section, on_success, on_error, response['poller_id']);
+              },
+              5000
+            );
+            return;
+          } else {
+            // Success
+            on_success(response);
+          }
           return;
         } else if (response !== null && 'success' in response && response['success'] === false && 'error' in response) {
           // Failure
@@ -156,6 +167,71 @@ function seravo_ajax_request(method, postbox_id, section, on_success, on_error, 
       }
     }
   );
+}
+
+function seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, retry = 0) {
+  if (retry == 10) {
+    on_error(seravo_ajax_l10n.server_timeout);
+    return;
+  }
+
+  jQuery.ajax(
+    {
+      url: seravo_ajax_l10n.ajax_url,
+      method: method,
+      data: {
+        'action': 'seravo_ajax_' + postbox_id,
+        'section': section,
+        'nonce': SERAVO_AJAX_NONCE,
+        'poller_id': poller_id,
+      },
+    },
+  ).done(
+    function (response) {
+      try {
+        response = jQuery.parseJSON(response);
+
+        if ('poller_id' in response) {
+          // Poll again
+          setTimeout(
+            function () {
+              seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, 0)
+            },
+            2000
+          );
+          return;
+        } else {
+          if (response !== null && 'success' in response && response['success'] === true) {
+            // Success
+            on_success(response);
+            return;
+          } else if (response !== null && 'success' in response && response['success'] === false && 'error' in response) {
+            // Failure
+            on_error(response['error']);
+            return;
+          }
+        }
+      } catch (error) {
+        // Failed to parse JSON
+        on_error(seravo_ajax_l10n.server_invalid_response);
+        return;
+      }
+
+      on_error(seravo_ajax_l10n.server_invalid_response);
+      return;
+    }
+  ).fail(
+    function () {
+      // Poll again
+      setTimeout(
+        function () {
+          seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, retry + 1)
+        },
+        3000
+      );
+    }
+  );
+
 }
 
 function get_form_data(section) {

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -353,6 +353,10 @@ class Loader {
       if ( apply_filters('seravo_show_security_page', true) && current_user_can('administrator') ) {
         require_once SERAVO_PLUGIN_SRC . 'modules/security.php';
       }
+
+      if ( defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
+        require_once SERAVO_PLUGIN_SRC . 'modules/test-page.php';
+      }
     }
 
     /*

--- a/src/lib/ajax/handler.php
+++ b/src/lib/ajax/handler.php
@@ -190,4 +190,23 @@ class AjaxHandler {
     return $this->data_cache_time;
   }
 
+  /**
+   * Check if polling is no longer needed or continue doing it.
+   * @return mixed|bool AjaxResponse if still polling, true if
+   *                    polling is done, false if not polling yet.
+   */
+  public static function check_polling() {
+    if ( isset($_REQUEST['poller_id']) && ! empty($_REQUEST['poller_id']) ) {
+      $pid = base64_decode($_REQUEST['poller_id']);
+
+      if ( \Seravo\Shell::is_pid_running($pid) ) {
+        return AjaxResponse::require_polling_response($pid);
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
 }

--- a/src/lib/ajax/response.php
+++ b/src/lib/ajax/response.php
@@ -124,6 +124,22 @@ class AjaxResponse {
   }
 
   /**
+   * Get response for requesting polling.
+   * @param string $pid Pid of the program to poll.
+   * @return \Seravo\Ajax\AjaxResponse Polling response.
+   */
+  public static function require_polling_response( $pid ) {
+    $response = new AjaxResponse();
+    $response->is_success(true);
+    $response->set_data(
+      array(
+        'poller_id' => base64_encode($pid),
+      )
+    );
+    return $response;
+  }
+
+  /**
    * Get response for errors on user inputs in forms.
    * @param string $message Message to display.
    * @return \Seravo\Ajax\AjaxResponse Error response.

--- a/src/lib/shell.php
+++ b/src/lib/shell.php
@@ -21,7 +21,7 @@ class Shell {
   public static function safe_exec( $command, $args = array(), $env = array(), &$output = null, &$result_code = null ) {
     $safe_command = self::sanitize_command($command, $args, $env);
 
-    exec($safe_command, output, result_code);
+    exec($safe_command, $output, $result_code);
   }
   /**
    * Function for sanitizing commands to be more safe.
@@ -51,6 +51,31 @@ class Shell {
     }
 
     return escapeshellcmd($safe_command);
+  }
+
+  /**
+   * Run a command on background.
+   * @param string $command Command to run.
+   * @return mixed|bool Pid of the program.
+   */
+  public static function backround_command( $command ) {
+    $output = array();
+    exec('(' . $command . ') > /dev/null & echo $!', $output);
+
+    if ( count($output) >= 1 ) {
+      return $output[0];
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if command is running.
+   * @param int $pid Pid of the program.
+   * @return bool Whether the command is running.
+   */
+  public static function is_pid_running( $pid ) {
+    return file_exists("/proc/{$pid}");
   }
 
 }

--- a/src/modules/test-page.php
+++ b/src/modules/test-page.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * File for test postboxes page. No need to
+ * translate anything here.
+ */
+
+namespace Seravo;
+
+use \Seravo\Ajax;
+use \Seravo\Postbox;
+use \Seravo\Postbox\Toolpage;
+use \Seravo\Postbox\Requirements;
+
+// Deny direct access to this file
+if ( ! defined('ABSPATH') ) {
+  die('Access denied!');
+}
+
+if ( ! class_exists('TestPage') ) {
+  class TestPage {
+
+    /**
+     * Initialize test-page.
+     */
+    public static function load() {
+      $page = new Toolpage('tools_page_test_page');
+
+      self::init_test_postboxes($page);
+
+      $page->enable_ajax();
+      $page->register_page();
+    }
+
+    /**
+     * Initialize test-page postboxes.
+     * @param \Seravo\Postbox\Toolpage $page The page for postboxes.
+     */
+    public static function init_test_postboxes( Toolpage $page ) {
+      /**
+       * Polling test postbox
+       */
+      $poller_demo = new Postbox\SimpleForm('poller-test', 'normal');
+      $poller_demo->set_title('Polling Test');
+      $poller_demo->set_button_text('Click me');
+      $poller_demo->set_button_func(array( __CLASS__, 'long_polling_operation' ));
+      $poller_demo->add_paragraph('Click the button to test the poller. It will sleep for 65 seconds and restart Nginx.');
+      $poller_demo->add_paragraph('See browsers dev-tools network tab to see what happens.');
+      $poller_demo->set_spinner_text('This will take a while...');
+      $poller_demo->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
+      $page->register_postbox($poller_demo);
+    }
+
+    /**
+     * AJAX function for testing polling. The function
+     * sleeps for 65 seconds and restarts Nginx.
+     * @return \Seravo\Ajax\AjaxResponse|mixed Response for long polling operation.
+     */
+    public static function long_polling_operation() {
+      $polling = Ajax\AjaxHandler::check_polling();
+
+      if ( $polling === true ) {
+        // Done polling
+        $response = new Ajax\AjaxResponse();
+        $response->is_success(true);
+        $response->set_data(
+          array(
+            'output' => '<pre>' . file_get_contents('/data/log/nginx-restart-test.log') . '</pre>',
+          )
+        );
+        return $response;
+      }
+
+      if ( $polling === false ) {
+        // Not polling yet
+        $command = 'sleep 65 && wp-restart-nginx > /data/log/nginx-restart-test.log';
+        $pid = Shell::backround_command($command);
+        if ( $pid === false ) {
+          return Ajax\AjaxResponse::exception_response();
+        }
+        return Ajax\AjaxResponse::require_polling_response($pid);
+      }
+
+      // Not done yet, keep polling
+      return $polling;
+    }
+
+  }
+
+  TestPage::load();
+}

--- a/src/modules/toolbox.php
+++ b/src/modules/toolbox.php
@@ -80,6 +80,17 @@ if ( ! class_exists('SeravoToolbox') ) {
         'logs_page',
         array( Logs::init(), 'render_tools_page' )
       );
+
+      if ( defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
+        add_submenu_page(
+          'tools.php',
+          __('Test-page', 'seravo'),
+          __('Test-page', 'seravo'),
+          'manage_options',
+          'test_page',
+          'Seravo\Postbox\seravo_two_column_postboxes_page'
+        );
+      }
     }
   }
 


### PR DESCRIPTION
#### What are the main changes in this PR?

Adds possibility to run commands on background and polling to see when it has finished.

Also added a test-page which is enabled in Seravo Plugin debug mode and there's an example usage of polling.

##### Why are we doing this? Any context or related work?
Needed for long operations and related to https://github.com/Seravo/seravo-plugin/issues/465.

#### Where should a reviewer start?

You can try the example on test-page.