### PR TITLE
Fix default postbox positioning (Closes: #635)

### DIFF
--- a/src/modules/pages/database.php
+++ b/src/modules/pages/database.php
@@ -103,7 +103,7 @@ class Database extends Toolpage {
     /**
      * Search & Replace tool postbox
      */
-    $search_replace = new Postbox\SimpleForm('database-search-replace');
+    $search_replace = new Postbox\SimpleForm('database-search-replace', 'side');
     $search_replace->set_title(__('Search-Replace Tool', 'seravo'));
     $search_replace->set_button_text(__('Run wp search-replace', 'seravo'), __('Do a dry run', 'seravo'));
     $search_replace->set_requirements(
@@ -119,7 +119,7 @@ class Database extends Toolpage {
     /**
      * Database cleanup tool postbox
      */
-    $cleanup = new Postbox\Postbox('database-cleanup');
+    $cleanup = new Postbox\Postbox('database-cleanup', 'column3');
     $cleanup->set_title(__('Database Cleanup Tool', 'seravo'));
     $cleanup->set_requirements(
       array(
@@ -134,7 +134,7 @@ class Database extends Toolpage {
     /**
      * Database size postbox
      */
-    $db_size = new Postbox\Postbox('database-size');
+    $db_size = new Postbox\Postbox('database-size', 'column4');
     $db_size->set_title(__('Database Size', 'seravo'));
     $db_size->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
     $db_size->set_build_func(array( __CLASS__, 'build_database_size' ));

--- a/src/modules/pages/security.php
+++ b/src/modules/pages/security.php
@@ -100,7 +100,7 @@ class Security extends Toolpage {
     /**
      * Check passwords postbox (Beta)
      */
-    $passwords = new Postbox\Postbox('check-passwords');
+    $passwords = new Postbox\Postbox('check-passwords', 'column4');
     $passwords->set_title(__('Check passwords (Beta)', 'seravo'));
     $passwords->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
     // Add AJAX handler for checking passwords
@@ -120,7 +120,7 @@ class Security extends Toolpage {
     /**
      * Last successful logins postbox
      */
-    $logins = new Postbox\LazyLoader('logins-info');
+    $logins = new Postbox\LazyLoader('logins-info', 'column3');
     $logins->set_title(__('Last successful logins', 'seravo'));
     $logins->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
     $logins->set_ajax_func(array( __CLASS__, 'get_last_successful_logins' ));

--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -160,7 +160,7 @@ class SiteStatus extends Toolpage {
     /**
      * Sanitize uploads postbox
      */
-    $sanitize_uploads = new Postbox\SettingsForm('sanitize-uploads', 'side');
+    $sanitize_uploads = new Postbox\SettingsForm('sanitize-uploads', 'column4');
     $sanitize_uploads->set_title(__('Sanitize Uploads', 'seravo'));
     $sanitize_uploads->set_requirements(
       array(
@@ -174,7 +174,7 @@ class SiteStatus extends Toolpage {
     /**
      * Disk Usage postbox
      */
-    $disk_usage = new Postbox\LazyLoader('disk-usage');
+    $disk_usage = new Postbox\LazyLoader('disk-usage', 'side');
     $disk_usage->set_build_func(array( __CLASS__, 'build_disk_usage' ));
     $disk_usage->use_hr(false);
     $disk_usage->set_title(__('Disk Usage', 'seravo'));
@@ -185,7 +185,7 @@ class SiteStatus extends Toolpage {
     /**
      * Cache status postbox
      */
-    $http_cache = new Postbox\Postbox('cache-status');
+    $http_cache = new Postbox\Postbox('cache-status', 'column3');
     $http_cache->set_title(__('Cache Status', 'seravo'));
     $http_cache->set_requirements(
       array(
@@ -201,7 +201,7 @@ class SiteStatus extends Toolpage {
     /**
      * Speed test postbox
      */
-    $speed_test = new Postbox\SimpleForm('speed-test');
+    $speed_test = new Postbox\SimpleForm('speed-test', 'side');
     $speed_test->set_title(__('Speed test', 'seravo'));
     $speed_test->set_build_form_func(array( __CLASS__, 'build_speed_test' ));
     $speed_test->set_ajax_func(array( __CLASS__, 'run_speed_test' ));
@@ -212,7 +212,7 @@ class SiteStatus extends Toolpage {
     /**
      * Optimize images postbox
      */
-    $optimize_images = new Postbox\SettingsForm('optimize-images', 'side');
+    $optimize_images = new Postbox\SettingsForm('optimize-images', 'column4');
     $optimize_images->set_title(__('Optimize Images', 'seravo'));
     $optimize_images->add_paragraph(__('Optimization reduces image file size. This improves the performance and browsing experience of your site.', 'seravo'));
     $optimize_images->add_paragraph(__('By setting the maximum image resolution, you can determine the maximum allowed dimensions for images.', 'seravo'));

--- a/src/modules/pages/upkeep.php
+++ b/src/modules/pages/upkeep.php
@@ -175,7 +175,7 @@ class Upkeep extends Toolpage {
     /**
      * Changes Status postbox
      */
-    $changes_status = new Postbox\FancyForm('backup-list-changes');
+    $changes_status = new Postbox\FancyForm('backup-list-changes', 'side');
     $changes_status->set_title(__('Changes Status', 'seravo'));
     $changes_status->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
     $changes_status->set_ajax_func(array( __CLASS__, 'fetch_backup_list_changes' ));
@@ -190,7 +190,7 @@ class Upkeep extends Toolpage {
     /**
      * Update Tests postbox
      */
-    $update_tests = new Postbox\FancyForm('update-tests');
+    $update_tests = new Postbox\FancyForm('update-tests', 'side');
     $update_tests->set_title(__('Update tests', 'seravo'));
     $update_tests->set_requirements(array( Requirements::CAN_BE_ANY_ENV => true ));
     $update_tests->set_ajax_func(array( __CLASS__, 'run_update_tests' ));
@@ -203,7 +203,7 @@ class Upkeep extends Toolpage {
     /**
      * Screenshots postbox
      */
-    $screenshots = new Postbox\Postbox('screenshots');
+    $screenshots = new Postbox\Postbox('screenshots', 'side');
     $screenshots->set_title(__('Screenshots', 'seravo'));
     $screenshots->set_requirements(array( Requirements::CAN_BE_PRODUCTION => true ));
     $screenshots->set_build_func(array( __CLASS__, 'build_screenshots_postbox' ));


### PR DESCRIPTION
#### What are the main changes in this PR?
Fix the default positioning of the postboxes. Use `column3` and `column4` when appropriate and "balance" the postboxes overall.

##### Why are we doing this? Any context or related work?
#635 
