### PR TITLE
Add strict PHPStan rules and run CI on oldest and latest WordPress stubs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     - php: '7.4'
       env: SNIFF=1 PHPSTAN=1
     - php: '8.0'
-      env: SNIFF=1 PHPSTAN=1
+      env: SNIFF=1 PHPSTAN=1 LATEST_WP=1
     - php: '8.0'
       env: SNIFF=1 PHPSTAN=1 PHPCS_VERSION=master WP_SNIFFS_VERSION=master SECURITY_SNIFFS_VERSION=master PHP_COMPAT_SNIFFS_VERSION=master
     - name: Gnitpick
@@ -29,6 +29,9 @@ jobs:
 install:
   # Install Composer packages
   - if [ -n "$PHPSTAN" ]; then composer install; fi
+  # Install latest WordPress stubs and WP-CLI stubs
+  - if [ -n "$LATEST_WP" ]; then composer require --dev "php-stubs/wordpress-stubs"; fi
+  - if [ -n "$LATEST_WP" ]; then composer require --dev "php-stubs/wp-cli-stubs"; fi
   # Install PHP CodeSniffer, WP Coding Standards and PHPCS Security Audit
   - if [ -n "$SNIFF" ]; then scripts/install-phpcs.sh; fi
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "rector/rector": "^0.11.16",
     "squizlabs/php_codesniffer": "3.6",
     "wp-coding-standards/wpcs": "^2.3",
-    "szepeviktor/phpstan-wordpress": "^0.7.5"
+    "szepeviktor/phpstan-wordpress": "^0.7.5",
+    "phpstan/phpstan-strict-rules": "^0.12.10"
   },
   "autoload": {
     "classmap": [

--- a/js/common.js
+++ b/js/common.js
@@ -3,13 +3,6 @@
 jQuery(document).ready(
   function () {
     jQuery('.seravo-show-more-wrapper').click(on_show_more_wrapper_click);
-
-    jQuery('.email-list-input').find('button').click(on_email_list_add_click);
-    jQuery('.email-list-input').each(
-      function () {
-        update_email_list(this);
-      }
-    );
   }
 );
 
@@ -52,75 +45,6 @@ function on_show_more_wrapper_click(event) {
       }
     );
   }
-}
-
-/**
- * Function to be called on email-list "add" button click.
- */
-function on_email_list_add_click(event) {
-  event.preventDefault();
-
-  var table = jQuery(this).closest('.email-list-input');
-  var input = table.find("input[type='email']");
-  var hidden_input = table.find("input[type='text']");
-
-  var email = input.val();
-  var emails = hidden_input.val().split(',');
-
-  if (emails.indexOf(email) != -1) {
-    return;
-  } else if (! is_email_valid(email)) {
-    return;
-  }
-
-  input.val('');
-
-  emails.push(email);
-  hidden_input.val(emails.join(','));
-
-  update_email_list(table);
-}
-
-/**
- * Function to be called when emails in email-list have changed.
- */
-function update_email_list(table) {
-  var hidden_input = jQuery(table).find("input[type='text']");
-  var emails = hidden_input.val();
-
-  jQuery(table).find('.email-list-row').remove();
-
-  if (emails === undefined) {
-    return;
-  }
-
-  emails.split(',').forEach(
-    function (email) {
-      if (email === "") {
-        return;
-      }
-
-      var content = '<p class="email-button-content" title="' + email + '">' + email + '</p><span class="delete-icon dashicons dashicons-no"></span>';
-      var button = '<button type="button" value="' + email + '" class="button email-button">' + content + '</button>';
-      jQuery(table).find('tr:last').after('<tr class="email-list-row"><td colspan="2">' + button + '</td></tr>')
-    }
-  );
-
-  jQuery(table).find('.email-button').click(
-    function () {
-      var email = jQuery(this).val();
-
-      var emails = hidden_input.val().split(',');
-      emails = emails.filter(
-        function (n) {
-          return n !== email;
-        }
-      )
-      hidden_input.val(emails.join(','));
-
-      update_email_list(table);
-    }
-  )
 }
 
 function is_email_valid(email) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,8 @@
 includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+
 parameters:
-    # TODO level: max
     level: 8
     scanFiles:
         - vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
@@ -34,3 +35,5 @@ parameters:
         # Uses function_exists()
         - '#^Function jetpack_protect_get_ip not found\.$#'
     reportUnmatchedIgnoredErrors: false
+    # TODO: Remove after 5.6/7.0 not supported at all
+    checkMissingClosureNativeReturnTypehintRule : false

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -88,35 +88,19 @@ class Loader {
     /*
      * Load translations
      */
-    add_action(
-      'plugins_loaded',
-      function () {
-        $this->load_textdomain();
-      }
-    );
+    add_action('plugins_loaded', array( __CLASS__, 'load_textdomain' ));
 
     /*
      * Register early on the direct download add_action as it must trigger
      * before anything is sent to the output buffer.
      */
-    add_action(
-      'plugins_loaded',
-      function () {
-        $this->protected_downloads();
-      }
-    );
+    add_action('plugins_loaded', array( __CLASS__, 'protected_downloads' ));
 
     /*
      * It is important to load plugins in init hook so that themes and plugins can override the functionality
      * Use smaller priority so that all plugins and themes are run first.
      */
-    add_action(
-      'init',
-      function () {
-        $this->load_all_modules();
-      },
-      20
-    );
+    add_action('init', array( __CLASS__, 'load_all_modules' ), 20);
   }
 
   /**
@@ -176,10 +160,10 @@ class Loader {
 
       // Filename must be of correct form, e.g. 2016-09.html or home.png
       // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
-      if ( isset($_GET['report']) && preg_match('/^\d{4}-\d{2}\.html$/', $_GET['report'], $matches) ) {
+      if ( isset($_GET['report']) && preg_match('/^\d{4}-\d{2}\.html$/', $_GET['report'], $matches) === 1 ) {
         self::x_accel_redirect('/data/slog/html/goaccess-' . $matches[0]);
       // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
-      } elseif ( isset($_GET['screenshot']) && preg_match('/^[a-z-.]+\.png$/', $_GET['screenshot'], $matches) ) {
+      } elseif ( isset($_GET['screenshot']) && preg_match('/^[a-z-.]+\.png$/', $_GET['screenshot'], $matches) === 1 ) {
         self::x_accel_redirect('/data/reports/tests/debug/' . $matches[0]);
       } else {
         // Yield an error if a file was requested, but with wrong filename.
@@ -267,7 +251,7 @@ class Loader {
     /*
      * Instance switcher
      */
-    if ( apply_filters('seravo_show_instance_switcher', true) && getenv('WP_ENV') !== 'development' ) {
+    if ( apply_filters('seravo_show_instance_switcher', true) === true && getenv('WP_ENV') !== 'development' ) {
       InstanceSwitcher::load();
     }
 

--- a/src/lib/ajax/handler.php
+++ b/src/lib/ajax/handler.php
@@ -213,8 +213,13 @@ class AjaxHandler {
    *                                        polling is done, false if not polling yet.
    */
   public static function check_polling() {
-    if ( isset($_REQUEST['poller_id']) && ! empty($_REQUEST['poller_id']) ) {
-      $pid = base64_decode($_REQUEST['poller_id']);
+    if ( isset($_REQUEST['poller_id']) && $_REQUEST['poller_id'] !== '' ) {
+      $pid = base64_decode($_REQUEST['poller_id'], true);
+
+      if ( $pid === false ) {
+        // Poller ID wasn't valid base64 string
+        return false;
+      }
 
       if ( \Seravo\Shell::is_pid_running($pid) ) {
         return AjaxResponse::require_polling_response($pid);

--- a/src/lib/ajax/templates/lazy-command.php
+++ b/src/lib/ajax/templates/lazy-command.php
@@ -73,7 +73,7 @@ class LazyCommand extends LazyLoader {
       return AjaxResponse::command_error_response($exec_command);
     }
 
-    if ( empty($output) ) {
+    if ( $output === array() ) {
       $output = $this->empty_message === null ? __('Command returned no data', 'seravo') : $this->empty_message;
     } else {
       $output = implode("\n", $output);

--- a/src/lib/ajax/templates/simple-command.php
+++ b/src/lib/ajax/templates/simple-command.php
@@ -85,7 +85,7 @@ class SimpleCommand extends SimpleForm {
       return AjaxResponse::command_error_response($this->command);
     }
 
-    if ( empty($output) ) {
+    if ( $output === array() ) {
       $output = $this->empty_message === null ? __('Command returned no data', 'seravo') : $this->empty_message;
     } else {
       $output = implode("\n", $output);

--- a/src/lib/api.php
+++ b/src/lib/api.php
@@ -30,7 +30,7 @@ class API {
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
     // Check for errors
-    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) || is_bool($response) ) {
+    if ( curl_error($ch) !== '' || ! in_array($httpcode, $handled_http_codes, true) || is_bool($response) ) {
       error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
       curl_close($ch);
       return new \WP_Error('seravo-api-get-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));
@@ -82,7 +82,7 @@ class API {
     $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
     // Check for errors
-    if ( curl_error($ch) || ! in_array($httpcode, $handled_http_codes) || is_bool($response) ) {
+    if ( curl_error($ch) !== '' || ! in_array($httpcode, $handled_http_codes, true) || is_bool($response) ) {
       error_log('SWD API (' . $api_query . ') error ' . $httpcode . ': ' . curl_error($ch));
       curl_close($ch);
       return new \WP_Error('seravo-api-put-fail', __('API call failed. Aborting. The error has been logged.', 'seravo'));

--- a/src/lib/compatibility.php
+++ b/src/lib/compatibility.php
@@ -29,7 +29,7 @@ class Compatibility {
 
     if ( strnatcmp(self::get_php_version(), '8.0.0') >= 0 ) {
       // PHP >8.0 returns empty string instead of false on failure
-      if ( empty($substr) ) {
+      if ( $substr === '' ) {
         return false;
       }
     }
@@ -51,7 +51,7 @@ class Compatibility {
     $exec = \exec($command, $output, $result_code);
     if ( strnatcmp(self::get_php_version(), '8.0.0') < 0 ) {
       // PHP <8.0 never returns false
-      if ( empty($exec) && $output === null && $result_code === null ) {
+      if ( $output === null && $result_code === null ) {
         return false;
       }
     }

--- a/src/lib/cruftremover.php
+++ b/src/lib/cruftremover.php
@@ -67,7 +67,7 @@ class CruftRemover {
     exec('find ' . $dir, $content);
     foreach ( $content as $path ) {
       if ( $path !== $dir ) {
-        if ( (! in_array($path, $wl_files)) && (! in_array($path, $wl_dirs)) ) {
+        if ( (! in_array($path, $wl_files, true)) && (! in_array($path, $wl_dirs, true)) ) {
           // The file was not whitelisted
           return false;
         }
@@ -218,14 +218,14 @@ class CruftRemover {
 
     foreach ( $list_files as $filename ) {
       $cruft_found = self::find_cruft_file($filename);
-      if ( ! empty($cruft_found) ) {
+      if ( $cruft_found !== array() ) {
         $crufts = array_merge($crufts, $cruft_found);
       }
     }
 
     foreach ( $list_dirs as $dirname ) {
       $cruft_found = self::find_cruft_dir($dirname);
-      if ( ! empty($cruft_found) ) {
+      if ( $cruft_found !== array() ) {
         $crufts = array_merge($crufts, $cruft_found);
       }
     }
@@ -256,20 +256,20 @@ class CruftRemover {
     foreach ( $list_known_files as $file ) {
       exec('ls ' . $file, $cruft_found);
 
-      if ( ! empty($cruft_found) ) {
+      if ( $cruft_found !== array() ) {
         $crufts = array_merge($crufts, $cruft_found);
       }
     }
 
     foreach ( $list_known_dirs as $dirname ) {
       exec('ls -d ' . $dirname, $cruft_found);
-        if ( ! empty($cruft_found) ) {
-          foreach ( $cruft_found as $key => $cruft_dir ) {
-            if ( self::only_has_whitelisted_content($cruft_dir, $white_list_files, $white_list_dirs) ) {
-              unset($cruft_found[$key]);
+        if ( $cruft_found !== array() ) {
+        foreach ( $cruft_found as $key => $cruft_dir ) {
+          if ( self::only_has_whitelisted_content($cruft_dir, $white_list_files, $white_list_dirs) ) {
+            unset($cruft_found[$key]);
             }
           }
-          $crufts = array_merge($crufts, $cruft_found);
+        $crufts = array_merge($crufts, $cruft_found);
         }
     }
 

--- a/src/lib/helpers.php
+++ b/src/lib/helpers.php
@@ -14,7 +14,7 @@ class Helpers {
    * @return bool
    */
   public static function is_development() {
-     return (getenv('WP_ENV') && getenv('WP_ENV') === 'development');
+     return getenv('WP_ENV') === 'development';
   }
 
   /**
@@ -23,7 +23,7 @@ class Helpers {
    * @return bool
    */
   public static function is_production() {
-     return (getenv('WP_ENV') && getenv('WP_ENV') === 'production');
+     return getenv('WP_ENV') === 'production';
   }
 
   /**
@@ -34,7 +34,7 @@ class Helpers {
    * @return bool
    */
   public static function is_staging() {
-     return (getenv('WP_ENV') && getenv('WP_ENV') === 'staging');
+     return getenv('WP_ENV') === 'staging';
   }
 
   /**
@@ -57,6 +57,7 @@ class Helpers {
    * @return string The size in human readable format.
    */
   public static function human_file_size( $size, $precision = 2 ) {
+    $i = 0;
     for ( $i = 0; ($size / 1024) > 0.9; ) {
       ++$i;
       $size /= 1024;

--- a/src/lib/logs.php
+++ b/src/lib/logs.php
@@ -47,10 +47,10 @@ class Logs {
     }
 
     $logs_with_time = array();
-    foreach ( $grouped_log_files as $group => $log_files ) {
+    foreach ( $grouped_log_files as $group => $files_in_group ) {
       // Sort files (oldest first)
       usort(
-        $log_files,
+        $files_in_group,
         function( $log1, $log2 ) {
           if ( strpos($log1, '.log-') === false ) {
             return 1;
@@ -65,7 +65,7 @@ class Logs {
 
       // Get log times
       $logs_with_time[$group] = array();
-      foreach ( $log_files as $i => $log_file ) {
+      foreach ( $files_in_group as $i => $log_file ) {
         $since = null;
         if ( $i > 0 ) {
           $since = $logs_with_time[$group][$i - 1]['until'];
@@ -103,7 +103,7 @@ class Logs {
 
     // Check that $filepath is valid log path
     $files = glob('/data/log/*');
-    $valid_log_path = $files !== false && in_array($filepath, $files);
+    $valid_log_path = $files !== false && in_array($filepath, $files, true);
 
     $f = $valid_log_path ? @fopen($filepath, 'rb') : false;
 
@@ -216,7 +216,7 @@ class Logs {
         --$limit;
       }
 
-      if ( $complete_lines !== false ) {
+      if ( $complete_lines !== array() ) {
         // Decrement lines needed
         $lines -= count($complete_lines);
         // Prepend complete lines to our output
@@ -250,7 +250,7 @@ class Logs {
   public static function read_gz_log_lines_backwards( $filepath, $offset = 0, $lines = 1 ) {
     // Check that $filepath is valid log path
     $files = glob('/data/log/*');
-    $valid_log_path = $files !== false && in_array($filepath, $files);
+    $valid_log_path = $files !== false && in_array($filepath, $files, true);
 
     $f = $valid_log_path ? @gzfile($filepath) : false;
 

--- a/src/lib/postbox/component/component.php
+++ b/src/lib/postbox/component/component.php
@@ -63,7 +63,7 @@ class Component {
    * @return void
    */
   public function add_children( $children ) {
-    if ( $children === null || empty($children) ) {
+    if ( $children === null || $children === array() ) {
       return;
     }
 

--- a/src/lib/postbox/component/template.php
+++ b/src/lib/postbox/component/template.php
@@ -202,7 +202,7 @@ class Template {
    * @return \Seravo\Postbox\Component Component with label and datetime picker.
    */
   public static function datetime_picker( $label, $id, $min = '', $max = '' ) {
-    return Component::from_raw($label . ' <input type="date" id="' . $id . '" name="' . $id . '" ' . (empty($min) ? '' : 'min="' . $min . '"') . (empty($max) ? '' : 'max="' . $max . '"') . '>');
+    return Component::from_raw($label . ' <input type="date" id="' . $id . '" name="' . $id . '" ' . ($min === '' ? '' : 'min="' . $min . '"') . ($max === '' ? '' : 'max="' . $max . '"') . '>');
   }
 
   /**

--- a/src/lib/postbox/handler.php
+++ b/src/lib/postbox/handler.php
@@ -121,7 +121,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
       $user_id = get_current_user_id();
 
-      if ( $user_id !== 0 && $order && $page ) {
+      if ( $user_id !== 0 && $order !== false && $page !== '' ) {
         update_user_option($user_id, 'seravo-postbox-order_' . $page, $order, true);
       }
       wp_die();
@@ -132,7 +132,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
      * @return void
      */
     public function enqueue_postboxes_scripts() {
-      if ( ! empty($this->postboxes) ) {
+      if ( $this->postboxes !== array() ) {
         // seravo-postbox.js
         wp_enqueue_script('seravo_postbox', SERAVO_PLUGIN_URL . 'js/lib/seravo-postbox.js', array( 'jquery', 'jquery-ui-sortable' ), Helpers::seravo_plugin_version());
         $postbox_l10n = array(
@@ -198,7 +198,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
       // do anything in that case. If only a single postbox is closed, WP returns a single string so
       // it should be converted into an array.
       $closed_postboxes = get_user_meta(get_current_user_id(), 'seravo-closed-postboxes_' . $screen, true);
-      if ( ! empty($closed_postboxes) ) {
+      if ( $closed_postboxes !== '' ) {
         if ( ! is_array($closed_postboxes) ) {
           $closed_postboxes = array( $closed_postboxes );
         }
@@ -207,7 +207,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
 
       // Use user-specified postbox order if set
       $custom_postbox_order = get_user_meta(get_current_user_id(), 'seravo-postbox-order_' . $screen, true);
-      if ( $custom_postbox_order ) {
+      if ( $custom_postbox_order !== '' ) {
         foreach ( $custom_postbox_order as $custom_context => $postbox_order_str ) {
 
           $postbox_order = explode(',', $postbox_order_str);
@@ -249,7 +249,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
      */
     private function do_postboxes( $screen, $context ) {
       // Loop through the postboxes for this context
-      if ( isset($this->postboxes[ $screen ][ $context ]) && ! empty($this->postboxes[ $screen ][ $context ]) ) {
+      if ( isset($this->postboxes[ $screen ][ $context ]) && $this->postboxes[ $screen ][ $context ] !== array() ) {
         foreach ( $this->postboxes[ $screen ][ $context ] as $postbox_id => &$postbox_content ) {
           $this->display_single_postbox($postbox_id, $postbox_content);
         }
@@ -323,7 +323,7 @@ if ( ! class_exists('Seravo_Postbox_Factory') ) {
      * @return void
      */
     private function display_single_postbox( $postbox_id, $postbox_content ) {
-      $closed = in_array($postbox_id, $this->closed_postboxes);
+      $closed = in_array($postbox_id, $this->closed_postboxes, true);
       ?>
 
       <div id="seravo-postbox-<?php echo $postbox_id; ?>" data-postbox-id="<?php echo $postbox_id; ?>"

--- a/src/lib/postbox/postbox.php
+++ b/src/lib/postbox/postbox.php
@@ -203,7 +203,12 @@ class Postbox {
     $this->component->print_html();
 
     if ( defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
-      $this->buildtime = hrtime(true) - $this->buildtime;
+      if ( $this->buildtime === null ) {
+        $this->buildtime = -1;
+      } else {
+        $this->buildtime = hrtime(true) - $this->buildtime;
+      }
+
       $this->debug_print();
     }
   }

--- a/src/lib/security-restrictions.php
+++ b/src/lib/security-restrictions.php
@@ -15,7 +15,7 @@ class SecurityRestrictions {
   public static function load() {
     add_action('activate_seravo-plugin/seravo-plugin.php', array( __CLASS__, 'maybe_enable_xml_rpc_blocking' ));
 
-    if ( get_option('seravo-disable-xml-rpc-all-methods') ) {
+    if ( get_option('seravo-disable-xml-rpc-all-methods') === 'on' ) {
       // Block XML-RPC completely
       add_filter('xmlrpc_enabled', '__return_false');
       add_filter('xmlrpc_methods', array( __CLASS__, 'remove_xmlrpc_methods' ));
@@ -25,7 +25,7 @@ class SecurityRestrictions {
           wp_die('XML-RPC blocked.');
         }
       }
-    } elseif ( get_option('seravo-disable-xml-rpc') ) {
+    } elseif ( get_option('seravo-disable-xml-rpc') === 'on' ) {
       // Block XML-RPC and X-pingback if IP not whitelisted
       // NOTE! Filter xmlrpc_enabled affects only authenticated XML-RPC requests,
       // and *not* XML-RPC in general.
@@ -33,7 +33,7 @@ class SecurityRestrictions {
       add_filter('xmlrpc_enabled', array( __CLASS__, 'maybe_block_xml_rpc' ));
     }
 
-    if ( get_option('seravo-disable-json-user-enumeration') ) {
+    if ( get_option('seravo-disable-json-user-enumeration') === 'on' ) {
       /*
          * When this is active any request like
          *   curl -iL https://<siteurl>/wp-json/wp/v2/users/ -H Pragma:no-cache
@@ -42,7 +42,7 @@ class SecurityRestrictions {
       add_filter('rest_endpoints', array( __CLASS__, 'disable_user_endpoints' ), 1000);
     }
 
-    if ( get_option('seravo-disable-get-author-enumeration') ) {
+    if ( get_option('seravo-disable-get-author-enumeration') === 'on' ) {
       /*
          * When this is active any request like
          *   curl -iL -H Pragma:no-cache https://<siteurl>/?author=7
@@ -164,7 +164,7 @@ class SecurityRestrictions {
 
       $data = json_decode(wp_remote_retrieve_body($response));
 
-      if ( ! empty($data) ) {
+      if ( $data !== array() ) {
         foreach ( $data as $ip ) {
           $whitelist[] = Helpers::cidr_to_range($ip);
         }

--- a/src/lib/sitestatus-ajax.php
+++ b/src/lib/sitestatus-ajax.php
@@ -22,7 +22,7 @@ function seravo_report_wp_core_verify() {
 function seravo_report_git_status() {
   exec('git -C /data/wordpress status', $output);
 
-  if ( empty($output) ) {
+  if ( $output !== array() ) {
     return array(
       'Git is not used on this site. To start using it,
       read our documentation for WordPress developers at
@@ -38,7 +38,7 @@ function seravo_report_git_status() {
  * @return void
  */
 function seravo_reset_shadow() {
-  if ( isset($_POST['shadow']) && ! empty($_POST['shadow']) ) {
+  if ( isset($_POST['shadow']) && $_POST['shadow'] !== '' ) {
     $shadow = $_POST['shadow'];
     $output = array();
 

--- a/src/modules/check-default-email.php
+++ b/src/modules/check-default-email.php
@@ -31,7 +31,7 @@ class CheckDefaultEmail {
     $email_local = strtok($email, '@');
 
     // Check if the email should should be changed. If so, show warning
-    if ( in_array($email_local, self::$bad_email_locals) ) {
+    if ( in_array($email_local, self::$bad_email_locals, true) ) {
       self::_seravo_show_email_warning();
     }
   }

--- a/src/modules/check-site-health.php
+++ b/src/modules/check-site-health.php
@@ -68,7 +68,7 @@ class SiteHealth {
 
     foreach ( $output as $plugin ) {
       // check that captcha is found and it's not inactive
-      if ( strpos($plugin, 'captcha') && strpos($plugin, 'inactive') === false ) {
+      if ( strpos($plugin, 'captcha') !== false && strpos($plugin, 'inactive') === false ) {
         self::$no_issues[__('Recaptcha is enabled', 'seravo')] = $captcha_tooltip;
         $captcha_found = true;
         break;
@@ -90,7 +90,7 @@ class SiteHealth {
     $theme_tooltip = __('It is recommended to remove inactive themes.', 'seravo');
 
     foreach ( $output as $line ) {
-      if ( strpos($line, 'inactive') ) {
+      if ( strpos($line, 'inactive') !== false ) {
         ++$inactive_themes;
       }
     }
@@ -120,7 +120,7 @@ class SiteHealth {
 
     foreach ( $output as $line ) {
 
-      if ( strpos($line, 'inactive') ) {
+      if ( strpos($line, 'inactive') !== false ) {
         ++$inactive_plugins;
       }
 
@@ -191,7 +191,7 @@ class SiteHealth {
   private static function result_to_html() {
     $output = '';
 
-    if ( empty(self::$potential_issues) ) {
+    if ( self::$potential_issues === null || self::$potential_issues === array() ) {
       $title = __('No issues were found', 'seravo');
       $status_color = Ajax\FancyForm::STATUS_GREEN;
     } else {

--- a/src/modules/dashboard-widgets.php
+++ b/src/modules/dashboard-widgets.php
@@ -52,7 +52,7 @@ class DashboardWidgets {
         }
       );
 
-      if ( apply_filters('seravo_dashboard_errors', true) ) {
+      if ( (bool) apply_filters('seravo_dashboard_errors', true) ) {
         self::$errors = LoginNotifications::retrieve_error_count();
       }
       if ( self::$errors > 0 || (PHP_MINOR_VERSION <= self::EOL_MINOR && PHP_MAJOR_VERSION <= self::EOL_MAJOR) ) {
@@ -110,10 +110,10 @@ class DashboardWidgets {
     $return_code = 0;
 
     // Get total disk usage
-    if ( ! $cached_usage ) {
-      $return_code = exec('du -sb /data ' . implode(' ', $exclude_dirs), $data_folder);
+    if ( $cached_usage === false ) {
+      $return_code = Compatibility::exec('du -sb /data ' . implode(' ', $exclude_dirs), $data_folder);
 
-      if ( $return_code !== false && ! empty($data_folder) ) {
+      if ( $return_code !== false && $data_folder !== array() ) {
         // cache only if successful & there's data in it
         set_transient('disk_space_usage', $data_folder, self::DISK_SPACE_CACHE_TIME);
       }
@@ -121,12 +121,12 @@ class DashboardWidgets {
       $data_folder = $cached_usage;
     }
 
-    if ( ! empty($data_folder) ) {
+    if ( $data_folder !== array() ) {
       $data_size = preg_split('/\s+/', $data_folder[0]);
       $data_size = $data_size !== false ? $data_size[0] : 0;
     }
-    $plan_details = API::get_site_data();
 
+    $plan_details = API::get_site_data();
     if ( is_wp_error($plan_details) ) {
       $plan_disk_limit = 0;
     } else {
@@ -216,11 +216,11 @@ class DashboardWidgets {
 
   /**
    * Display the site status widget which contains HTTPS statistics and some plan details
-   * @return mixed|void
+   * @return void
    */
   public static function display_site_status() {
     if ( ! Helpers::is_production() ) {
-      return _e('This feature is available only on live production sites.', 'seravo');
+      _e('This feature is available only on live production sites.', 'seravo');
     }
     $site_info = API::get_site_data();
     $http_requests_limit = 0;
@@ -249,7 +249,7 @@ class DashboardWidgets {
       <?php
       $reports = glob('/data/slog/html/goaccess-*.html');
 
-      if ( $reports !== false && ! empty($reports) ) {
+      if ( $reports !== false && $reports !== array() ) {
         $contact_email_url = '<a href="mailto:help@seravo.com">help@seravo.com</a>';
         $msg = wp_sprintf(
           // translators: %1$s contact email link

--- a/src/modules/noindex-domain-alias.php
+++ b/src/modules/noindex-domain-alias.php
@@ -30,11 +30,11 @@ class Noindex {
     if ( isset($_SERVER['HTTP_HOST']) ) {
 
       if (
-        preg_match('/^.*\.wp-palvelu\.fi$/', $_SERVER['HTTP_HOST']) ||
-        preg_match('/^.*\.seravo\.fi$/', $_SERVER['HTTP_HOST']) ||
-        preg_match('/^.*\.seravo\.com$/', $_SERVER['HTTP_HOST']) ||
-        preg_match('/^.*\.wp\..*$/', $_SERVER['HTTP_HOST']) ||
-        preg_match('/^.*\.dev\..*$/', $_SERVER['HTTP_HOST'])
+        preg_match('/^.*\.wp-palvelu\.fi$/', $_SERVER['HTTP_HOST']) === 1 ||
+        preg_match('/^.*\.seravo\.fi$/', $_SERVER['HTTP_HOST']) === 1 ||
+        preg_match('/^.*\.seravo\.com$/', $_SERVER['HTTP_HOST']) === 1 ||
+        preg_match('/^.*\.wp\..*$/', $_SERVER['HTTP_HOST']) === 1 ||
+        preg_match('/^.*\.dev\..*$/', $_SERVER['HTTP_HOST']) === 1
       ) {
 
         $output = "User-agent: *\n";

--- a/src/modules/pages/database.php
+++ b/src/modules/pages/database.php
@@ -248,8 +248,8 @@ class Database extends Toolpage {
    */
   public static function execute_search_replace() {
     // Check that both to and from are set
-    if ( ! isset($_REQUEST['sr-from']) || empty($_REQUEST['sr-from']) ||
-          ! isset($_REQUEST['sr-to']) || empty($_REQUEST['sr-to']) ) {
+    if ( ! isset($_REQUEST['sr-from']) || $_REQUEST['sr-from'] === '' ||
+          ! isset($_REQUEST['sr-to']) || $_REQUEST['sr-to'] === '' ) {
       return Ajax\AjaxResponse::form_input_error(__('Error: Both <code>from</code> and <code>to</code> needs to be set', 'seravo'));
     }
 

--- a/src/modules/pages/logs.php
+++ b/src/modules/pages/logs.php
@@ -225,11 +225,11 @@ class Logs extends Toolpage {
     $response->is_success(true);
 
     $logs = \Seravo\Logs::read_log_lines_backwards('/data/log/' . $_GET['file'], $_GET['offset'], 30);
-    if ( isset($logs['error']) && ! empty($logs['error']) ) {
+    if ( isset($logs['error']) && $logs['error'] !== '' ) {
       // Something went wrong
       $response->is_success(false);
     } else {
-      $keyword = isset($_GET['log-keyword']) && ! empty($_GET['log-keyword']) ? $_GET['log-keyword'] : null;
+      $keyword = isset($_GET['log-keyword']) && $_GET['log-keyword'] !== '' ? $_GET['log-keyword'] : null;
       if ( $keyword !== null ) {
         $output = preg_replace('/' . $keyword . '/i', '<span class="highlight">$0</span>', $logs['output']);
         if ( $output !== null ) {

--- a/src/modules/pages/test-page.php
+++ b/src/modules/pages/test-page.php
@@ -177,7 +177,6 @@ class TestPage extends Toolpage {
     $demo_settings->add_field('seravo-test-setting-string', 'Give a string', 'write something', '', Settings::FIELD_TYPE_STRING);
     $demo_settings->add_field('seravo-test-setting-integer', 'Give an integer', '', '<p>Integer fields only accept whole numbers</p>', Settings::FIELD_TYPE_INTEGER, 12345);
     $demo_settings->add_field('seravo-test-setting-number', 'Give a number', '', '<p>But number fields accept any numeric value</p>', Settings::FIELD_TYPE_NUMBER, 3.14159);
-    $demo_settings->add_field('seravo-test-setting-emails', 'Give an email list', 'name@example.com', '', Settings::FIELD_TYPE_EMAIL_LIST);
     return $demo_settings;
   }
 
@@ -277,18 +276,15 @@ class TestPage extends Toolpage {
    * @return void
    */
   public static function build_nag_test( Component $base, Postbox\Postbox $postbox ) {
-    // Always true
-    if ( random_int(0, 0) === 0 ) {
-      $notice = new Component('', '<table><tr>', '</tr></table>');
-      $notice->add_child(new Component('You have cache! Please purge it now!', '<td><b>', '</b></td>'));
-      $notice->add_child($postbox->get_ajax_handler('nag-test')->get_component()->set_wrapper('<td>', '</td>'));
-      $base->add_child(Template::nag_notice($notice, 'notice-error', true));
-
-      $notice = new Component('', '<table><tr>', '</tr></table>');
-      $notice->add_child(new Component('You have cache! Please purge it now! (2)', '<td><b>', '</b></td>'));
-      $notice->add_child($postbox->get_ajax_handler('nag-test-2')->get_component()->set_wrapper('<td>', '</td>'));
-      $base->add_child(Template::nag_notice($notice, 'notice-error', true));
-    }
+    // Normally render this block conditionally
+    $notice = new Component('', '<table><tr>', '</tr></table>');
+    $notice->add_child(new Component('You have cache! Please purge it now!', '<td><b>', '</b></td>'));
+    $notice->add_child($postbox->get_ajax_handler('nag-test')->get_component()->set_wrapper('<td>', '</td>'));
+    $base->add_child(Template::nag_notice($notice, 'notice-error', true));
+    $notice = new Component('', '<table><tr>', '</tr></table>');
+    $notice->add_child(new Component('You have cache! Please purge it now! (2)', '<td><b>', '</b></td>'));
+    $notice->add_child($postbox->get_ajax_handler('nag-test-2')->get_component()->set_wrapper('<td>', '</td>'));
+    $base->add_child(Template::nag_notice($notice, 'notice-error', true));
 
     $base->add_child(Template::paragraph('You should see two nags above. The second nag will return output.'));
   }

--- a/src/modules/passwords.php
+++ b/src/modules/passwords.php
@@ -61,7 +61,7 @@ class Passwords {
    * @return void
    */
   public static function clear_seravo_pwned_check_timestamp( $user_id ) {
-    if ( isset($_POST['pass1']) && ! empty($_POST['pass1']) ) {
+    if ( isset($_POST['pass1']) && $_POST['pass1'] !== '' ) {
       delete_user_meta($user_id, 'seravo_pwned_check');
     }
   }
@@ -95,7 +95,7 @@ class Passwords {
     // Make the check every 3 months
     $time_now = time();
     $pwned_meta = get_user_meta($user->ID, 'seravo_pwned_check', true);
-    if ( empty($pwned_meta) || $time_now - (int) $pwned_meta > 90 * DAY_IN_SECONDS ) {
+    if ( $pwned_meta === '' || $time_now - (int) $pwned_meta > 90 * DAY_IN_SECONDS ) {
       // Check if the password has been pwned
       exec('wp-check-haveibeenpwned --json ' . self::$password_hash . ' 2>&1', $pwned_check);
       $result = \json_decode(isset($pwned_check[0]) ? $pwned_check[0] : '', true);

--- a/src/modules/purge-cache.php
+++ b/src/modules/purge-cache.php
@@ -92,7 +92,7 @@ class PurgeCache {
     $response = array();
 
     // Check nonce
-    if ( ! isset($_REQUEST['nonce']) || ! wp_verify_nonce($_REQUEST['nonce'], 'seravo_purge_cache_nonce') ) {
+    if ( ! isset($_REQUEST['nonce']) || wp_verify_nonce($_REQUEST['nonce'], 'seravo_purge_cache_nonce') === false ) {
       $response['success'] = false;
       $response['output'] = __('Error: the nonce did not verify.', 'seravo');
     } else {

--- a/src/modules/seravotest-auth-bypass.php
+++ b/src/modules/seravotest-auth-bypass.php
@@ -28,7 +28,7 @@ class SeravoTestAuthBypass {
     // key is found, and if soautomatically login user and redirect to wp-admin.
     $key = get_transient('seravotest-auth-bypass-key');
 
-    if ( ! empty($key) && $key === $_GET['seravotest-auth-bypass'] ) {
+    if ( $key === $_GET['seravotest-auth-bypass'] ) {
       // Remove bypass key so it cannot be used again
       delete_transient('seravotest-auth-bypass-key');
 

--- a/src/modules/svg-support.php
+++ b/src/modules/svg-support.php
@@ -47,7 +47,7 @@ class SVGSupport {
       }
 
       $clean = $sanitizer->sanitize($dirty);
-      if ( empty($clean) ) {
+      if ( $clean === '' ) {
         $file['error'] = __(
           "This file couldn't be sanitized so for security reasons it wasn't uploaded",
           'seravo'

--- a/src/modules/thirdparty-fixes.php
+++ b/src/modules/thirdparty-fixes.php
@@ -281,6 +281,6 @@ class ThirdPartyFixes {
     }
     $ip = jetpack_protect_get_ip();
     $whitelist = $this->retrieve_whitelist();
-    return in_array($ip, $whitelist);
+    return in_array($ip, $whitelist, true);
   }
 }

--- a/src/modules/wp-login-log.php
+++ b/src/modules/wp-login-log.php
@@ -31,9 +31,9 @@ class LoginLog {
     // Bail out quickly if username and password were not sent on this load
     if (
       ! isset($_POST['log']) ||
-      empty($_POST['log']) ||
+      $_POST['log'] === '' ||
       ! isset($_POST['pwd']) ||
-      empty($_POST['pwd'])
+      $_POST['pwd'] === ''
     ) {
       return $redirect_to;
     }

--- a/src/modules/wp-plugin-log.php
+++ b/src/modules/wp-plugin-log.php
@@ -27,8 +27,8 @@ class PluginLog {
    * @param mixed[]      $arr_data Details about the upgrade.
    * @return void
    */
-  public static function on_upgrader_process_complete( $upgrader = null, $arr_data = null ) {
-    if ( empty($upgrader) || empty($arr_data) ) {
+  public static function on_upgrader_process_complete( $upgrader, $arr_data ) {
+    if ( $arr_data === array() ) {
       return;
     }
     if ( $arr_data['type'] !== null && $arr_data['action'] !== null ) {

--- a/src/modules/wp-user-log.php
+++ b/src/modules/wp-user-log.php
@@ -28,10 +28,6 @@ class UserLog {
    * @return void
    */
   public static function on_edit_user_created_user( $user_id ) {
-    if ( empty($user_id) || ! is_numeric($user_id) ) {
-      return;
-    }
-
     $user = get_userdata($user_id);
     if ( $user === false ) {
       return;
@@ -46,10 +42,6 @@ class UserLog {
    * @return void
    */
   public static function on_register_new_user( $user_id ) {
-    if ( empty($user_id || ! is_numeric($user_id)) ) {
-      return;
-    }
-
     self::write_log('User (ID:' . $user_id . ') registered');
   }
 
@@ -60,10 +52,6 @@ class UserLog {
    * @return void
    */
   public static function on_delete_user( $user_id, $redirect_user_id = null ) {
-    if ( empty($user_id || ! is_numeric($user_id)) ) {
-      return;
-    }
-
     $user = get_userdata($user_id);
     if ( $user === false ) {
       return;
@@ -88,9 +76,6 @@ class UserLog {
    * @return void
    */
   public static function on_deleted_user( $user_id, $redirect_user_id = null ) {
-    if ( empty($user_id || ! is_numeric($user_id)) ) {
-      return;
-    }
     self::write_log_user('deleted user (ID:' . $user_id . ')');
   }
 
@@ -100,9 +85,6 @@ class UserLog {
    * @return void
    */
   public static function on_after_password_reset( $user ) {
-    if ( empty($user) ) {
-      return;
-    }
     self::write_log('User ' . $user->user_login . ' (ID:' . $user->ID . ') resetted password');
   }
 
@@ -113,10 +95,6 @@ class UserLog {
    * @return void
    */
   public static function on_profile_update( $user_id, $old_user_data ) {
-    if ( empty($user_id) ) {
-      return;
-    }
-
     $new_user_data = get_userdata($user_id);
     if ( $new_user_data === false ) {
       return;
@@ -144,10 +122,6 @@ class UserLog {
    * @return void
    */
   public static function on_set_user_role( $user_id, $role, $old_roles ) {
-    if ( empty($user_id) || ! is_numeric($user_id) ) {
-      return;
-    }
-
     // If ID is 0, there is no current user. eg role set on registration or wp-test
     if ( wp_get_current_user()->ID === 0 ) {
       $new_user_data = get_userdata($user_id);

--- a/style/common.css
+++ b/style/common.css
@@ -189,24 +189,6 @@ table.widefat {
 
 /* Email list */
 
-.email-list-input {
-  table-layout: fixed;
-  width: max-content;
-  border-spacing: 0;
-}
-
-.email-list-input td {
-  padding: 0 !important;
-}
-
-.email-list-row td {
-  padding-top: 5px !important;
-}
-
-.email-list-add-button {
-  margin-left: 5px !important;
-}
-
 .email-button {
   width: 200px;
   height: 20px;


### PR DESCRIPTION
#### What are the main changes in this PR?

- Add strict PHPStan rules. Changes mainly were:
    - Strict return check for `preg_match` and like. It may return `0` or `false` and loose comparison sees both as `false`.
    - Replace usage of `empty()` with strict comparison, `empty` is bad as means we don't know the type but we always must know the variable type.
    - Use strict modes of `in_array`, `base64_decode` etc.
    - Strict return check for `strpos`. It may return `0` (string was found) or `false` (not found) and loose comparison sees both as `false`. These were a big mistake, there's even a big banner on PHP docs warning about this. Thanks to PHPStan this shouldn't happen again.
- Remove email-list setting type as obsolete.
- Make CI run PHPStan on latest WordPress and WP-CLI stubs too so we know if some function was removed/changed in latest version.