### PR TITLE
Run PHPStan on CI for PHP versions 7.1/7.4/8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ os: linux
 
 php:
   - '5.6'
-  - '7.4'
-  - '8.0'
   - 'nightly'
 
 jobs:
   include:
-    # Latest stable PHP version to run the sniffs against
+    - php: '7.1'
+      env: SNIFF=1 PHPSTAN=1
     - php: '7.4'
-      env: SNIFF=1
-    # Next PHP version with latest version of all sniffs for early detection of things that deprecate
+      env: SNIFF=1 PHPSTAN=1
     - php: '8.0'
-      env: SNIFF=1 PHPCS_VERSION=master WP_SNIFFS_VERSION=master SECURITY_SNIFFS_VERSION=master PHP_COMPAT_SNIFFS_VERSION=master
+      env: SNIFF=1 PHPSTAN=1
+    - php: '8.0'
+      env: SNIFF=1 PHPSTAN=1 PHPCS_VERSION=master WP_SNIFFS_VERSION=master SECURITY_SNIFFS_VERSION=master PHP_COMPAT_SNIFFS_VERSION=master
     - name: Gnitpick
       language: python
       services: # none
@@ -24,15 +24,20 @@ jobs:
       - python3 ./gnitpick.py
   allow_failures:
     - php: nightly
-    - env: SNIFF=1 PHPCS_VERSION=master WP_SNIFFS_VERSION=master SECURITY_SNIFFS_VERSION=master PHP_COMPAT_SNIFFS_VERSION=master
+    - env: SNIFF=1 PHPSTAN=1 PHPCS_VERSION=master WP_SNIFFS_VERSION=master SECURITY_SNIFFS_VERSION=master PHP_COMPAT_SNIFFS_VERSION=master
 
 install:
+  # Install Composer packages
+  - if [ -n "$PHPSTAN" ]; then composer install; fi
   # Install PHP CodeSniffer, WP Coding Standards and PHPCS Security Audit
   - if [ -n "$SNIFF" ]; then scripts/install-phpcs.sh; fi
 
 script:
   # Syntax check all PHP files and fail for any error text in STDERR
-  - '! find . -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
+  - '! find src/ -type f -name "*.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
+  - '! find . -type f -name "seravo-plugin.php" -exec php -d error_reporting=32767 -l {} \; 2>&1 >&- | grep "^"'
+  # Static analysis to check the code for errors
+  - if [ -n "$PHPSTAN" ]; then vendor/bin/phpstan --memory-limit=512M analyse; fi
   # Style and security check using PHP CheckSniffer
   - if [ -n "$SNIFF" ]; then $HOME/.local/bin/phpcs -i; $HOME/.local/bin/phpcs -ns; fi
   # Run code and test functionality

--- a/src/modules/dashboard-widgets.php
+++ b/src/modules/dashboard-widgets.php
@@ -1,6 +1,8 @@
 <?php
 namespace Seravo;
 
+use \Seravo\Compatibility;
+
 /** Class DashboardWidgets
  *
  * Generate WP admin dashboard widgets
@@ -282,7 +284,7 @@ class DashboardWidgets {
           }
           ++$report_month_counter;
 
-          $total_requests_string = exec("grep -oE 'total_requests\": ([0-9]+),' {$report}");
+          $total_requests_string = Compatibility::exec("grep -oE 'total_requests\": ([0-9]+),' {$report}");
           if ( $total_requests_string === false ) {
             continue;
           }

--- a/src/modules/pages/database.php
+++ b/src/modules/pages/database.php
@@ -4,6 +4,7 @@ namespace Seravo\Page;
 
 use \Seravo\Shell;
 use \Seravo\Helpers;
+use \Seravo\Compatibility;
 
 use \Seravo\Ajax;
 use \Seravo\Ajax\AjaxResponse;
@@ -349,7 +350,7 @@ class Database extends Toolpage {
   public static function fetch_db_info() {
     $response = new AjaxResponse();
     $db_columns = array();
-    $cmd = exec('wp db size', $output, $return_code);
+    $cmd = Compatibility::exec('wp db size', $output, $return_code);
 
     if ( $cmd === false || $return_code !== 0 ) {
       $response->is_success(false);
@@ -384,8 +385,8 @@ class Database extends Toolpage {
    */
   public static function fetch_db_table_sizes() {
     $response = new AjaxResponse();
-    $size_in_format = exec('wp db size --size_format=b', $total, $result_code_normal);
-    $size_in_json = exec('wp db size --tables --format=json', $json, $result_code_json);
+    $size_in_format = Compatibility::exec('wp db size --size_format=b', $total, $result_code_normal);
+    $size_in_json = Compatibility::exec('wp db size --tables --format=json', $json, $result_code_json);
     $execution_fail = __('Executing command <code>wp db size</code> failed. Command returned with exit status ', 'seravo');
 
     if ( $size_in_format === false || $result_code_normal !== 0 ) {

--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -3,9 +3,10 @@
 namespace Seravo\Page;
 
 use \Seravo\Helpers;
-use \Seravo\Dashboard_Widgets;  // TODO: Not good, get rid of
-use \Seravo\Site_Health;        // TODO: Not good, get rid of (??)
+use \Seravo\DashboardWidgets;   // TODO: Not good, get rid of
+use \Seravo\SiteHealth;         // TODO: Not good, get rid of (??)
 use \Seravo\API;
+use \Seravo\Compatibility;
 use \Seravo\Page\Upkeep;        // TODO: Not good, get rid of
 
 use \Seravo\Ajax;
@@ -695,7 +696,7 @@ class SiteStatus extends Toolpage {
       $months = array();
 
       foreach ( array_reverse($reports) as $report ) {
-        $total_requests_string = exec("grep -oE 'total_requests\": ([0-9]+),' {$report}");
+        $total_requests_string = Compatibility::exec("grep -oE 'total_requests\": ([0-9]+),' {$report}");
         if ( $total_requests_string === false ) {
           continue;
         }


### PR DESCRIPTION
#### What are the main changes in this PR?

Run PHPStan on CI as PHPStan has different output for different PHP versions and nobody has all the PHP versions installed locally. Running PHPStan is a must anyways as it doesn't tell about optional improvements but actual errors or errors waiting to happen.

This makes sure Seravo Plugin is always compatible with multiple PHP versions, not just the ones that's on the developers local machine and demo site.

Sadly we can't run PHPStan on PHP <7.1 but function signatures didn't really change much between 5.6->7.1 so I don't think we are missing anything and Seravo Plugin is dropping official 5.6 support anyways. The old 5.6 tests are still ran normally, this PR doesn't break anything, only adds more fail-safes.

Also fixes `seravo-plugin-2/master` PHPStan errors for PHP 7.1 and 7.4.