### PR TITLE
Add PHPStan and fix errors up to level 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,19 @@
     "seravo.com"
   ],
   "require": {
+    "php": "^5.6 || ^7.0 || ^8.0",
     "composer/installers": "^1.0",
     "enshrined/svg-sanitize": ">=0.13.3"
   },
   "require-dev": {
-    "rector/rector": "^0.11.16",
+    "pheromone/phpcs-security-audit": "^2.0",
+    "phpcompatibility/php-compatibility": "^9.3",
     "php-stubs/wordpress-stubs": "4.7.14",
     "php-stubs/wp-cli-stubs": "2.4.0",
+    "rector/rector": "^0.11.16",
     "squizlabs/php_codesniffer": "3.6",
     "wp-coding-standards/wpcs": "^2.3",
-    "pheromone/phpcs-security-audit": "^2.0",
-    "phpcompatibility/php-compatibility": "^9.3"
+    "szepeviktor/phpstan-wordpress": "^0.7.5"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
   },
   "scripts": {
     "test": [
+      "vendor/bin/phpstan --memory-limit=512M analyse",
       "vendor/bin/rector --dry-run",
       "vendor/bin/phpcs -n"
     ],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,6 @@ parameters:
     paths:
         - seravo-plugin.php
         - src/
+    ignoreErrors:
+        # Uses func_get_args()
+        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,13 +1,34 @@
 includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-    level: 0
     # TODO level: max
+    level: 8
     scanFiles:
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+        - src/lib/domain-tables.php
+        - src/lib/domains-ajax.php
     paths:
         - seravo-plugin.php
         - src/
+    bootstrapFiles:
+        - seravo-plugin.php
+    excludes_analyse:
+        # TODO: remove excludes
+        - src/lib/domain-tables.php
+        - src/lib/domains-ajax.php
+        - src/lib/list-table.php
+        - src/lib/cruftfiles-ajax.php
+        - src/lib/cruftplugins-ajax.php
+        - src/lib/cruftthemes-ajax.php
+        - src/modules/pages/security.php
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+        - '#^Function current_user_can invoked with \d parameters, 1 required\.$#'
+        - '#^Function wp_sprintf invoked with \d parameters, 1 required\.$#'
+        - '#^Function add_query_arg invoked with 2 parameters, 0 required\.$#'
+        # Defined in wp-config.php
+        - '#^Constant WP_LANG_DIR not found\.$#'
+        # Uses function_exists()
+        - '#^Function jetpack_protect_get_ip not found\.$#'
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,10 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
+    level: 0
+    # TODO level: max
     scanFiles:
-        - src/lib/list-table.php
-        - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
-        - vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
-        - vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
+    paths:
+        - seravo-plugin.php
+        - src/

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -19,13 +19,14 @@ if ( ! defined('ABSPATH') ) {
 }
 
 // Use debug mode only in development
-define('SERAVO_PLUGIN_DEBUG', false);
+//define('SERAVO_PLUGIN_DEBUG', false);
+
 if ( defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
   nocache_headers();
 }
 
 if ( ! defined('SERAVO_PLUGIN_URL') ) {
-  define('SERAVO_PLUGIN_URL', plugin_dir_url(__FILE__));
+  define('SERAVO_PLUGIN_URL', \plugin_dir_url(__FILE__));
 }
 if ( ! defined('SERAVO_PLUGIN_DIR') ) {
   define('SERAVO_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -89,7 +90,7 @@ class Loader {
     add_action(
       'plugins_loaded',
       function () {
-        return $this->load_textdomain();
+        $this->load_textdomain();
       }
     );
 
@@ -100,7 +101,7 @@ class Loader {
     add_action(
       'plugins_loaded',
       function () {
-        return $this->protected_downloads();
+        $this->protected_downloads();
       }
     );
 
@@ -111,7 +112,7 @@ class Loader {
     add_action(
       'init',
       function () {
-        return $this->load_all_modules();
+        $this->load_all_modules();
       },
       20
     );
@@ -120,6 +121,7 @@ class Loader {
   /**
    * Pass file download to Nginx with X-Accel-Redirect headers
    * @param string $file Path to file on filesystem, or URL with .seravo prefix
+   * @return void
    */
   public static function x_accel_redirect( $file ) {
     // If a real file path was given, send out MIME type and file size headers
@@ -151,6 +153,7 @@ class Loader {
 
   /**
    * Pass report file on to admin users
+   * @return void
    */
   public static function protected_downloads() {
     global $pagenow;
@@ -185,6 +188,9 @@ class Loader {
     }
   }
 
+  /**
+   * @return void
+   */
   public static function load_textdomain() {
 
     // Load translations first from the languages directory
@@ -196,9 +202,12 @@ class Loader {
     );
 
     // And then from this plugin folder
-    load_muplugin_textdomain('seravo', basename(SERAVO_PLUGIN_DIR) . '/languages');
+    load_muplugin_textdomain('seravo', SERAVO_PLUGIN_DIR . 'languages');
   }
 
+  /**
+   * @return void
+   */
   public static function load_all_modules() {
     /*
      * Helpers for hiding useless notifications and small fixes in logging

--- a/src/lib/ajax/handler.php
+++ b/src/lib/ajax/handler.php
@@ -36,11 +36,11 @@ class AjaxHandler {
 
 
   /**
-   * @var array|null Function to be called on AJAX call.
+   * @var callable|null Function to be called on AJAX call.
    */
   private $ajax_func;
   /**
-   * @var array|null Function to be called on AJAX component render.
+   * @var callable|null Function to be called on AJAX component render.
    */
   private $build_func;
   /**
@@ -61,6 +61,7 @@ class AjaxHandler {
    * by the postbox once the page is ready.
    * @param string $id    Unique id/slug of the postbox.
    * @param string $nonce Name of WordPress nonce for the page.
+   * @return void
    */
   public function init( $id, $nonce ) {
     $this->id = $id;
@@ -69,7 +70,7 @@ class AjaxHandler {
     add_action(
       'wp_ajax_seravo_ajax_' . $this->id,
       function() {
-        return $this->_ajax_handler();
+        $this->_ajax_handler();
       }
     );
   }
@@ -77,8 +78,9 @@ class AjaxHandler {
   /**
    * Set the AJAX function for the handler. The function will be
    * called on AJAX calls here. AJAX function should return an AjaxResponse.
-   * @param array $ajax_func  Function to be called on AJAX call.
-   * @param int   $cache_time Seconds to cache data for (default is 0).
+   * @param callable $ajax_func  Function to be called on AJAX call.
+   * @param int      $cache_time Seconds to cache data for (default is 0).
+   * @return void
    */
   public function set_ajax_func( $ajax_func, $cache_time = 0 ) {
     $this->ajax_func = $ajax_func;
@@ -88,7 +90,8 @@ class AjaxHandler {
   /**
    * Set the optional build function for the handler.
    * The function will be called on get_component() calls.
-   * @param array $build_func Function to be called on AJAX component render.
+   * @param callable $build_func Function to be called on AJAX component render.
+   * @return void
    */
   public function set_build_func( $build_func ) {
     $this->build_func = $build_func;
@@ -98,6 +101,7 @@ class AjaxHandler {
    * Set the time data returned by AJAX function
    * is cached in transient for.
    * @param int $cache_time Seconds to cache data for (default is 0).
+   * @return void
    */
   public function set_cache_time( $cache_time ) {
     $this->data_cache_time = $cache_time;
@@ -124,17 +128,30 @@ class AjaxHandler {
    * or responds with error on invalid requests.
    *
    * Caching and exceptions are taken care of here.
+   * @return void
    */
   public function _ajax_handler() {
+    if ( $this->ajax_nonce === null ) {
+      AjaxResponse::unknown_error_response()->send();
+      return;
+    }
+
     check_ajax_referer($this->ajax_nonce, 'nonce');
 
     if ( ! isset($_REQUEST['section']) ) {
       // There must always be a section
       AjaxResponse::invalid_request_response()->send();
+      return;
     }
 
     if ( $_REQUEST['section'] !== $this->section ) {
       // This request doesn't concern us
+      return;
+    }
+
+    if ( ! is_callable($this->ajax_func) ) {
+      // No ajax function
+      AjaxResponse::unknown_error_response()->send();
       return;
     }
 
@@ -192,8 +209,8 @@ class AjaxHandler {
 
   /**
    * Check if polling is no longer needed or continue doing it.
-   * @return mixed|bool AjaxResponse if still polling, true if
-   *                    polling is done, false if not polling yet.
+   * @return \Seravo\Ajax\AjaxResponse|bool AjaxResponse if still polling, true if
+   *                                        polling is done, false if not polling yet.
    */
   public static function check_polling() {
     if ( isset($_REQUEST['poller_id']) && ! empty($_REQUEST['poller_id']) ) {

--- a/src/lib/ajax/response.php
+++ b/src/lib/ajax/response.php
@@ -11,7 +11,7 @@ namespace Seravo\Ajax;
 class AjaxResponse {
 
   /**
-   * @var bool[]|string[]|mixed[]|mixed Data to respond with.
+   * @var mixed[] Data to respond with.
    */
   public $data = array();
 
@@ -22,6 +22,7 @@ class AjaxResponse {
   /**
    * Set whether the request was succesful or not.
    * @param bool $is_success Value for 'success' field.
+   * @return void
    */
   public function is_success( $is_success ) {
     $this->data['success'] = $is_success;
@@ -30,6 +31,7 @@ class AjaxResponse {
   /**
    * Set error message in 'error' field in case there was one.
    * @param string $error Error to be shown for user.
+   * @return void
    */
   public function set_error( $error ) {
     $this->data['error'] = $error;
@@ -38,7 +40,8 @@ class AjaxResponse {
   /**
    * Set the data to be responded with. Data is merged with
    * success and error fields.
-   * @param array $data The response data.
+   * @param mixed[] $data The response data.
+   * @return void
    */
   public function set_data( $data ) {
     $this->data = array_merge($this->data, $data);
@@ -46,7 +49,8 @@ class AjaxResponse {
 
   /**
    * Set raw response data overwriting all current fields.
-   * @param mixed $response Raw response that won't be tampered with.
+   * @param mixed[] $response Raw response that won't be tampered with.
+   * @return void
    */
   public function set_raw_response( $response ) {
     $this->data = $response;
@@ -68,6 +72,7 @@ class AjaxResponse {
 
   /**
    * Send the response. No coming back from here.
+   * @return void
    */
   public function send() {
     echo $this->to_json();

--- a/src/lib/ajax/templates/fancy-form.php
+++ b/src/lib/ajax/templates/fancy-form.php
@@ -28,25 +28,25 @@ class FancyForm extends AjaxHandler {
   const STATUS_RED = 'red';
 
   /**
-   * @var array|null  Callback for building the form.
+   * @var callable|null Callback for building the form.
    */
   private $build_form_func;
 
   /**
-   * @var string|null Text to be shown on the main button.
+   * @var string|null   Text to be shown on the main button.
    */
   private $button_text;
   /**
-   * @var string|null Text to be shown on the dryrun button.
+   * @var string|null   Text to be shown on the dryrun button.
    */
   private $dryrun_button_text;
 
   /**
-   * @var string|null Text to be shown next to the spinner.
+   * @var string|null   Text to be shown next to the spinner.
    */
   private $spinner_text;
   /**
-   * @var string|null Text to be shown in wrapper by default.
+   * @var string|null   Text to be shown in wrapper by default.
    */
   private $title_text;
 
@@ -69,11 +69,16 @@ class FancyForm extends AjaxHandler {
    * Can be gotten with get_component().
    * @param \Seravo\Postbox\Component $base    Base component.
    * @param string                    $section Unique section inside the postbox.
+   * @return void
    */
   public function build_component( Component $base, $section ) {
     $form = new Component();
     if ( $this->build_form_func !== null ) {
       \call_user_func($this->build_form_func, $form);
+    }
+
+    if ( $this->button_text === null ) {
+      $this->button_text = __('Run', 'seravo');
     }
 
     if ( $this->dryrun_button_text !== null ) {
@@ -107,7 +112,8 @@ class FancyForm extends AjaxHandler {
 
   /**
    * Set the callback function to be called for building the form.
-   * @param array $build_form_func Function for building the form.
+   * @param callable $build_form_func Function for building the form.
+   * @return void
    */
   public function set_build_form_func( $build_form_func ) {
     $this->build_form_func = $build_form_func;
@@ -115,8 +121,9 @@ class FancyForm extends AjaxHandler {
 
   /**
    * Set text for the buttons.
-   * @param string $text        Text on the button.
-   * @param string $dryrun_text Text on the dry-run button (optional).
+   * @param string      $text        Text on the button.
+   * @param string|null $dryrun_text Text on the dry-run button (optional).
+   * @return void
    */
   public function set_button_text( $text, $dryrun_text = null ) {
     $this->button_text = $text;
@@ -125,7 +132,8 @@ class FancyForm extends AjaxHandler {
 
   /**
    * Set text to be shown next to the spinner.
-   * @param string $text Spinner text.
+   * @param string|null $text Spinner text.
+   * @return void
    */
   public function set_spinner_text( $text ) {
     $this->spinner_text = $text;
@@ -133,7 +141,8 @@ class FancyForm extends AjaxHandler {
 
   /**
    * Set text to be shown in wrapper by default.
-   * @param string $text Title text.
+   * @param string|null $text Title text.
+   * @return void
    */
   public function set_title_text( $text ) {
     $this->title_text = $text;

--- a/src/lib/ajax/templates/lazy-command.php
+++ b/src/lib/ajax/templates/lazy-command.php
@@ -61,7 +61,7 @@ class LazyCommand extends LazyLoader {
   public function ajax_command_exec( $section ) {
     $exec_command = $this->command;
 
-    if ( $this->command === null ) {
+    if ( $exec_command === null ) {
       return AjaxResponse::unknown_error_response();
     }
 
@@ -70,7 +70,7 @@ class LazyCommand extends LazyLoader {
     exec($exec_command, $output, $retval);
 
     if ( $retval !== 0 && ! $this->allow_failure ) {
-      return AjaxResponse::command_error_response($this->command);
+      return AjaxResponse::command_error_response($exec_command);
     }
 
     if ( empty($output) ) {
@@ -96,6 +96,7 @@ class LazyCommand extends LazyLoader {
    * @param string $command       Command for exec.
    * @param int    $cache_time    Seconds to cache response for (default 300).
    * @param bool   $allow_failure Whether exit code other than 0 should respond with an error (default false).
+   * @return void
    */
   public function set_command( $command, $cache_time = 300, $allow_failure = false ) {
     $this->command = $command;
@@ -107,6 +108,7 @@ class LazyCommand extends LazyLoader {
   /**
    * Set whether exit code other than 0 should respond with an error.
    * @param bool $allow_failure Whether to allow failure.
+   * @return void
    */
   public function set_allow_failure( $allow_failure ) {
     $this->allow_failure = $allow_failure;
@@ -115,6 +117,7 @@ class LazyCommand extends LazyLoader {
   /**
    * Set a message to be shown if command returns no data.
    * @param string $message Message to be shown for no command output.
+   * @return void
    */
   public function set_empty_message( $message ) {
     $this->empty_message = $message;

--- a/src/lib/ajax/templates/lazy-loader.php
+++ b/src/lib/ajax/templates/lazy-loader.php
@@ -14,7 +14,7 @@ use \Seravo\Postbox\Template;
 class LazyLoader extends AjaxHandler {
 
   /**
-   * @var Bool Whether to use <hr> element or not.
+   * @var bool Whether to use <hr> element or not.
    */
   private $use_hr = true;
 
@@ -40,6 +40,7 @@ class LazyLoader extends AjaxHandler {
    * Can be gotten with get_component().
    * @param \Seravo\Postbox\Component $base Base component.
    * @param string $section Unique section inside the postbox.
+   * @return void
    */
   public function build_component( Component $base, $section ) {
     $component = new Component();
@@ -53,6 +54,7 @@ class LazyLoader extends AjaxHandler {
   /**
    * Set <hr> element usage for the AJAX handler.
    * @param bool $use_hr True for using <hr>.
+   * @return void
    */
   public function use_hr( $use_hr ) {
     $this->use_hr = $use_hr;

--- a/src/lib/ajax/templates/simple-command.php
+++ b/src/lib/ajax/templates/simple-command.php
@@ -68,12 +68,14 @@ class SimpleCommand extends SimpleForm {
       return AjaxResponse::unknown_error_response();
     }
 
-    $dry_run = isset($_GET['dryrun']) && $_GET['dryrun'] === 'true';
-    if ( $dry_run && $this->dryrun_command === null ) {
-      return AjaxResponse::unknown_error_response();
-    }
+    $exec_command = $this->command;
 
-    $exec_command = $dry_run ? $this->dryrun_command : $this->command;
+    $dry_run = isset($_GET['dryrun']) && $_GET['dryrun'] === 'true';
+    if ( $dry_run && $this->dryrun_command !== null ) {
+        $exec_command = $this->dryrun_command;
+    } elseif ( $dry_run ) {
+        return AjaxResponse::unknown_error_response();
+    }
 
     $output = null;
     $retval = null;
@@ -106,6 +108,7 @@ class SimpleCommand extends SimpleForm {
    * @param string      $command       Command to be executed.
    * @param string|null $dryrun        Dry-run command to be executed (default null).
    * @param bool        $allow_failure Whether exit code other than 0 should respond with an error (default false).
+   * @return void
    */
   public function set_command( $command, $dryrun = null, $allow_failure = false ) {
     $this->command = $command;
@@ -116,6 +119,7 @@ class SimpleCommand extends SimpleForm {
   /**
    * Set whether exit code other than 0 should respond with an error.
    * @param bool $allow_failure Whether to allow failure.
+   * @return void
    */
   public function set_allow_failure( $allow_failure ) {
     $this->allow_failure = $allow_failure;
@@ -124,6 +128,7 @@ class SimpleCommand extends SimpleForm {
   /**
    * Set a message to be shown if command returns no data.
    * @param string $message Message to be shown for no command output.
+   * @return void
    */
   public function set_empty_message( $message ) {
     $this->empty_message = $message;

--- a/src/lib/ajax/templates/simple-form.php
+++ b/src/lib/ajax/templates/simple-form.php
@@ -14,27 +14,27 @@ use \Seravo\Postbox\Template;
 class SimpleForm extends AjaxHandler {
 
   /**
-   * @var array|null  Callback for building the form.
+   * @var callable|null Callback for building the form.
    */
   private $build_form_func;
 
   /**
-   * @var string|null Text to be shown on the main button.
+   * @var string|null  Text to be shown on the main button.
    */
   private $button_text;
 
   /**
-   * @var string|null Text to be shown on the dryrun button.
+   * @var string|null  Text to be shown on the dryrun button.
    */
   private $dryrun_button_text;
 
   /**
-   * @var string|null Text to be shown next to the spinner.
+   * @var string|null  Text to be shown next to the spinner.
    */
   private $spinner_text;
 
   /**
-   * @var bool Whether the spinner and buttons should switch places.
+   * @var bool         Whether the spinner and buttons should switch places.
    */
   private $flip_spinner = false;
 
@@ -57,6 +57,7 @@ class SimpleForm extends AjaxHandler {
    * Can be gotten with get_component().
    * @param \Seravo\Postbox\Component $base    Base component.
    * @param string                    $section Unique section inside the postbox.
+   * @return void
    */
   public function build_component( Component $base, $section ) {
     $form = new Component();
@@ -68,6 +69,10 @@ class SimpleForm extends AjaxHandler {
       $spinner = Template::spinner_with_text($section . '-spinner', $this->spinner_text);
     } else {
       $spinner = Template::spinner($section . '-spinner');
+    }
+
+    if ( $this->button_text === null ) {
+      $this->button_text = __('Run', 'seravo');
     }
 
     if ( $this->dryrun_button_text !== null ) {
@@ -106,7 +111,8 @@ class SimpleForm extends AjaxHandler {
 
   /**
    * Set the callback function to be called for building the form.
-   * @param array $build_form_func Function for building the form.
+   * @param callable $build_form_func Function for building the form.
+   * @return void
    */
   public function set_build_form_func( $build_form_func ) {
     $this->build_form_func = $build_form_func;
@@ -116,6 +122,7 @@ class SimpleForm extends AjaxHandler {
    * Set text for the buttons.
    * @param string $text        Text on the button.
    * @param string $dryrun_text Text on the dry-run button (optional).
+   * @return void
    */
   public function set_button_text( $text, $dryrun_text = null ) {
     $this->button_text = $text;
@@ -125,6 +132,7 @@ class SimpleForm extends AjaxHandler {
   /**
    * Set text to be shown next to the spinner.
    * @param string $text Spinner text.
+   * @return void
    */
   public function set_spinner_text( $text ) {
     $this->spinner_text = $text;
@@ -133,6 +141,7 @@ class SimpleForm extends AjaxHandler {
   /**
    * Set whether the spinner and buttons should switch places.
    * @param bool $flip Whether to flip.
+   * @return void
    */
   public function set_spinner_flip( $flip ) {
     $this->flip_spinner = $flip;

--- a/src/lib/api.php
+++ b/src/lib/api.php
@@ -11,34 +11,60 @@ class API {
 
   /**
    * Get various data from the site API for the current site.
-   * @return \WP_Error|mixed
+   * @param string $api_query          The API endpoint with the neccesary parameters.
+   * @param int[]  $handled_http_codes HTTP codes that are handled. Others will return \WP_Error.
+   * @return \WP_Error|mixed[] Decoded data returned or WP_Error object if request failed or JSON decode failed.
    */
   public static function get_site_data( $api_query = '', $handled_http_codes = array( 200 ) ) {
     $site = getenv('USER');
+
     $ch = curl_init('http://localhost:8888/v1/site/' . $site . $api_query);
+    if ( $ch === false ) {
+      // CurlHandle couldn't be created
+      return new \WP_Error('seravo-api-get-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+    }
+
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'X-Api-Key: ' . getenv('SERAVO_API_KEY') ));
+
     $response = curl_exec($ch);
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
     // Check for errors
-    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) ) {
+    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) || is_bool($response) ) {
       error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
       curl_close($ch);
       return new \WP_Error('seravo-api-get-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
     }
 
     curl_close($ch);
-    return json_decode($response, true);
+
+    $decoded = json_decode($response, true);
+    if ( $decoded === false ) {
+      return new \WP_Error('seravo-api-json-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+    }
+    return $decoded;
   }
 
   /**
-   * @return \WP_Error|bool|string
+   * @param mixed[] $data               JSON encodeable data to post.
+   * @param string  $api_query          The API endpoint.
+   * @param int[]   $handled_http_codes HTTP codes that are handled. Others will return \WP_Error.
+   * @param string  $method             The HTTP method to use. Default is 'PUT'.
+   * @return \WP_Error|string Raw data returned or WP_Error object if request failed or JSON decode/encode failed.
    */
   public static function update_site_data( $data, $api_query = '', $handled_http_codes = array( 200 ), $method = 'PUT' ) {
     $data_json = json_encode($data);
+    if ( $data_json === false ) {
+      return new \WP_Error('seravo-api-json-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+    }
+
     $site = getenv('USER');
+
     $ch = curl_init('http://localhost:8888/v1/site/' . $site . $api_query);
+    if ( $ch === false ) {
+      return new \WP_Error('seravo-api-put-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
+    }
 
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -57,7 +83,7 @@ class API {
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
     // Check for errors
-    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) ) {
+    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) || is_bool($response) ) {
       error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
       curl_close($ch);
       return new \WP_Error('seravo-api-put-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));

--- a/src/lib/canonical-domain-and-https.php
+++ b/src/lib/canonical-domain-and-https.php
@@ -18,8 +18,11 @@ if ( ! class_exists('Canonical_Domain_And_Https') ) {
 
   class Canonical_Domain_And_Https {
 
-    // NOTE! This function is executed on every page load.
-    // Be careful to keep the overhead here minimal.
+    /**
+     * NOTE! This function is executed on every page load.
+     * Be careful to keep the overhead here minimal.
+     * @return void
+     */
     public static function load() {
 
       // Check if siteurl and home both include https addresses. If so, enforce

--- a/src/lib/domain-tables.php
+++ b/src/lib/domain-tables.php
@@ -539,6 +539,9 @@ class Seravo_DNS_Table {
 
  }
 
+  /**
+   * @return mixed[]|\WP_Error
+   */
   public static function fetch_dns_records( $action, $domain ) {
     $api_query = '/domain/' . $domain . '/' . $action;
 

--- a/src/lib/helpers.php
+++ b/src/lib/helpers.php
@@ -38,6 +38,9 @@ class Helpers {
      return (getenv('WP_ENV') && getenv('WP_ENV') === 'staging');
   }
 
+  /**
+   * @return string Seravo Plugin version string. If SERAVO_PLUGIN_DEBUG is enabled, random number is appended.
+   */
   public static function seravo_plugin_version() {
      $version = get_file_data(SERAVO_PLUGIN_DIR . 'seravo-plugin.php', array( 'Version' ), 'plugin')[0];
 
@@ -50,10 +53,11 @@ class Helpers {
   }
 
   /**
-   * @return string
+   * @param int $size      The size in bytes.
+   * @param int $precision The amount of decimal places.
+   * @return string The size in human readable format.
    */
   public static function human_file_size( $size, $precision = 2 ) {
-    $size = (int) $size; // 'wp db size' returns value with non-numeric characters
     for ( $i = 0; ($size / 1024) > 0.9; ) {
       ++$i;
       $size /= 1024;
@@ -69,21 +73,23 @@ class Helpers {
    *  [0] => 3221250250,
    *  [1] => 3221254346,
    *
-   * @param string IPv4 range in CIDR format (eg. xxx.xxx.xxx.xxx/20)
-   * @return array Upper and lower limits in ip2long format.
+   * @param string $cidr IPv4 range in CIDR format (eg. xxx.xxx.xxx.xxx/20)
+   * @return int[] Upper and lower limits in ip2long format.
    * @version 1.0
    * @see https://gist.github.com/tott/7684443
-   **/
+   */
   public static function cidr_to_range( $cidr ) {
     $cidr = explode('/', $cidr);
     $range = array();
     $range[0] = (ip2long($cidr[0])) & ((-1 << (32 - (int) $cidr[1])));
-    $range[1] = $range[0] + pow(2, (32 - (int) $cidr[1])) - 1;
+    $range[1] = (int) ($range[0] + pow(2, (32 - (int) $cidr[1])) - 1);
     return $range;
   }
 
   /**
-   * @return bool
+   * @param int[][] $range Upper and lower limits in ip2long format.
+   * @param int     $ip    The IP to check in ip2long format.
+   * @return bool Whether the IP is in range or not.
    */
   public static function ip_in_range( $range, $ip ) {
     foreach ( $range as $limits ) {
@@ -95,7 +101,8 @@ class Helpers {
   }
 
   /**
-   * @return string
+   * @param string $file The filepath to sanitize.
+   * @return string Sanitized path.
    */
   public static function sanitize_full_path( $file ) {
     $path = explode('/', $file);

--- a/src/lib/postbox/component/component.php
+++ b/src/lib/postbox/component/component.php
@@ -34,9 +34,9 @@ class Component {
 
   /**
    * Constructor for AjaxHandler. Will be called on new instance.
-   * @param string The HTML content of the component.
-   * @param string The opening tag of the component.
-   * @param string The closing tag of the component.
+   * @param string $content       The HTML content of the component.
+   * @param string $wrapper_open  The opening tag of the component.
+   * @param string $wrapper_close The closing tag of the component.
    */
   public function __construct( $content = '', $wrapper_open = '', $wrapper_close = '' ) {
     $this->content = $content;
@@ -46,7 +46,8 @@ class Component {
 
   /**
    * Add a child which will be rendered after the content.
-   * @param mixed $child $child Child component to be added.
+   * @param \Seravo\Postbox\Component|null $child Child component to be added.
+   * @return void
    */
   public function add_child( $child ) {
     if ( $child === null ) {
@@ -58,7 +59,8 @@ class Component {
 
   /**
    * Add children which are rendered after the content.
-   * @param \Seravo\Postbox\Component[] $children List of children to be added.
+   * @param \Seravo\Postbox\Component[]|null|null[] $children List of children to be added.
+   * @return void
    */
   public function add_children( $children ) {
     if ( $children === null || empty($children) ) {
@@ -79,10 +81,6 @@ class Component {
   public function to_html() {
     $html = $this->wrapper_open . $this->content;
     foreach ( $this->children as $child ) {
-      if ( $child === null ) {
-        continue;
-      }
-
       $html .= $child->to_html();
     }
     return $html . $this->wrapper_close;
@@ -90,6 +88,7 @@ class Component {
 
   /**
    * Prints the HTML for the component.
+   * @return void
    */
   public function print_html() {
     echo $this->to_html();

--- a/src/lib/postbox/component/template.php
+++ b/src/lib/postbox/component/template.php
@@ -53,7 +53,7 @@ class Template {
 
   /**
    * Display HTML list view.
-   * @param string|array $element Element or elements to add onto list.
+   * @param string|string[] $element Element or elements to add onto list.
    * @return \Seravo\Postbox\Component List view component.
    */
   public static function list_view( $element ) {
@@ -72,13 +72,13 @@ class Template {
 
   /**
    * Display elements in a specified table.
-   * @param string $class Specified table class.
-   * @param string $th_class Class for th elements.
-   * @param string $td_class Class for td elements.
-   * @param array $column_titles Column titles in array.
-   * @param array $all_rows Rows as $rows => $row array.
-   * @param bool $tooltip_titles Display tooltips in titles field or not.
-   * @return \Seravo\Postbox\Component
+   * @param string     $class          Specified table class.
+   * @param string     $th_class       Class for th elements.
+   * @param string     $td_class       Class for td elements.
+   * @param string[]   $column_titles  Column titles in array.
+   * @param string[][] $all_rows       Rows as $row => $cell[] array.
+   * @param bool       $tooltip_titles Display tooltips in titles field or not.
+   * @return \Seravo\Postbox\Component A table component.
    */
   public static function table_view( $class, $th_class, $td_class, $column_titles, $all_rows, $tooltip_titles = false ) {
     $main_table = new Component('', '<table class="' . $class . '">', '</table>');
@@ -92,8 +92,8 @@ class Template {
     foreach ( $all_rows as $rows ) {
       $row = new Component('', '<tr>', '</tr>');
 
-      foreach ( $rows as $row_element ) {
-        $row->add_child(Component::from_raw('<td class="' . $td_class . '"' . ($tooltip_titles ? 'title="' . $row_element . '"' : '') . '>' . $row_element . '</td>'));
+      foreach ( $rows as $cell ) {
+        $row->add_child(Component::from_raw('<td class="' . $td_class . '"' . ($tooltip_titles ? 'title="' . $cell . '"' : '') . '>' . $cell . '</td>'));
       }
       $main_table->add_child($row);
     }
@@ -205,15 +205,13 @@ class Template {
     return Component::from_raw($label . ' <input type="date" id="' . $id . '" name="' . $id . '" ' . (empty($min) ? '' : 'min="' . $min . '"') . (empty($max) ? '' : 'max="' . $max . '"') . '>');
   }
 
-  /* Add radio_button with the given details.
-   * @param string $name Name for the radio button input.
-   * @param string $value Value of the radio button.
-   * @param string $content Content message for the radio button.
-   * @param bool $checked Check the radiobutton.
-   * @return \Seravo\Postbox\Component Button component.
-   */
   /**
-   * @return \Seravo\Postbox\Component
+   * Add radio button with the given details.
+   * @param string $name    The input name.
+   * @param string $value   The input value.
+   * @param string $content The label.
+   * @param bool   $checked Whether the button is checked or not.
+   * @return \Seravo\Postbox\Component Radio button component.
    */
   public static function radio_button( $name, $value, $content, $checked = false ) {
     return Component::from_raw('<input type="radio" name="' . $name . '" value="' . $value . '"' . ($checked ? ' checked=""' : '') . '>' . $content . '<br>');
@@ -306,8 +304,8 @@ class Template {
 
   /**
    * Get wrapper component to show multiple components side by side.
-   * @param \Seravo\Postbox\Component[] $components Components from left to right.
-   * @param string $additional_class Additional CSS class for the container.
+   * @param \Seravo\Postbox\Component[]|null[] $components       Components from left to right.
+   * @param string                             $additional_class Additional CSS class for the container.
    * @return \Seravo\Postbox\Component Side-by-side component.
    */
   public static function n_by_side( $components, $additional_class = '' ) {

--- a/src/lib/postbox/requirements.php
+++ b/src/lib/postbox/requirements.php
@@ -91,6 +91,7 @@ final class Requirements {
    * Initialize requirements from array. Array should
    * be in "[Requirements::*] => value" format.
    * @param array<string, mixed> $requirements Requirements to be initialized.
+   * @return void
    */
   public function init_from_array( $requirements ) {
     if ( isset($requirements[self::IS_ADMIN]) ) {

--- a/src/lib/postbox/templates/fancy-form.php
+++ b/src/lib/postbox/templates/fancy-form.php
@@ -14,6 +14,11 @@ use \Seravo\Ajax;
 class FancyForm extends InfoBox {
 
   /**
+   * @var \Seravo\Ajax\FancyForm The single ajax handler for this postbox.
+   */
+  private $handler;
+
+  /**
    * Constructor for FancyForm. Will be called on new instance.
    * @param string $id      Unique id/slug of the postbox.
    * @param string $context Default admin dashboard context where the postbox should be displayed in.
@@ -21,55 +26,55 @@ class FancyForm extends InfoBox {
   public function __construct( $id, $context = 'normal' ) {
     parent::__construct($id, $context);
 
-    $ajax_handler = new Ajax\FancyForm($id);
-    $this->add_ajax_handler($ajax_handler);
+    $this->handler = new Ajax\FancyForm($id);
+    $this->add_ajax_handler($this->handler);
   }
 
   /**
    * Set the callback function to be called for building the form.
-   * @param array $build_form_func Function for building the form.
+   * @param callable $build_form_func Function for building the form.
+   * @return void
    */
   public function set_build_form_func( $build_form_func ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_build_form_func($build_form_func);
+    $this->handler->set_build_form_func($build_form_func);
   }
 
   /**
    * Set the callback function for the postbox. The function will be
    * called on button clicks. The callback function should return an AjaxResponse.
-   * @param array $button_func Function to be called on button click.
+   * @param callable $button_func Function to be called on button click.
+   * @return void
    */
   public function set_ajax_func( $button_func ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_ajax_func($button_func);
+    $this->handler->set_ajax_func($button_func);
   }
 
   /**
    * Set text for the buttons.
    * @param string $text        Text on the button.
    * @param string $dryrun_text Text on the dry-run button (optional).
+   * @return void
    */
   public function set_button_text( $text, $dryrun_text = null ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_button_text($text, $dryrun_text);
+    $this->handler->set_button_text($text, $dryrun_text);
   }
 
   /**
    * Set text to be shown next to the spinner.
    * @param string $text Spinner text.
+   * @return void
    */
   public function set_spinner_text( $text ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_spinner_text($text);
+    $this->handler->set_spinner_text($text);
   }
 
   /**
    * Set text to be shown in wrapper by default.
    * @param string $text Title text.
+   * @return void
    */
   public function set_title_text( $text ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_title_text($text);
+    $this->handler->set_title_text($text);
   }
 
 }

--- a/src/lib/postbox/templates/info-box.php
+++ b/src/lib/postbox/templates/info-box.php
@@ -32,6 +32,7 @@ class InfoBox extends Postbox {
   /**
    * Postbox will be built here.
    * @param \Seravo\Postbox\Component $base Base component to build postbox on.
+   * @return void
    */
   public function build( Component $base ) {
     foreach ( $this->paragraphs as $paragraph ) {
@@ -45,6 +46,7 @@ class InfoBox extends Postbox {
   /**
    * Add new paragraph to display.
    * @param string $text Info text.
+   * @return void
    */
   public function add_paragraph( $text ) {
     $this->paragraphs[] = $text;

--- a/src/lib/postbox/templates/lazy-command.php
+++ b/src/lib/postbox/templates/lazy-command.php
@@ -14,6 +14,11 @@ use \Seravo\Ajax;
 class LazyCommand extends InfoBox {
 
   /**
+   * @var \Seravo\Ajax\LazyCommand The single ajax handler for this postbox.
+   */
+  private $handler;
+
+  /**
    * Constructor for AutoCommand. Will be called on new instance.
    * @param string $id      Unique id/slug of the postbox.
    * @param string $context Default admin dashboard context where the postbox should be displayed in.
@@ -21,8 +26,8 @@ class LazyCommand extends InfoBox {
   public function __construct( $id, $context = 'normal' ) {
     parent::__construct($id, $context);
 
-    $ajax_handler = new Ajax\LazyCommand($id);
-    $this->add_ajax_handler($ajax_handler);
+    $this->handler = new Ajax\LazyCommand($id);
+    $this->add_ajax_handler($this->handler);
   }
 
   /**
@@ -30,28 +35,28 @@ class LazyCommand extends InfoBox {
    * @param string $command Command for exec.
    * @param int    $cache_time Seconds to cache response for (default 300).
    * @param bool   $allow_failure Whether exit code other than 0 should respond with an error (default false).
+   * @return void
    */
   public function set_command( $command, $cache_time = 300, $allow_failure = false ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_command($command, $cache_time, $allow_failure);
+    $this->handler->set_command($command, $cache_time, $allow_failure);
   }
 
   /**
    * Set whether exit code other than 0 should respond with an error.
    * @param bool $allow_failure Whether to allow failure.
+   * @return void
    */
   public function set_allow_failure( $allow_failure ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_allow_failure($allow_failure);
+    $this->handler->set_allow_failure($allow_failure);
   }
 
   /**
    * Set a message to be shown if command returns no data.
    * @param string $message Message to be shown for no command output.
+   * @return void
    */
   public function set_empty_message( $message ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_empty_message($message);
+    $this->handler->set_empty_message($message);
   }
 
 }

--- a/src/lib/postbox/templates/lazy-loader.php
+++ b/src/lib/postbox/templates/lazy-loader.php
@@ -13,6 +13,11 @@ use \Seravo\Ajax;
 class LazyLoader extends InfoBox {
 
   /**
+   * @var \Seravo\Ajax\LazyLoader The single ajax handler for this postbox.
+   */
+  private $handler;
+
+  /**
    * Constructor for LazyLoader. Will be called on new instance.
    * @param string $id      Unique id/slug of the postbox.
    * @param string $context Default admin dashboard context where the postbox should be displayed in.
@@ -20,25 +25,26 @@ class LazyLoader extends InfoBox {
   public function __construct( $id, $context = 'normal' ) {
     parent::__construct($id, $context);
 
-    $ajax_handler = new Ajax\LazyLoader($id);
-    $this->add_ajax_handler($ajax_handler);
+    $this->handler = new Ajax\LazyLoader($id);
+    $this->add_ajax_handler($this->handler);
   }
 
   /**
    * Set AJAX function for the handler of the postbox.
-   * @param function $ajax_func Function to execute on AJAX call.
+   * @param callable $ajax_func Function to execute on AJAX call.
+   * @return void
    */
   public function set_ajax_func( $ajax_func ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_ajax_func($ajax_func);
+    $this->handler->set_ajax_func($ajax_func);
   }
 
   /**
    * Set <hr> element usage for the AJAX handler.
    * @param bool $use_hr True for using <hr>.
+   * @return void
    */
   public function use_hr( $use_hr ) {
-    $this->ajax_handlers[$this->id]->use_hr($use_hr);
+    $this->handler->use_hr($use_hr);
   }
 
 }

--- a/src/lib/postbox/templates/simple-command.php
+++ b/src/lib/postbox/templates/simple-command.php
@@ -14,6 +14,11 @@ use \Seravo\Ajax;
 class SimpleCommand extends InfoBox {
 
   /**
+   * @var \Seravo\Ajax\SimpleCommand The single ajax handler for this postbox.
+   */
+  private $handler;
+
+  /**
    * Constructor for AutoCommand. Will be called on new instance.
    * @param string $id      Unique id/slug of the postbox.
    * @param string $context Default admin dashboard context where the postbox should be displayed in.
@@ -21,8 +26,8 @@ class SimpleCommand extends InfoBox {
   public function __construct( $id, $context = 'normal' ) {
     parent::__construct($id, $context);
 
-    $ajax_handler = new Ajax\SimpleCommand($id);
-    $this->add_ajax_handler($ajax_handler);
+    $this->handler = new Ajax\SimpleCommand($id);
+    $this->add_ajax_handler($this->handler);
   }
 
   /**
@@ -30,47 +35,47 @@ class SimpleCommand extends InfoBox {
    * @param string      $command       Command to be executed.
    * @param string|null $dryrun        Dry-run command to be executed (default null).
    * @param bool        $allow_failure Whether exit code other than 0 should respond with an error (default false).
+   * @return void
    */
   public function set_command( $command, $dryrun = null, $allow_failure = false ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_command($command, $dryrun, $allow_failure);
+    $this->handler->set_command($command, $dryrun, $allow_failure);
   }
 
   /**
    * Set whether exit code other than 0 should respond with an error.
    * @param bool $allow_failure Whether to allow failure.
+   * @return void
    */
   public function set_allow_failure( $allow_failure ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_allow_failure($allow_failure);
+    $this->handler->set_allow_failure($allow_failure);
   }
 
   /**
    * Set a message to be shown if command returns no data.
    * @param string $message Message to be shown for no command output.
+   * @return void
    */
   public function set_empty_message( $message ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_empty_message($message);
+    $this->handler->set_empty_message($message);
   }
 
   /**
    * Set text for the buttons.
    * @param string $text        Text on the button.
    * @param string $dryrun_text Text on the dry-run button (needs to be if there's dry-run command).
+   * @return void
    */
   public function set_button_text( $text, $dryrun_text = null ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_button_text($text, $dryrun_text);
+    $this->handler->set_button_text($text, $dryrun_text);
   }
 
   /**
    * Set text to be shown next to the spinner.
    * @param string $text Spinner text.
+   * @return void
    */
   public function set_spinner_text( $text ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_spinner_text($text);
+    $this->handler->set_spinner_text($text);
   }
 
 }

--- a/src/lib/postbox/templates/simple-form.php
+++ b/src/lib/postbox/templates/simple-form.php
@@ -13,6 +13,11 @@ use \Seravo\Ajax;
 class SimpleForm extends InfoBox {
 
   /**
+   * @var \Seravo\Ajax\SimpleForm The single ajax handler for this postbox.
+   */
+  private $handler;
+
+  /**
    * Constructor for SimpleForm. Will be called on new instance.
    * @param string $id      Unique id/slug of the postbox.
    * @param string $context Default admin dashboard context where the postbox should be displayed in.
@@ -20,46 +25,46 @@ class SimpleForm extends InfoBox {
   public function __construct( $id, $context = 'normal' ) {
     parent::__construct($id, $context);
 
-    $ajax_handler = new Ajax\SimpleForm($id);
-    $this->add_ajax_handler($ajax_handler);
+    $this->handler = new Ajax\SimpleForm($id);
+    $this->add_ajax_handler($this->handler);
   }
 
   /**
    * Set the callback function to be called for building the form.
-   * @param array $build_form_func Function for building the form.
+   * @param callable $build_form_func Function for building the form.
+   * @return void
    */
   public function set_build_form_func( $build_form_func ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_build_form_func($build_form_func);
+    $this->handler->set_build_form_func($build_form_func);
   }
 
   /**
    * Set the callback function for the postbox. The function will be
    * called on button clicks. The callback function should return an AjaxResponse.
-   * @param array $button_func Function to be called on button click.
+   * @param callable $button_func Function to be called on button click.
+   * @return void
    */
   public function set_ajax_func( $button_func ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_ajax_func($button_func);
+    $this->handler->set_ajax_func($button_func);
   }
 
   /**
    * Set text for the buttons.
    * @param string $text        Text on the button.
    * @param string $dryrun_text Text on the dry-run button (optional).
+   * @return void
    */
   public function set_button_text( $text, $dryrun_text = null ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_button_text($text, $dryrun_text);
+    $this->handler->set_button_text($text, $dryrun_text);
   }
 
   /**
    * Set text to be shown next to the spinner.
    * @param string $text Spinner text.
+   * @return void
    */
   public function set_spinner_text( $text ) {
-    $handler = $this->ajax_handlers[$this->id];
-    $handler->set_spinner_text($text);
+    $this->handler->set_spinner_text($text);
   }
 
 }

--- a/src/lib/postbox/toolpage.php
+++ b/src/lib/postbox/toolpage.php
@@ -11,20 +11,19 @@ namespace Seravo\Postbox;
 abstract class Toolpage {
 
   /**
-   * @var string Admin screen id where the page should be displayed in.
+   * @var string   Admin screen id where the page should be displayed in.
    */
   private $screen;
   /**
-   * @var string Slug name to refer to this page.
+   * @var string   Slug name to refer to this page.
    */
   private $slug;
   /**
-   * @var string The text to be displayed in the title tags of the page and menu.
+   * @var string   The text to be displayed in the title tags of the page and menu.
    */
   private $title;
   /**
-   * TODO: Check if this is used for wrong purpose in Seravo Plugin!
-   * @var string The position in the menu order this item should appear
+   * @var callable The position in the menu order this item should appear
    */
   private $position;
 
@@ -40,21 +39,23 @@ abstract class Toolpage {
   /**
    * Will be called for page initialization. Scripts are
    * included and charts/ajax enabled here.
+   * @return void
    */
   abstract public function init_page();
 
   /**
    * Will be called for setting requirements. Nothing else
    * should be done here.
+   * @return void
    */
   abstract public function set_requirements( Requirements $requirements);
 
   /**
    * Constructor for Toolpage. Will be called on new instance.
-   * @param string $title The text to be displayed in the title tags of the page and menu.
-   * @param string $screen Admin screen id where the page should be displayed in.
-   * @param string $slug Slug name to refer to this page.
-   * @param string $position The position in the menu order this item should appear.
+   * @param string   $title The text to be displayed in the title tags of the page and menu.
+   * @param string   $screen Admin screen id where the page should be displayed in.
+   * @param string   $slug Slug name to refer to this page.
+   * @param callable $position The position in the menu order this item should appear.
    */
   public function __construct( $title, $screen, $slug, $position ) {
     $this->title = $title;
@@ -88,6 +89,7 @@ abstract class Toolpage {
   /**
    * Enables AJAX features for this page. This must be called
    * on the page if there's even a single postbox using AJAX.
+   * @return void
    */
   public function enable_ajax() {
     add_action(
@@ -126,6 +128,7 @@ abstract class Toolpage {
   /**
    * Enables chart features for this page. This must be called
    * on the page if there's even a single postbox using charts.
+   * @return void
    */
   public function enable_charts() {
     add_action(
@@ -135,7 +138,7 @@ abstract class Toolpage {
           return;
         }
 
-        wp_enqueue_script('apexcharts-js', SERAVO_PLUGIN_URL . 'js/lib/apexcharts.js', '', \Seravo\Helpers::seravo_plugin_version(), true);
+        wp_enqueue_script('apexcharts-js', SERAVO_PLUGIN_URL . 'js/lib/apexcharts.js', array(), \Seravo\Helpers::seravo_plugin_version(), true);
         wp_enqueue_script('seravo-charts', SERAVO_PLUGIN_URL . 'js/charts.js', array( 'jquery' ), \Seravo\Helpers::seravo_plugin_version(), false);
 
         $charts_l10n = array(
@@ -163,6 +166,7 @@ abstract class Toolpage {
    * Register postbox to be shown on the page. The same postbox
    * instance shouldn't be used elsewhere without clone.
    * @param \Seravo\Postbox\Postbox $postbox Postbox to be registered.
+   * @return void
    */
   public function register_postbox( Postbox $postbox ) {
     $postbox->on_page_assign($this->screen);
@@ -189,6 +193,7 @@ abstract class Toolpage {
   /**
    * Register the page to be rendered. This should be called once
    * the page is ready and all the postboxes are added.
+   * @return void
    */
   private function register_page() {
     foreach ( $this->postboxes as $postbox ) {
@@ -200,6 +205,7 @@ abstract class Toolpage {
 
   /**
    * Register the page in "Tools" submenu.
+   * @return void
    */
   private function register_submenu() {
     add_submenu_page(

--- a/src/lib/shell.php
+++ b/src/lib/shell.php
@@ -12,11 +12,12 @@ class Shell {
   /**
    * Function for executing command more safely. Note that
    * this still isn't bulletproof.
-   * @param string $command      The hardcoded command to execute.
-   * @param array  $args         Optional extra arguments.
-   * @param array  $env          Optional extra env variables (key=>value).
-   * @param array  &$output      Array for the output.
-   * @param array  &$result_code Command exit code.
+   * @param string   $command     The hardcoded command to execute.
+   * @param string[] $args        Optional extra arguments.
+   * @param string[] $env         Optional extra env variables (key => value).
+   * @param string[] $output      Array for the output.
+   * @param int      $result_code Command exit code.
+   * @return void
    */
   public static function safe_exec( $command, $args = array(), $env = array(), &$output = null, &$result_code = null ) {
     $safe_command = self::sanitize_command($command, $args, $env);
@@ -26,9 +27,9 @@ class Shell {
   /**
    * Function for sanitizing commands to be more safe.
    * Note that this still isn't bulletproof.
-   * @param string $command      The hardcoded command to execute.
-   * @param array  $args         Optional extra arguments.
-   * @param array  $env          Optional extra env variables (key=>value).
+   * @param string          $command The hardcoded command to execute.
+   * @param null[]|string[] $args    Optional extra arguments.
+   * @param string[]        $env     Optional extra env variables (key=>value).
    * @return string Sanitized command.
    */
   public static function sanitize_command( $command, $args = array(), $env = array() ) {
@@ -71,7 +72,7 @@ class Shell {
 
   /**
    * Check if command is running.
-   * @param int $pid Pid of the program.
+   * @param string $pid Pid of the program.
    * @return bool Whether the command is running.
    */
   public static function is_pid_running( $pid ) {

--- a/src/lib/sitestatus-ajax.php
+++ b/src/lib/sitestatus-ajax.php
@@ -7,12 +7,18 @@ if ( ! defined('ABSPATH') ) {
   die('Access denied!');
 }
 
+/**
+ * @return string[] Output from verify-checksums command.
+ */
 function seravo_report_wp_core_verify() {
   exec('wp core verify-checksums 2>&1', $output);
   array_unshift($output, '$ wp core verify-checksums');
   return $output;
 }
 
+/**
+ * @return string[] Output from git status or error if git not available.
+ */
 function seravo_report_git_status() {
   exec('git -C /data/wordpress status', $output);
 
@@ -28,12 +34,22 @@ function seravo_report_git_status() {
   return $output;
 }
 
+/**
+ * @return void
+ */
 function seravo_reset_shadow() {
   if ( isset($_POST['shadow']) && ! empty($_POST['shadow']) ) {
     $shadow = $_POST['shadow'];
     $output = array();
+
     // Check if the shadow is known
-    foreach ( API::get_site_data('/shadows') as $data ) {
+    $shadows = API::get_site_data('/shadows');
+
+    if ( is_wp_error($shadows) ) {
+      wp_die();
+    }
+
+    foreach ( $shadows as $data ) {
       if ( $data['name'] == $shadow ) {
         exec('wp-shadow-reset ' . $shadow . ' --force 2>&1', $output);
         echo json_encode($output);
@@ -44,6 +60,9 @@ function seravo_reset_shadow() {
   wp_die();
 }
 
+/**
+ * @return void
+ */
 function seravo_ajax_site_status() {
   check_ajax_referer('seravo_site_status', 'nonce');
 

--- a/src/modules/check-default-email.php
+++ b/src/modules/check-default-email.php
@@ -21,10 +21,16 @@ if ( ! class_exists('CheckDefaultEmail') ) {
      */
     private static $bad_email_locals = array( 'no-reply', 'noreply', 'vagrant' );
 
+    /**
+     * @return void
+     */
     public static function load() {
       add_action('admin_notices', array( __CLASS__, '_seravo_check_default_email' ));
     }
 
+    /**
+     * @return void
+     */
     public static function _seravo_check_default_email() {
       // Get admin email option and take the local part before the @ sign
       $email = get_option('admin_email');
@@ -36,6 +42,9 @@ if ( ! class_exists('CheckDefaultEmail') ) {
       }
     }
 
+    /**
+     * @return void
+     */
     public static function _seravo_show_email_warning() {
       ?><div class="notice notice-error"><p>
       <?php

--- a/src/modules/check-https.php
+++ b/src/modules/check-https.php
@@ -16,10 +16,16 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('CheckHttps') ) {
   class CheckHttps {
 
+    /**
+     * @return void
+     */
     public static function load() {
       add_action('admin_notices', array( __CLASS__, '_seravo_check_https' ));
     }
 
+    /**
+     * @return void
+     */
     public static function _seravo_check_https() {
       // Get the siteurl and home url and check if https is enabled, if not, show warning
       $siteurl = get_option('siteurl');
@@ -29,6 +35,9 @@ if ( ! class_exists('CheckHttps') ) {
       }
     }
 
+    /**
+     * @return void
+     */
     public static function _seravo_show_https_warning() {
       $siteurl = get_option('siteurl'); ?>
       <div class="notice notice-error">

--- a/src/modules/check-php-version.php
+++ b/src/modules/check-php-version.php
@@ -17,8 +17,10 @@ if ( ! class_exists('CheckPHPVersion') ) {
 
   class CheckPHPVersion {
 
+    /**
+     * @return void
+     */
     public static function load() {
-
       add_action('admin_notices', array( __CLASS__, '_seravo_check_php_version' ));
       add_filter('wp_update_php_url', array( __CLASS__, '_seravo_update_php_url' ));
     }
@@ -39,9 +41,7 @@ if ( ! class_exists('CheckPHPVersion') ) {
       $recommended_version = '7.4';
 
       if ( version_compare(PHP_VERSION, $recommended_version, '<') ) {
-
         self::_seravo_show_php_recommendation($recommended_version);
-
       }
 
     }
@@ -53,6 +53,10 @@ if ( ! class_exists('CheckPHPVersion') ) {
       return __('https://help.seravo.com/article/41-set-your-site-to-use-newest-php-version', 'seravo');
     }
 
+    /**
+     * @param string $recommended_version The currently recommended PHP-version.
+     * @return void
+     */
     public static function _seravo_show_php_recommendation( $recommended_version ) {
       $url = self::_seravo_update_php_url();
       ?>

--- a/src/modules/check-site-health.php
+++ b/src/modules/check-site-health.php
@@ -33,6 +33,8 @@ if ( ! class_exists('Site_Health') ) {
     /**
      * Helper method for the class to execute given command & wrapping the return value
      * automatically as result array.
+     * @param string $command The command to be executed.
+     * @return string[] Output from the command.
      */
     private static function exec_command( $command ) {
         $output = array();
@@ -44,6 +46,7 @@ if ( ! class_exists('Site_Health') ) {
     /**
      * Check siteurl & home HTTPS usage status
      * Logic is from check-https-module
+     * @return void
      */
     private static function check_https() {
       $siteurl = get_option('siteurl');
@@ -59,6 +62,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Check that some recaptcha plugin is installed and active on WordPress.
+     * @return void
      */
     private static function check_recaptcha() {
       $output = self::exec_command('wp plugin list');
@@ -81,6 +85,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Count the inactive themes.
+     * @return void
      */
     private static function check_inactive_themes() {
       $output = self::exec_command('wp theme list');
@@ -106,6 +111,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Check potential bad and deprecated plugins specified by @bad_plugins array.
+     * @return void
      */
     private static function check_plugins() {
       // check inactive plugins and all plugin related issues
@@ -148,6 +154,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Fetch the PHP error count by using the error count of Login_Notifications module.
+     * @return void
      */
     private static function check_php_errors() {
       $php_info = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=logs_page&logfile=php-error.log" target="_blank">php-error.log</a>';
@@ -167,6 +174,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Execute command wp-test and wrap up whether it runs successfully or not.
+     * @return void
      */
     private static function check_wp_test() {
       exec('wp-test', $output, $return_variable);
@@ -181,7 +189,7 @@ if ( ! class_exists('Site_Health') ) {
 
     /**
      * Return passed and failed tests formatted in HTML.
-     * @return array Output, title and status color.
+     * @return mixed[] Output, title and status color.
      */
     private static function result_to_html() {
       $output = '';
@@ -212,16 +220,18 @@ if ( ! class_exists('Site_Health') ) {
       $output .= Template::section_title(__('Passed tests', 'seravo'), 'success')->to_html();
       $counter = 0;
 
-      foreach ( self::$no_issues as $element => $tooltip ) {
-        $tooltip_component = Template::tooltip($tooltip)->to_html();
+      if ( self::$no_issues !== null ) {
+        foreach ( self::$no_issues as $element => $tooltip ) {
+          $tooltip_component = Template::tooltip($tooltip)->to_html();
 
-        if ( $counter === count(self::$no_issues) - 1 ) {
-          // Apply border-bottom to the last element
-          $output .= '<div class="success-box" style="border-bottom: 1px solid #ccd0d4">' . $tooltip_component . $element . '</div>';
-        } else {
-          $output .= Template::text($tooltip_component . $element, 'success-box')->to_html();
+          if ( $counter === count(self::$no_issues) - 1 ) {
+            // Apply border-bottom to the last element
+            $output .= '<div class="success-box" style="border-bottom: 1px solid #ccd0d4">' . $tooltip_component . $element . '</div>';
+          } else {
+            $output .= Template::text($tooltip_component . $element, 'success-box')->to_html();
+          }
+          ++$counter;
         }
-        ++$counter;
       }
 
       return array( $output, $title, $status_color );

--- a/src/modules/dashboard-widgets.php
+++ b/src/modules/dashboard-widgets.php
@@ -17,30 +17,30 @@ if ( ! class_exists('Dashboard_Widgets') ) {
   class Dashboard_Widgets {
 
     /**
-     * @var int|null
+     * @var int|null The amount of PHP errors.
      */
     private static $errors;
-    // end of life versions
     /**
-     * @var int
+     * @var int Major end of life version.
      */
     const EOL_MAJOR = 7;
     /**
-     * @var int
+     * @var int Major end of life version.
      */
     const EOL_MINOR = 2;
 
-    // the relative disk usage
     /**
-     * @var float
+     * @var float The relative disk usage.
      */
     const LOW_DISK_SPACE_USAGE = 0.9;
-    // set a transient for 15 minutes
     /**
-     * @var int
+     * @var int Set a transient for 15 minutes.
      */
     const DISK_SPACE_CACHE_TIME = 900;
 
+    /**
+     * @return void
+     */
     public static function load() {
       // remove wp own PHP nag
       add_action('wp_dashboard_setup', array( __CLASS__, 'remove_wp_php_nag' ));
@@ -93,6 +93,7 @@ if ( ! class_exists('Dashboard_Widgets') ) {
 
     /**
      * Remove the WordPress old PHP nag on admin dashboard
+     * @return void
      */
     public static function remove_wp_php_nag() {
       remove_meta_box('dashboard_php_nag', 'dashboard', 'normal');
@@ -128,7 +129,8 @@ if ( ! class_exists('Dashboard_Widgets') ) {
       }
 
       if ( ! empty($data_folder) ) {
-        $data_size = preg_split('/\s+/', $data_folder[0])[0];
+        $data_size = preg_split('/\s+/', $data_folder[0]);
+        $data_size = $data_size !== false ? $data_size[0] : 0;
       }
       $plan_details = API::get_site_data();
 
@@ -153,6 +155,9 @@ if ( ! class_exists('Dashboard_Widgets') ) {
       );
     }
 
+    /**
+     * @return void
+     */
     public static function display_disk_space_low_warning() {
       $disk_space = self::disk_space_usage();
       $disk_usage_url = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=site_status_page#disk_usage_heading" target="_blank">' .
@@ -174,8 +179,9 @@ if ( ! class_exists('Dashboard_Widgets') ) {
     }
 
     /**
-    * Display the amount of php-error.log lines that have appeared this week and old PHP version.
-    */
+     * Display the amount of php-error.log lines that have appeared this week and old PHP version.
+     * @return void
+     */
     public static function display_php_warning_widget() {
 
       if ( self::$errors > 0 ) {
@@ -251,7 +257,7 @@ if ( ! class_exists('Dashboard_Widgets') ) {
       <?php
       $reports = glob('/data/slog/html/goaccess-*.html');
 
-      if ( count($reports) !== 0 ) {
+      if ( $reports !== false && ! empty($reports) ) {
         $contact_email_url = '<a href="mailto:help@seravo.com">help@seravo.com</a>';
         $msg = wp_sprintf(
         // translators: %1$s contact email link
@@ -285,7 +291,12 @@ if ( ! class_exists('Dashboard_Widgets') ) {
             break;
           }
           ++$report_month_counter;
+
           $total_requests_string = exec("grep -oE 'total_requests\": ([0-9]+),' {$report}");
+          if ( $total_requests_string === false ) {
+            continue;
+          }
+
           preg_match('/(\d+)/', $total_requests_string, $total_requests_match);
           $total_requests = (int) $total_requests_match[1];
           if ( $total_requests > $max_requests ) {

--- a/src/modules/fixes.php
+++ b/src/modules/fixes.php
@@ -17,6 +17,7 @@ if ( ! class_exists('Fixes') ) {
 
     /**
      * Loads Seravo features
+     * @return void
      */
     public static function load() {
 
@@ -65,6 +66,8 @@ if ( ! class_exists('Fixes') ) {
      * See https://core.trac.wordpress.org/ticket/31245
      * and https://github.com/tillkruss/redis-cache/issues/58
      *
+     * @param string $option Option that changed.
+     * @return void
      */
     public static function maybe_clear_alloptions_cache( $option ) {
 
@@ -81,6 +84,7 @@ if ( ! class_exists('Fixes') ) {
 
     /**
      * Removes core update notifications
+     * @return void
      */
     public static function hide_update_notifications() {
       remove_action('admin_notices', 'update_nag', 3);
@@ -90,7 +94,7 @@ if ( ! class_exists('Fixes') ) {
      * Removes red update bubbles from admin menus
      * @return array<string, string>|array<string, array<string, int>>
      */
-    public static function hide_update_data( $update_data, $titles = '' ) {
+    public static function hide_update_data() {
       return array(
         'counts' => array(
           'plugins'      => 0,
@@ -105,6 +109,8 @@ if ( ! class_exists('Fixes') ) {
 
     /**
      * Removes Site Health update check
+     * @param mixed[] $tests
+     * @return mixed[]
      */
     public static function remove_update_check( $tests ) {
       unset($tests['async']['background_updates']);
@@ -118,6 +124,8 @@ if ( ! class_exists('Fixes') ) {
      *
      * Doesn't force http 401 for AJAX calls as some AJAX actions don't
      * need authorization.
+     *
+     * @return void
      */
     public static function change_http_code_to_unauthorized() {
       if ( ! defined('DOING_AJAX') ) {
@@ -125,6 +133,9 @@ if ( ! class_exists('Fixes') ) {
       }
     }
 
+    /**
+     * @return void
+     */
     public static function send_no_cache_headers() {
       // Use WP function for this
       nocache_headers();

--- a/src/modules/hide-users.php
+++ b/src/modules/hide-users.php
@@ -14,10 +14,17 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('HideUsers') ) {
   class HideUsers {
 
+    /**
+     * @return void
+     */
     public static function load() {
         add_action('pre_user_query', array( __CLASS__, 'hide_user_from_page' ), 10, 3);
     }
 
+    /**
+     * @param \WP_User_Query $user_query
+     * @return void
+     */
     public static function hide_user_from_page( $user_query ) {
         if ( defined('WP_CLI') ) {
             return;
@@ -45,9 +52,8 @@ if ( ! class_exists('HideUsers') ) {
         );
     }
 
-    // Array of users that will be hidden from WP user front-end, wp-cli output and WP Admin panel.
     /**
-     * @var string[]
+     * @var string[] Array of users that will be hidden from WP user front-end, wp-cli output and WP Admin panel.
      */
     private static $hidden_user_array = array( 'seravotest', 'seravo' );
 

--- a/src/modules/login-notification.php
+++ b/src/modules/login-notification.php
@@ -17,22 +17,25 @@ if ( ! class_exists('Login_Notifications') ) {
      * @var mixed[]|null
      */
     private static $login;
-    // How many rows will be retrieved when reading logs, affects dashboard load time
     /**
-     * @var int
+     * @var int Amount of rows read from logs, affects dashboard load time.
      */
     private static $max_rows = 200;
 
+    /**
+     * @return void
+     */
     public static function load() {
       add_action('load-index.php', array( __CLASS__, 'retrieve_notification_data' ));
       add_action('load-profile.php', array( __CLASS__, 'retrieve_notification_data' ));
     }
 
     /**
-    * Retreives login notification data when loading the dashboard page.
-    */
+     * Retreives login notification data when loading the dashboard page.
+     * @return void
+     */
     public static function retrieve_notification_data() {
-      wp_enqueue_style('login-notification', SERAVO_PLUGIN_URL . 'style/login-notification.css', '', Helpers::seravo_plugin_version());
+      wp_enqueue_style('login-notification', SERAVO_PLUGIN_URL . 'style/login-notification.css', array(), Helpers::seravo_plugin_version());
 
       // Retrieve last login notification only if the user has just logged in
       if ( isset($_SERVER['HTTP_REFERER']) ) {
@@ -79,7 +82,7 @@ if ( ! class_exists('Login_Notifications') ) {
             wp_add_dashboard_widget(
               'seravo-error-widget',
               __('Large error log', 'seravo'),
-              array( __CLASS__, 'display_admin_log_read_notification' )
+              array( __CLASS__, 'display_admin_large_log_read_notification' )
             );
           }
         );
@@ -123,25 +126,29 @@ if ( ! class_exists('Login_Notifications') ) {
     }
 
     /**
-    * Get the last login details from the current user logged into WordPress.
-    *
-    * @return array Previous login ip address and date, or empty array if not found
-    */
+     * Get the last login details from the current user logged into WordPress.
+     * @return array<string,mixed> Previous login data.
+     */
     public static function retrieve_last_login() {
       // Read login log file and reverse it
       $log_read = Logs::read_log_lines_backwards('/data/log/wp-login.log', -1, self::$max_rows);
       if ( $log_read === array() ) {
-        return;
+        return array();
       }
 
       $output_reversed = array_reverse($log_read['output']);
 
       $already_skipped = false;
 
+      $user_data = get_userdata(wp_get_current_user()->ID);
+      if ( $user_data === false ) {
+        return array();
+      }
+
       foreach ( $output_reversed as $line ) {
         preg_match('/^(?<ip>[.:0-9a-f]+) - (?<name>[\w\-_.*@ ]+) \[(?<datetime>[\d\/\w: +]+)\] .* (?<status>[A-Z]+$)/', $line, $entry);
 
-        $is_current_user_login = (get_userdata(wp_get_current_user()->ID)->user_login === $entry['name']);
+        $is_current_user_login = $user_data->user_login === $entry['name'];
 
         // Handle only successful logins
         if ( $entry['status'] == 'SUCCESS' && $is_current_user_login ) {
@@ -157,14 +164,19 @@ if ( ! class_exists('Login_Notifications') ) {
 
           // Fetch login date and time
           $timezone = get_option('timezone_string');
+
           $datetime = \DateTime::createFromFormat('d/M/Y:H:i:s T', $entry['datetime']);
+          if ( $datetime === false ) {
+            continue;
+          }
+
           $datetime->setTimezone(new \DateTimeZone(empty($timezone) ? 'UTC' : $timezone));
 
           return array(
             'date'   => $datetime->format(get_option('date_format')),
             'time'   => $datetime->format(get_option('time_format')),
             'ip'     => $ip,
-            'domain' => $domain,
+            'domain' => $domain !== false ? $domain : '',
           );
         }
       }
@@ -172,10 +184,18 @@ if ( ! class_exists('Login_Notifications') ) {
     }
 
     /**
-    * Display the latest login of the current user logged in.
-    */
+     * Display the latest login of the current user logged in.
+     * @return void
+     */
     public static function display_admin_logins_notification() {
+      if ( self::$login === null ) {
+        return;
+      }
+
       $user_data = get_userdata(wp_get_current_user()->ID);
+      if ( $user_data === false ) {
+        return;
+      }
 
       if ( empty(self::$login['domain']) ) {
         $msg = wp_sprintf(
@@ -211,8 +231,9 @@ if ( ! class_exists('Login_Notifications') ) {
     }
 
     /**
-    * Display an error if the php-error.log file is exceptionally large
-    */
+     * Display an error if the php-error.log file is exceptionally large
+     * @return void
+     */
     public static function display_admin_large_log_read_notification() {
       $url = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=logs_page&logfile=php-error.log">php-error.log</a>';
       $msg = wp_sprintf(
@@ -222,8 +243,9 @@ if ( ! class_exists('Login_Notifications') ) {
     }
 
     /**
-    * Display an error if there is problem reading the php-error.log file
-    */
+     * Display an error if there is problem reading the php-error.log file
+     * @return void
+     */
     public static function display_admin_broken_log_read_notification() {
       $url = '<a href="' . get_option('siteurl') . '/wp-admin/tools.php?page=logs_page&logfile=php-error.log">php-error.log</a>';
       $msg = wp_sprintf(
@@ -232,5 +254,7 @@ if ( ! class_exists('Login_Notifications') ) {
       echo '<div>' . $msg . '</div>';
     }
   }
+
   Login_Notifications::load();
+
 }

--- a/src/modules/noindex-domain-alias.php
+++ b/src/modules/noindex-domain-alias.php
@@ -14,14 +14,20 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('Noindex') ) {
   class Noindex {
 
+    /**
+     * @return void
+     */
     public static function load() {
-
       add_filter('robots_txt', array( __CLASS__, 'maybe_hide_domain_alias' ), 10, 2);
-
     }
 
+    /**
+     * @param string $output The contents of robots.txt to be outputted.
+     * @param bool   $public Whether the site is considered "public".
+     * @return string The robots.txt content.
+     */
     public static function maybe_hide_domain_alias( $output, $public ) {
-      if ( '0' === $public ) {
+      if ( ! $public ) {
         // bail early if blog is not public
         return $output;
       }

--- a/src/modules/optimize-on-upload.php
+++ b/src/modules/optimize-on-upload.php
@@ -14,6 +14,9 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
 
   class OptimizeImagesOnUpload {
 
+    /**
+     * @return void
+     */
     public static function load() {
       /*
        * Run optimizer for all thumbnail sizes. Don't use 'handle_upload' as it
@@ -42,6 +45,8 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
      * If the file does not exists or is not an image, the optimizer will just
      * quickly bail out without any problems.
      *
+     * @param string $filename Name of the image file to be optimized.
+     * @return string The filename that was passed in.
      */
     public static function optimize_images_on_upload( $filename ) {
       $max_width = get_option('seravo-image-max-resolution-width');
@@ -61,11 +66,9 @@ if ( ! class_exists('OptimizeImagesOnUpload') ) {
       return $filename;
     }
 
-    /*
+    /**
      * Default WordPress JPEG quality is 82, which some find too low.
      * Override that with 90, which is almost always a high quality level.
-     */
-    /**
      * @return int
      */
     public static function jpeg_thumbnail_quality() {

--- a/src/modules/pages/backups.php
+++ b/src/modules/pages/backups.php
@@ -48,6 +48,7 @@ class Backups extends Toolpage {
   /**
    * Will be called for page initialization. Includes scripts
    * and enables toolpage features needed for this page.
+   * @return void
    */
   public function init_page() {
     self::init_postboxes($this);
@@ -67,6 +68,9 @@ class Backups extends Toolpage {
     $requirements->can_be_development = \true;
   }
 
+  /**
+   * @return void
+   */
   public static function init_postboxes( Toolpage $page ) {
     /**
      * Backup info postbox

--- a/src/modules/pages/domains.php
+++ b/src/modules/pages/domains.php
@@ -13,7 +13,13 @@ use \Seravo\Postbox\Requirements;
  */
 class Domains extends Toolpage {
 
+  /**
+   * @var \Seravo\Seravo_Domains_List_Table
+   */
   public static $domains_table;
+  /**
+   * @var \Seravo\Seravo_Mails_Forward_Table
+   */
   public static $mails_table;
 
   /**
@@ -50,6 +56,7 @@ class Domains extends Toolpage {
   /**
    * Will be called for page initialization. Includes scripts
    * and enables toolpage features needed for this page.
+   * @return void
    */
   public function init_page() {
     self::init_postboxes();
@@ -64,6 +71,7 @@ class Domains extends Toolpage {
    * must be as strict as possible but as loose as the
    * postbox with the loosest requirements on the page.
    * @param \Seravo\Postbox\Requirements $requirements Instance to set requirements to.
+   * @return void
    */
   public function set_requirements( Requirements $requirements ) {
     $requirements->can_be_production = \true;
@@ -72,6 +80,7 @@ class Domains extends Toolpage {
   /**
    * Register scripts.
    * @param string $screen The current screen.
+   * @return void
    */
   public static function enqueue_scripts( $screen ) {
     if ( $screen !== 'tools_page_domains_page' ) {
@@ -79,7 +88,7 @@ class Domains extends Toolpage {
     }
 
     wp_enqueue_script('seravo-domains-js', SERAVO_PLUGIN_URL . 'js/domains.js', array( 'jquery' ), Helpers::seravo_plugin_version(), false);
-    wp_enqueue_style('seravo-domains-css', SERAVO_PLUGIN_URL . 'style/domains.css', '', Helpers::seravo_plugin_version(), false);
+    wp_enqueue_style('seravo-domains-css', SERAVO_PLUGIN_URL . 'style/domains.css', array(), Helpers::seravo_plugin_version());
 
     $loc_translation_domains = array(
       'ajaxurl'             => admin_url('admin-ajax.php'),
@@ -106,6 +115,9 @@ class Domains extends Toolpage {
     wp_localize_script('seravo-domains-js', 'seravo_domains_loc', $loc_translation_domains);
   }
 
+  /**
+   * @return void
+   */
   public static function init_postboxes() {
     \Seravo\Postbox\seravo_add_raw_postbox(
       'domains-management',
@@ -124,6 +136,9 @@ class Domains extends Toolpage {
     );
   }
 
+  /**
+   * @return void
+   */
   public static function render_domains_postbox() {
     ?>
     <p><?php _e('Domains routed to this WordPress site are listed below.', 'seravo'); ?></p>
@@ -142,6 +157,9 @@ class Domains extends Toolpage {
     <?php
   }
 
+  /**
+   * @return void
+   */
   public static function render_mails_postbox() {
     ?>
     <div class="mail-table">

--- a/src/modules/pages/security.php
+++ b/src/modules/pages/security.php
@@ -64,7 +64,7 @@ class Security extends Toolpage {
     // AJAX functionality for listing and removing plugins
     add_action('wp_ajax_seravo_list_cruft_plugins', 'Seravo\seravo_ajax_list_cruft_plugins');
     add_action('wp_ajax_seravo_remove_plugins', 'Seravo\seravo_ajax_remove_plugins');
-    // AJAX functionality for listing and removing themess
+    // AJAX functionality for listing and removing themes
     add_action('wp_ajax_seravo_list_cruft_themes', 'Seravo\seravo_ajax_list_cruft_themes');
     add_action('wp_ajax_seravo_remove_themes', 'Seravo\seravo_ajax_remove_themes');
 
@@ -86,17 +86,18 @@ class Security extends Toolpage {
   /**
    * Register scripts.
    * @param string $screen The current screen.
+   * @return void
    */
   public static function enqueue_scripts( $screen ) {
     if ( $screen !== 'tools_page_security_page' ) {
       return;
     }
 
-    wp_enqueue_script('seravo-cruftfiles-js', SERAVO_PLUGIN_URL . 'js/cruftfiles.js', '', Helpers::seravo_plugin_version());
-    wp_enqueue_script('seravo-cruftplugins-js', SERAVO_PLUGIN_URL . 'js/cruftplugins.js', '', Helpers::seravo_plugin_version());
-    wp_enqueue_script('seravo-cruftthemes-js', SERAVO_PLUGIN_URL . 'js/cruftthemes.js', '', Helpers::seravo_plugin_version());
-    wp_enqueue_style('seravo-security-css', SERAVO_PLUGIN_URL . 'style/security.css', '', Helpers::seravo_plugin_version());
-    wp_enqueue_style('seravo-cruftfiles-css', SERAVO_PLUGIN_URL . 'style/cruftfiles.css', '', Helpers::seravo_plugin_version());
+    wp_enqueue_script('seravo-cruftfiles-js', SERAVO_PLUGIN_URL . 'js/cruftfiles.js', array(), Helpers::seravo_plugin_version());
+    wp_enqueue_script('seravo-cruftplugins-js', SERAVO_PLUGIN_URL . 'js/cruftplugins.js', array(), Helpers::seravo_plugin_version());
+    wp_enqueue_script('seravo-cruftthemes-js', SERAVO_PLUGIN_URL . 'js/cruftthemes.js', array(), Helpers::seravo_plugin_version());
+    wp_enqueue_style('seravo-security-css', SERAVO_PLUGIN_URL . 'style/security.css', array(), Helpers::seravo_plugin_version());
+    wp_enqueue_style('seravo-cruftfiles-css', SERAVO_PLUGIN_URL . 'style/cruftfiles.css', array(), Helpers::seravo_plugin_version());
 
     $loc_translation_files = array(
       'no_data'       => __('No data returned for the section.', 'seravo'),
@@ -152,6 +153,7 @@ class Security extends Toolpage {
   /**
    * Init postboxes on Security page.
    * @param Toolpage $page Page to init postboxes.
+   * @return void
    */
   public static function init_postboxes( Toolpage $page ) {
     \Seravo\Postbox\seravo_add_raw_postbox(
@@ -214,6 +216,7 @@ class Security extends Toolpage {
   /**
    * Check if the security settings have been set and show a notice if they
    * haven't been. No matter if the features are disabled or enabled.
+   * @return void
    */
   public static function _seravo_check_security_options() {
     $options = array(
@@ -245,7 +248,7 @@ class Security extends Toolpage {
 
   /**
    * Get setting section for the security settings postbox.
-   * @return \Seravo\Postbox\Setting The setting section instance.
+   * @return \Seravo\Postbox\Settings The setting section instance.
    */
   public static function get_security_settings() {
     $security_settings = new Settings('seravo-security-settings');
@@ -291,8 +294,9 @@ class Security extends Toolpage {
 
   /**
    * Build function for last successfull logins postbox.
-   * @param Component $base Base component.
-   * @param Postbox $postbox Postbox widget.
+   * @param \Seravo\Postbox\Component $base    Base component.
+   * @param \Seravo\Postbox\Postbox   $postbox Postbox widget.
+   * @return void
    */
   public static function build_last_logins( Component $base, Postbox\Postbox $postbox ) {
     $base->add_child(Template::paragraph(__('This tool can be used to retrieve last 10 successful logins. For more details and full login log see <a href="tools.php?page=logs_page&logfile=wp-login.log" target="_blank">wp-login.log</a>.', 'seravo')));
@@ -391,6 +395,9 @@ class Security extends Toolpage {
     return $response;
   }
 
+  /**
+   * @return void
+   */
   public static function cruftfiles_postbox() {
     ?>
     <p id="cruftfiles_tool">
@@ -411,6 +418,9 @@ class Security extends Toolpage {
     <?php
   }
 
+  /**
+   * @return void
+   */
   public static function cruftplugins_postbox() {
     ?>
     <p>
@@ -432,6 +442,9 @@ class Security extends Toolpage {
     <?php
   }
 
+  /**
+   * @return void
+   */
   public static function cruftthemes_postbox() {
     ?>
     <p>
@@ -451,6 +464,7 @@ class Security extends Toolpage {
   /**
    * $_POST['deletefile'] is either a string denoting only one file
    * or it can contain an array containing strings denoting files.
+   * @return void
    */
   public static function ajax_delete_file() {
     check_ajax_referer('seravo_cruftfiles', 'nonce');
@@ -479,6 +493,8 @@ class Security extends Toolpage {
   }
 
   /**
+   * @param string $dir
+   * @param int    $recursive
    * @return bool|void
    */
   public static function rmdir_recursive( $dir, $recursive ) {
@@ -487,7 +503,7 @@ class Security extends Toolpage {
         continue; // Skip current and upper level directories
       }
       if ( is_dir("{$dir}/{$file}") ) {
-        rmdir_recursive("{$dir}/{$file}", 1);
+        self::rmdir_recursive("{$dir}/{$file}", 1);
       } else {
         unlink("{$dir}/{$file}");
       }

--- a/src/modules/pages/test-page.php
+++ b/src/modules/pages/test-page.php
@@ -78,6 +78,7 @@ class TestPage extends Toolpage {
   /**
    * Initialize test-page postboxes.
    * @param \Seravo\Postbox\Toolpage $page The page for postboxes.
+   * @return void
    */
   public static function init_postboxes( Toolpage $page ) {
     /**
@@ -165,7 +166,7 @@ class TestPage extends Toolpage {
 
   /**
    * Get setting section for the setting demo postbox.
-   * @return \Seravo\Postbox\Setting The setting section instance.
+   * @return \Seravo\Postbox\Settings The setting section instance.
    */
   private static function get_demo_settings() {
     $demo_settings = new Settings('demo-settings', 'This title is optional');
@@ -227,7 +228,8 @@ class TestPage extends Toolpage {
 
     $message = 'This is bad mmkay?';
     $status_color = Ajax\FancyForm::STATUS_RED;
-    if ( count(preg_grep('/OK \(/i', $output)) >= 1 && $retval === 0 ) {
+    $ok = preg_grep('/OK \(/i', $output);
+    if ( $ok !== false && count($ok) >= 1 && $retval === 0 ) {
       // Success
       $message = "It's all good!";
       $status_color = Ajax\FancyForm::STATUS_GREEN;
@@ -269,6 +271,7 @@ class TestPage extends Toolpage {
    * Function for building nag-test postbox.
    * @param \Seravo\Postbox\Component $base    Component to build on.
    * @param \Seravo\Postbox\Postbox   $postbox The nag-test postbox.
+   * @return void
    */
   public static function build_nag_test( Component $base, Postbox\Postbox $postbox ) {
     // Always true

--- a/src/modules/passwords.php
+++ b/src/modules/passwords.php
@@ -22,6 +22,7 @@ if ( ! class_exists('Passwords') ) {
 
     /**
      * Load passwords features
+     * @return void
      */
     public static function load() {
 
@@ -38,22 +39,12 @@ if ( ! class_exists('Passwords') ) {
      * Register scripts
      *
      * @param string $page hook name
+     * @return void
      */
     public static function register_scripts( $page ) {
 
-      wp_register_style(
-        'seravo_passwords',
-        SERAVO_PLUGIN_URL . 'style/passwords.css',
-        '',
-        Helpers::seravo_plugin_version()
-      );
-      wp_register_script(
-        'seravo_passwords',
-        SERAVO_PLUGIN_URL . 'js/passwords.js',
-        array( 'jquery' ),
-        Helpers::seravo_plugin_version(), // version string
-        true // in footer
-      );
+      wp_register_style('seravo_passwords', SERAVO_PLUGIN_URL . 'style/passwords.css', array(), Helpers::seravo_plugin_version());
+      wp_register_script('seravo_passwords', SERAVO_PLUGIN_URL . 'js/passwords.js', array( 'jquery' ), Helpers::seravo_plugin_version(), true);
 
       if ( $page === 'profile.php' || $page === 'user-new.php' ) {
         wp_enqueue_style('seravo_passwords');
@@ -74,6 +65,9 @@ if ( ! class_exists('Passwords') ) {
      * check from running too frequently. When the user changes their password,
      * this field needs to be reset so that the check is guaranteed to run on
      * the next login.
+     *
+     * @param int $user_id ID of the user with changed meta.
+     * @return void
      */
     public static function clear_seravo_pwned_check_timestamp( $user_id ) {
       if ( isset($_POST['pass1']) && ! empty($_POST['pass1']) ) {
@@ -81,11 +75,22 @@ if ( ! class_exists('Passwords') ) {
       }
     }
 
+    /**
+     * @param \WP_User|\WP_Error $user     WP_User or WP_Error object if a previous callback failed authentication.
+     * @param string             $password Password used to login.
+     * @return \WP_Error|\WP_User The object given as $user.
+     */
     public static function calculate_password_hash( $user, $password ) {
       self::$password_hash = sha1($password);
       return $user;
     }
 
+    /**
+     * @param string             $redirect_to           The redirect destination URL.
+     * @param string             $requested_redirect_to The requested redirect destination URL passed as a parameter.
+     * @param \WP_User|\WP_Error $user                  WP_User object if login was successful, WP_Error object otherwise.
+     * @return string The new $redirect_to.
+     */
     public static function search_password_database( $redirect_to, $requested_redirect_to, $user ) {
       // Check if user has capability 'publish_pages'. By default user roles
       // editor, admin and superadmin are the only ones that have it.
@@ -121,6 +126,11 @@ if ( ! class_exists('Passwords') ) {
       return $redirect_to;
     }
 
+    /**
+     * @param string $redirect_to The URL user was really about to be redirected.
+     * @param string $hash        The user password hash.
+     * @return void
+     */
     public static function show_pwned_alert( $redirect_to, $hash ) {
     ?>
       <!DOCTYPE html>
@@ -152,4 +162,5 @@ if ( ! class_exists('Passwords') ) {
   }
 
   Passwords::load();
+
 }

--- a/src/modules/postbox-init.php
+++ b/src/modules/postbox-init.php
@@ -23,12 +23,13 @@ if ( ! isset($seravo_postbox_factory) ) {
 /**
  * Add a Seravo postbox. This function is only a wrapper for Seravo_Postbox_Factory::add_postbox, but
  * it unifies the Postbox API with the WP core add_meta_box.
- * @param string       $id            Unique id/slug of the postbox.
- * @param string       $title         Display title of the postbox.
- * @param callable     $callback      A function that outputs the postbox content.
- * @param string       $screen        Admin screen id where the postbox should be displayed in.
- * @param string       $context       Default admin dashboard context where the postbox should be displayed in.
- * @param array[mixed] $callback_args Array of arguments that will get passed to the callback function.
+ * @param string   $id            Unique id/slug of the postbox.
+ * @param string   $title         Display title of the postbox.
+ * @param callable $callback      A function that outputs the postbox content.
+ * @param string   $screen        Admin screen id where the postbox should be displayed in.
+ * @param string   $context       Default admin dashboard context where the postbox should be displayed in.
+ * @param mixed[]  $callback_args Array of arguments that will get passed to the callback function.
+ * @return void
  */
 function seravo_add_raw_postbox( $id, $title, $callback, $screen = 'tools_page', $context = 'normal', $callback_args = array() ) {
   global $seravo_postbox_factory;
@@ -38,8 +39,9 @@ function seravo_add_raw_postbox( $id, $title, $callback, $screen = 'tools_page',
 /**
  * Add a Seravo postbox. This function is only a wrapper for Seravo_Postbox_Factory::add_postbox, but
  * it unifies the Postbox API with the WP core add_meta_box.
- * @param string                  $screen Admin screen id where the postbox should be displayed in.
+ * @param string                  $screen  Admin screen id where the postbox should be displayed in.
  * @param \Seravo\Postbox\Postbox $postbox Seravo Postbox to be added.
+ * @return void
  */
 function seravo_add_postbox( $screen, Postbox $postbox ) {
   global $seravo_postbox_factory;
@@ -48,7 +50,7 @@ function seravo_add_postbox( $screen, Postbox $postbox ) {
     $postbox->id,
     $postbox->title,
     function () use ( $postbox ) {
-      return $postbox->_build();
+      $postbox->_build();
     },
     $screen,
     $postbox->context,
@@ -58,17 +60,24 @@ function seravo_add_postbox( $screen, Postbox $postbox ) {
 
 /**
  * Display a page with currently registered Seravo postboxes.
+ * @return void
  */
 function seravo_postboxes_page() {
   global $seravo_postbox_factory;
   $seravo_postbox_factory->display_postboxes_page('four_column');
 }
 
+/**
+ * @return void
+ */
 function seravo_two_column_postboxes_page() {
   global $seravo_postbox_factory;
   $seravo_postbox_factory->display_postboxes_page('two_column');
 }
 
+/**
+ * @return void
+ */
 function seravo_wide_column_postboxes_page() {
   global $seravo_postbox_factory;
   $seravo_postbox_factory->display_postboxes_page('one_column');

--- a/src/modules/purge-cache.php
+++ b/src/modules/purge-cache.php
@@ -14,6 +14,9 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('Purge_Cache') ) {
   class Purge_Cache {
 
+    /**
+     * @return void
+     */
     public static function load() {
       // Check permissions before registering actions
       if ( current_user_can(self::custom_capability()) ) {
@@ -27,6 +30,8 @@ if ( ! class_exists('Purge_Cache') ) {
 
     /**
      * Add a purge button in the WP Admin Bar
+     * @param \WP_Admin_Bar $admin_bar Instance of the admin bar.
+     * @return void
      */
     public static function purge_button( $admin_bar ) {
       $purge_url = add_query_arg('seravo_purge_cache', '1');
@@ -43,9 +48,10 @@ if ( ! class_exists('Purge_Cache') ) {
 
     /**
      * Load required scripts and styles for this module
+     * @return void
      */
     public static function enqueue_scripts() {
-      wp_enqueue_style('seravo_purge_cache', SERAVO_PLUGIN_URL . 'style/purge-cache.css', '', Helpers::seravo_plugin_version());
+      wp_enqueue_style('seravo_purge_cache', SERAVO_PLUGIN_URL . 'style/purge-cache.css', array(), Helpers::seravo_plugin_version());
       wp_enqueue_script('seravo_purge_cache', SERAVO_PLUGIN_URL . 'js/purge-cache.js', array( 'jquery' ), Helpers::seravo_plugin_version(), false);
       $loc_array = array(
         'seravo_purge_cache_nonce' => wp_create_nonce('seravo_purge_cache_nonce'),
@@ -56,11 +62,15 @@ if ( ! class_exists('Purge_Cache') ) {
 
     /**
      * Make capability filterable
+     * @return string
      */
     public static function custom_capability() {
       return apply_filters('seravo_purge_cache_capability', 'edit_posts');
     }
 
+    /**
+     * @return void
+     */
     public static function seravo_purge_notification() {
       // Don't show anything if there is no need to.
       if ( ! isset($_REQUEST['seravo_purge_success']) ) {
@@ -82,6 +92,7 @@ if ( ! class_exists('Purge_Cache') ) {
 
     /**
      * Purge the cache via AJAX
+     * @return void
      */
     public static function purge_cache() {
       $response = array();

--- a/src/modules/sanitize-on-upload.php
+++ b/src/modules/sanitize-on-upload.php
@@ -11,22 +11,29 @@ if ( ! defined('ABSPATH') ) {
 }
 
 if ( ! class_exists('SanitizeOnUpload') ) {
+  class SanitizeOnUpload {
 
-    class SanitizeOnUpload {
-
+    /**
+     * @return void
+     */
     public static function load() {
-        add_filter('wp_handle_upload_prefilter', array( __CLASS__, 'upload_prefilter' ), 10, 1);
+      add_filter('wp_handle_upload_prefilter', array( __CLASS__, 'upload_prefilter' ), 10, 1);
     }
 
+    /**
+     * @param mixed[] $file Filename to be sanitized.
+     * @return mixed[] Sanitized filename.
+     */
     public static function upload_prefilter( $file ) {
-        // Convert all characters in the filename to HTML entities first and then
-        // run a replacement to replace them with standard characters.
-        $file['name'] = preg_replace('/&([a-z])[a-z]+;/i', '$1', htmlentities($file['name']));
-        return $file;
+      // Convert all characters in the filename to HTML entities first and then
+      // run a replacement to replace them with standard characters.
+      $file['name'] = preg_replace('/&([a-z])[a-z]+;/i', '$1', htmlentities($file['name']));
+      return $file;
     }
 
-    }
-    if ( get_option('seravo-enable-sanitize-uploads') === 'on' ) {
-        SanitizeOnUpload::load();
-    }
+  }
+
+  if ( get_option('seravo-enable-sanitize-uploads') === 'on' ) {
+    SanitizeOnUpload::load();
+  }
 }

--- a/src/modules/seravotest-auth-bypass.php
+++ b/src/modules/seravotest-auth-bypass.php
@@ -15,15 +15,19 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('Seravotest_User_Login') ) {
   class Seravotest_Auth_Bypass {
 
+    /**
+     * @return void
+     */
     public static function load() {
-
       // Check for permission to enter only if flag is set
       if ( isset($_GET['seravotest-auth-bypass']) ) {
         add_action('login_init', array( __CLASS__, 'attempt_login' ), 10, 2);
       }
-
     }
 
+    /**
+     * @return void
+     */
     public static function attempt_login() {
       // If special authentication bypass key is found, check if a matching
       // key is found, and if soautomatically login user and redirect to wp-admin.
@@ -35,7 +39,7 @@ if ( ! class_exists('Seravotest_User_Login') ) {
 
         $user = get_user_by('login', 'seravotest');
 
-        if ( ! is_wp_error($user) ) {
+        if ( $user !== false ) {
           wp_clear_auth_cookie();
           wp_set_current_user($user->ID);
           wp_set_auth_cookie($user->ID);

--- a/src/modules/speed-test.php
+++ b/src/modules/speed-test.php
@@ -13,6 +13,9 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('Speed_Test') ) {
   class Speed_Test {
 
+    /**
+     * @return void
+     */
     public static function load() {
       // Check permissions before registering actions
       if ( current_user_can(self::custom_capability()) ) {
@@ -22,11 +25,18 @@ if ( ! class_exists('Speed_Test') ) {
       }
     }
 
+    /**
+     * @return string
+     */
     public static function custom_capability() {
       return apply_filters('seravo_speed_test_capability', 'edit_posts');
     }
 
-    // Add speed test button to WP Admin Bar
+    /**
+     * Add speed test button to WP Admin Bar
+     * @param \WP_Admin_Bar $admin_bar Instance of the admin bar.
+     * @return void
+     */
     public static function speed_test_button( $admin_bar ) {
       $target_location = ltrim($_SERVER['REQUEST_URI'], '/');
       $url = get_home_url() . '/wp-admin/tools.php?page=site_status_page';
@@ -63,11 +73,13 @@ if ( ! class_exists('Speed_Test') ) {
 
     /**
      * Load required scripts and styles for this module
+     * @return void
      */
     public static function enqueue_scripts() {
-      wp_enqueue_style('seravo_speed_test', SERAVO_PLUGIN_URL . 'style/speed-test.css', null, Helpers::seravo_plugin_version(), 'all');
+      wp_enqueue_style('seravo_speed_test', SERAVO_PLUGIN_URL . 'style/speed-test.css', array(), Helpers::seravo_plugin_version(), 'all');
     }
   }
+
   /* Caching happens in general only in production */
   if ( Helpers::is_production() ) {
     Speed_Test::load();

--- a/src/modules/svg-support.php
+++ b/src/modules/svg-support.php
@@ -11,32 +11,48 @@ if ( ! defined('ABSPATH') ) {
 }
 
 if ( ! class_exists('SVGSupport') ) {
-
   class SVGSupport {
 
-    // The sanitizer
-    protected $sanitizer;
-
+    /**
+     * @return void;
+     */
     public static function load() {
       add_filter('upload_mimes', array( __CLASS__, 'add_to_mime_types' ));
       add_filter('wp_handle_upload_prefilter', array( __CLASS__, 'sanitize_svg' ));
     }
 
-    // Add SVG to allowed mime types
+    /**
+     * Add SVG to allowed mime types
+     * @param array<string,string> $mimes Allowed file-extensions and their mime types.
+     * @return array<string,string> Allowed mime types with SVG added.
+     */
     public static function add_to_mime_types( $mimes ) {
       $mimes['svg'] = 'image/svg+xml';
       $mimes['svgz'] = 'image/svg+xml';
       return $mimes;
     }
 
-    // Check if the file is SVG and sanitize if it is
+    /**
+     * Check if the file is SVG and sanitize if it is
+     * @param mixed[] $file Details of the image uploaded.
+     * @return mixed[] Details of the image uploaded after sanization.
+     */
     public static function sanitize_svg( $file ) {
       $sanitizer = new \enshrined\svgSanitize\Sanitizer();
       $sanitizer->minify(true);
       if ( $file['type'] === 'image/svg+xml' ) {
         $dirty = file_get_contents($file['tmp_name']);
+        if ( $dirty === false ) {
+          // Couldn't read the file
+          $file['error'] = __(
+            "This file couldn't be sanitized so for security reasons it wasn't uploaded",
+            'seravo'
+          );
+          return $file;
+        }
+
         $clean = $sanitizer->sanitize($dirty);
-        if ( $clean === false ) {
+        if ( empty($clean) ) {
           $file['error'] = __(
             "This file couldn't be sanitized so for security reasons it wasn't uploaded",
             'seravo'
@@ -51,4 +67,5 @@ if ( ! class_exists('SVGSupport') ) {
   }
 
   SVGSupport::load();
+
 }

--- a/src/modules/wp-cli.php
+++ b/src/modules/wp-cli.php
@@ -23,11 +23,16 @@ class Seravo_WP_CLI extends \WP_CLI_Command {
    *
    *     wp seravo updates
    *
+   * @param string[] $args       Arguments for the command.
+   * @param string[] $assoc_args Associated arguments for the command.
+   * @return void
    */
   public function updates( $args, $assoc_args ) {
-
-    require_once SERAVO_PLUGIN_SRC . 'modules/upkeep.php';
     $site_info = Upkeep::seravo_admin_get_site_info();
+    if ( is_wp_error($site_info) ) {
+      \WP_CLI::error('Seravo API failed to return information about updates.');
+      return;
+    }
 
     if ( $site_info['seravo_updates'] === true ) {
       \WP_CLI::success('Seravo Updates: enabled');
@@ -36,8 +41,8 @@ class Seravo_WP_CLI extends \WP_CLI_Command {
     } else {
       \WP_CLI::error('Seravo API failed to return information about updates.');
     }
-
   }
+
 }
 
-\WP_CLI::add_command('seravo', 'Seravo\Seravo_WP_CLI');
+\WP_CLI::add_command('seravo updates', array( Seravo_WP_CLI::class, 'updates' ));

--- a/src/modules/wp-login-log.php
+++ b/src/modules/wp-login-log.php
@@ -14,8 +14,10 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('LoginLog') ) {
   class LoginLog {
 
+    /**
+     * @return void
+     */
     public static function load() {
-
       // At least the username must be correct for 'wp_authenticate_user' to run,
       // so it isn't good enough for our log, which also should log brute force
       // attacks. Instead use 'login_redirect' which is fired right after
@@ -23,11 +25,15 @@ if ( ! class_exists('LoginLog') ) {
       // wp-login.php load, so we shall not process it unless we really detect a
       // login in progress.
       add_filter('login_redirect', array( __CLASS__, 'wp_login_redirect_log' ), 10, 3);
-
     }
 
+    /**
+     * @param string             $redirect_to           The redirect destination URL.
+     * @param string             $requested_redirect_to The requested redirect destination URL passed as a parameter.
+     * @param \WP_User|\WP_Error $user                  WP_User object if login was successful, WP_Error object otherwise.
+     * @return string The $redirect_to passed.
+     */
     public static function wp_login_redirect_log( $redirect_to, $requested_redirect_to, $user ) {
-
       // Bail out quickly if username and password were not sent on this load
       if ( ! isset($_POST['log']) ||
             empty($_POST['log']) ||
@@ -66,6 +72,11 @@ if ( ! class_exists('LoginLog') ) {
       // Finally write the log to disk
 
       $log_fp = fopen('/data/log/wp-login.log', 'a');
+      if ( $log_fp === false ) {
+        // Couldn't open the file
+        return $redirect_to;
+      }
+
       fwrite($log_fp, "{$remote_addr} - {$remote_user} [{$time_local}] \"{$request}\" {$status_code} 1000 \"{$http_referer}\" \"{$http_user_agent}\" {$login_status} \n");
       fclose($log_fp);
 

--- a/src/modules/wp-plugin-log.php
+++ b/src/modules/wp-plugin-log.php
@@ -15,6 +15,9 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('PluginLog') ) {
   class PluginLog {
 
+    /**
+     * @return void
+     */
     public static function load() {
       add_action('activate_plugin', array( __CLASS__, 'on_try_activate_plugin' ), 10, 2);
       add_action('activated_plugin', array( __CLASS__, 'on_activate_plugin' ), 10, 2);
@@ -25,6 +28,11 @@ if ( ! class_exists('PluginLog') ) {
       add_action('delete_plugin', array( __CLASS__, 'on_delete_plugin' ));
     }
 
+    /**
+     * @param \WP_Upgrader $upgrader A WP_Upgrader instance.
+     * @param mixed[]      $arr_data Details about the upgrade.
+     * @return void
+     */
     public static function on_upgrader_process_complete( $upgrader = null, $arr_data = null ) {
       if ( empty($upgrader) || empty($arr_data) ) {
           return;
@@ -36,13 +44,13 @@ if ( ! class_exists('PluginLog') ) {
         return;
       }
 
-      if ( $type === 'theme' ) {
+      if ( $upgrader instanceof \Theme_Upgrader ) {
         if ( $action === 'install' ) {
           self::write_log('installed theme ' . $upgrader->theme_info());
         } elseif ( $action === 'update' ) {
           self::write_log('updated theme ' . $upgrader->theme_info());
         }
-      } elseif ( $type === 'plugin' ) {
+      } elseif ( $upgrader instanceof \Plugin_Upgrader ) {
         if ( $action === 'install' ) {
           self::write_log('installed plugin ' . $upgrader->plugin_info());
         } elseif ( $action === 'update' ) {
@@ -51,34 +59,70 @@ if ( ! class_exists('PluginLog') ) {
       }
     }
 
+    /**
+     * @param string $plugin Path to the plugin file relative to the plugins directory.
+     * @return void
+     */
     public static function on_delete_plugin( $plugin = '' ) {
       self::write_log('deleted plugin ' . $plugin);
     }
 
+    /**
+     * @param string $plugin             Path to the plugin file relative to the plugins directory.
+     * @param bool   $network_activation Whether this was for all sites in the network or just the current site.
+     * @return void
+     */
     public static function on_try_activate_plugin( $plugin, $network_activation ) {
       self::write_log('is trying to activate plugin ' . $plugin);
     }
 
+    /**
+     * @param string $plugin             Path to the plugin file relative to the plugins directory.
+     * @param bool   $network_activation Whether this was for all sites in the network or just the current site.
+     * @return void
+     */
     public static function on_activate_plugin( $plugin, $network_activation ) {
       self::write_log('activated plugin ' . $plugin);
     }
 
+    /**
+     * @param string $plugin             Path to the plugin file relative to the plugins directory.
+     * @param bool   $network_activation Whether this was for all sites in the network or just the current site.
+     * @return void
+     */
     public static function on_try_deactivate_plugin( $plugin, $network_activation ) {
       self::write_log('is trying to deactivate plugin ' . $plugin);
     }
 
+    /**
+     * @param string $plugin             Path to the plugin file relative to the plugins directory.
+     * @param bool   $network_activation Whether this was for all sites in the network or just the current site.
+     * @return void
+     */
     public static function on_deactivate_plugin( $plugin, $network_activation ) {
       self::write_log('deactivated plugin ' . $plugin);
     }
 
+    /**
+     * @param string $theme Name of the new theme.
+     * @return void
+     */
     public static function on_switch_theme( $theme ) {
       self::write_log('switched to theme ' . $theme);
     }
 
+    /**
+     * @param string $message Message to be written in to log.
+     * @return void
+     */
     public static function write_log( $message ) {
       $time_local = gmdate('j/M/Y:H:i:s O');
 
       $log_fp = fopen('/data/log/wp-settings.log', 'a');
+      if ( $log_fp === false ) {
+        // Couldn't open the file, can't do much
+        return;
+      }
 
       $current_user = wp_get_current_user();
       $user_id = $current_user->ID;
@@ -94,4 +138,5 @@ if ( ! class_exists('PluginLog') ) {
   }
 
   PluginLog::load();
+
 }

--- a/src/modules/wp-user-log.php
+++ b/src/modules/wp-user-log.php
@@ -15,6 +15,9 @@ if ( ! defined('ABSPATH') ) {
 if ( ! class_exists('UserLog') ) {
   class UserLog {
 
+    /**
+     * @return void
+     */
     public static function load() {
       add_action('edit_user_created_user', array( __CLASS__, 'on_edit_user_created_user' ), 10, 1);
       add_action('register_new_user', array( __CLASS__, 'on_register_new_user' ), 10, 1);
@@ -25,18 +28,29 @@ if ( ! class_exists('UserLog') ) {
       add_action('set_user_role', array( __CLASS__, 'on_set_user_role' ), 10, 3);
     }
 
-    // Existing user creates a new user
+    /**
+     * Existing user creates a new user.
+     * @param int $user_id ID of the user.
+     * @return void
+     */
     public static function on_edit_user_created_user( $user_id ) {
       if ( empty($user_id) || ! is_numeric($user_id) ) {
         return;
       }
 
       $user = get_userdata($user_id);
+      if ( $user === false ) {
+        return;
+      }
 
       self::write_log_user('created user ' . $user->user_login . ' (ID:' . $user_id . ')');
     }
 
-    // A new user registration
+    /**
+     * A new user registration.
+     * @param int $user_id ID of the user.
+     * @return void
+     */
     public static function on_register_new_user( $user_id ) {
       if ( empty($user_id || ! is_numeric($user_id)) ) {
         return;
@@ -45,23 +59,40 @@ if ( ! class_exists('UserLog') ) {
       self::write_log('User (ID:' . $user_id . ') registered');
     }
 
-    // User attempts to delete another user
+    /**
+     * User attempts to delete another user.
+     * @param int      $user_id          ID of the user.
+     * @param int|null $redirect_user_id ID of the user to reassign posts and links to.
+     * @return void
+     */
     public static function on_delete_user( $user_id, $redirect_user_id = null ) {
       if ( empty($user_id || ! is_numeric($user_id)) ) {
         return;
       }
 
       $user = get_userdata($user_id);
+      if ( $user === false ) {
+        return;
+      }
+
       // Check if the user content is reassinged to another user
       if ( $redirect_user_id === null ) {
         self::write_log_user('attempts to delete user ' . $user->user_login . ' (ID:' . $user_id . ')');
       } else {
         $redirect_user = get_userdata($redirect_user_id);
+        if ( $redirect_user === false ) {
+          return;
+        }
         self::write_log_user('attempts to delete user ' . $user->user_login . ' (ID:' . $user_id . ') and reassign content to user ' . $redirect_user->user_login . ' (ID:' . $redirect_user_id . ')');
       }
     }
 
-    // User deletes another user
+    /**
+     * User deletes another user.
+     * @param int      $user_id          ID of the user.
+     * @param int|null $redirect_user_id ID of the user to reassign posts and links to.
+     * @return void
+     */
     public static function on_deleted_user( $user_id, $redirect_user_id = null ) {
       if ( empty($user_id || ! is_numeric($user_id)) ) {
         return;
@@ -69,7 +100,11 @@ if ( ! class_exists('UserLog') ) {
       self::write_log_user('deleted user (ID:' . $user_id . ')');
     }
 
-    // User succesfully resets password
+    /**
+     * User succesfully resets password.
+     * @param \WP_User $user The user's WP_User object.
+     * @return void
+     */
     public static function on_after_password_reset( $user ) {
       if ( empty($user) ) {
         return;
@@ -77,13 +112,21 @@ if ( ! class_exists('UserLog') ) {
       self::write_log('User ' . $user->user_login . ' (ID:' . $user->ID . ') resetted password');
     }
 
-    // User changes user settings
+    /**
+     * User changes user settings.
+     * @param int      $user_id       ID of the user.
+     * @param \WP_User $old_user_data Object containing user's data prior to update.
+     * @return void
+     */
     public static function on_profile_update( $user_id, $old_user_data ) {
-      if ( empty($user_id) || ! is_numeric($user_id) || ! $old_user_data ) {
+      if ( empty($user_id) ) {
         return;
       }
 
       $new_user_data = get_userdata($user_id);
+      if ( $new_user_data === false ) {
+        return;
+      }
 
       $username = $new_user_data->user_login;
       $username .= (' (ID:' . $user_id . ')');
@@ -99,7 +142,13 @@ if ( ! class_exists('UserLog') ) {
       }
     }
 
-    // User's role is changed
+    /**
+     * User's role is changed.
+     * @param int      $user_id   ID of the user.
+     * @param string   $role      The new role.
+     * @param string[] $old_roles An array of the user's previous roles.
+     * @return void
+     */
     public static function on_set_user_role( $user_id, $role, $old_roles ) {
       if ( empty($user_id) || ! is_numeric($user_id) ) {
         return;
@@ -108,6 +157,10 @@ if ( ! class_exists('UserLog') ) {
       // If ID is 0, there is no current user. eg role set on registration or wp-test
       if ( wp_get_current_user()->ID === 0 ) {
         $new_user_data = get_userdata($user_id);
+        if ( $new_user_data === false ) {
+          return;
+        }
+
         $username = $new_user_data->user_login;
 
         // Hide seravotest user from the logs
@@ -119,7 +172,11 @@ if ( ! class_exists('UserLog') ) {
       }
     }
 
-    // Add current user info to the log entry
+    /**
+     * Add current user info to the log entry.
+     * @param string $message Message to be written in to log.
+     * @return void
+     */
     public static function write_log_user( $message ) {
       $current_user = wp_get_current_user();
       $user_id = $current_user->ID;
@@ -129,10 +186,19 @@ if ( ! class_exists('UserLog') ) {
       self::write_log($message);
     }
 
+    /**
+     * @param string $message Message to be written in to log.
+     * @return void
+     */
     public static function write_log( $message ) {
       $time_local = date('j/M/Y:H:i:s O');
 
       $log_fp = fopen('/data/log/wp-user.log', 'a');
+      if ( $log_fp === false ) {
+        // Couldn't open the file, can't do much
+        return;
+      }
+
       fwrite($log_fp, "{$time_local} {$message}\n");
       fclose($log_fp);
     }


### PR DESCRIPTION
#### What are the main changes in this PR?

Cruft AJAX files are completely skipped and security.php is partly skipped as @Moppa5 is currently working on those files.

##### Why are we doing this? Any context or related work?
https://github.com/Seravo/seravo-plugin/pull/542 and refactoring project

#### Where should a reviewer start?

All these changes are written by hand, no automation involved, meaning there's plenty of mistakes.

Mistakes in the comments are no big deal. Some of the `@param`s etc are still missing description and valid type hint (a lot of `mixed[]` at least for now), they should be written when refactoring that file.

But every time there's changes in the code, they must be checked for mistakes. I recommend reviewing this commit by commit, that's why I haven't squashed the commits. Similar changes are grouped by commits and are easier to inspect.

Most of the changes to comments are in lvl 6 and most of the code changes are lvl 7-8. Rest are really small commits.