### PR TITLE
Enhance password checks (Closes: #615, #625)

### DIFF
--- a/src/modules/passwords.php
+++ b/src/modules/passwords.php
@@ -104,9 +104,9 @@ final class Passwords {
     $pwned_meta = \get_user_meta($user->ID, 'seravo_pwned_check', true);
     if ( $pwned_meta === '' || $time_now - ((int) $pwned_meta) > 90 * DAY_IN_SECONDS ) {
       // Check if the password has been pwned
-      $exec = Compatibility::exec('wp-check-haveibeenpwned --json ' . self::$password_hash . ' 2>&1', $pwned_check, $return_code);
+      $exec = Compatibility::exec('wp-check-haveibeenpwned --json ' . self::$password_hash . ' 2>&1', $pwned_check);
       $result = \json_decode(isset($pwned_check[0]) ? $pwned_check[0] : '', true);
-      if ( $exec === false || $return_code !== 0 || isset($result['error']) || ! isset($result['found']) ) {
+      if ( $exec === false || isset($result['error']) || ! isset($result['found']) ) {
         // Something went wrong
         \error_log("Failed to run 'wp-check-haveibeenpwned'!");
         return $redirect_to;


### PR DESCRIPTION
#### What are the main changes in this PR?

- Format/Filter the wp-check-passwords output
- Remove return code from the wp-check-haveibeenpwned

##### Why are we doing this? Any context or related work?
Mostly related to #615, but because both are related to password checking also #625 minor fix included.