### PR TITLE
Move EOL and recommended PHP versions to Helpers (Closes: #618)

### DIFF
--- a/src/lib/helpers.php
+++ b/src/lib/helpers.php
@@ -85,6 +85,22 @@ class Helpers {
   }
 
   /**
+   * Get the recommended PHP version.
+   * @return string Recommended PHP version.
+   */
+  public static function get_recommended_php_version() {
+    return '7.4';
+  }
+
+  /**
+   * Get the current end of life PHP version.
+   * @return string Current end of life PHP version.
+   */
+  public static function get_eol_php_version() {
+    return '7.2.34';
+  }
+
+  /**
    * @param int $size      The size in bytes.
    * @param int $precision The amount of decimal places.
    * @return string The size in human readable format.

--- a/src/modules/admin-checks.php
+++ b/src/modules/admin-checks.php
@@ -4,6 +4,7 @@ namespace Seravo\Module;
 
 use \Seravo\Logs;
 use \Seravo\Postbox\Template;
+use \Seravo\Helpers;
 
 /**
  * Class AdminChecks
@@ -95,7 +96,7 @@ final class AdminChecks {
    * @return void
    */
   public static function check_php_version() {
-    $recommended_version = '7.4';
+    $recommended_version = Helpers::get_recommended_php_version();
     if ( \version_compare(PHP_VERSION, $recommended_version, '>=') ) {
       return;
     }

--- a/src/modules/dashboard-widgets.php
+++ b/src/modules/dashboard-widgets.php
@@ -20,11 +20,6 @@ class DashboardWidgets {
   private static $errors = 0;
 
   /**
-   * @var string End of Life PHP version.
-   */
-  const PHP_EOL_VERSION = '7.2.34';
-
-  /**
    * @var float The relative disk usage.
    */
   const LOW_DISK_SPACE_USAGE = 0.9;
@@ -80,7 +75,7 @@ class DashboardWidgets {
     /**
      * PHP warnings & errors widget
      */
-    if ( self::$errors > 0 || \version_compare(Helpers::get_php_version(), self::PHP_EOL_VERSION, '<=') ) {
+    if ( self::$errors > 0 || \version_compare(Helpers::get_php_version(), Helpers::get_eol_php_version(), '<=') ) {
       $php_widget = new Postbox\Postbox('php-warning-widget');
       $php_widget->set_requirements(
         array(
@@ -234,7 +229,7 @@ class DashboardWidgets {
       $base->add_child(Template::paragraph($msg));
     }
 
-    if ( \version_compare(Helpers::get_php_version(), self::PHP_EOL_VERSION, '<=') ) {
+    if ( \version_compare(Helpers::get_php_version(), Helpers::get_eol_php_version(), '<=') ) {
       $base->add_child(Template::section_title(__('Old PHP Version', 'seravo')));
       $php_version = '<b>' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '</b>';
       $php_version_change_url = '<a href="' . \get_option('siteurl') . '/wp-admin/tools.php?page=upkeep_page#seravo-postbox-change-php-version" target="_blank">' .


### PR DESCRIPTION
#### What are the main changes in this PR?
Move the PHP end of life and recommended version implementations to Helpers class.

##### Why are we doing this? Any context or related work?
#618 