### PR TITLE
Rewrite disk usage fetching

### DIFF
--- a/src/lib/shell.php
+++ b/src/lib/shell.php
@@ -58,7 +58,7 @@ class Shell {
    * @param string $command Command to run.
    * @return mixed|bool Pid of the program.
    */
-  public static function backround_command( $command ) {
+  public static function background_command( $command ) {
     $output = array();
     \exec('(' . $command . ') > /dev/null & echo $!', $output);
 

--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -915,7 +915,7 @@ class SiteStatus extends Toolpage {
           return AjaxResponse::api_error_response();
         }
 
-        $pid = \Seravo\Shell::backround_command('wp-shadow-reset ' . $shadow . ' --force 2>&1');
+        $pid = \Seravo\Shell::background_command('wp-shadow-reset ' . $shadow . ' --force 2>&1');
 
         if ( $pid === false ) {
           return Ajax\AjaxResponse::exception_response();

--- a/src/modules/pages/test-page.php
+++ b/src/modules/pages/test-page.php
@@ -191,7 +191,7 @@ class TestPage extends Toolpage {
     if ( $polling === false ) {
       // Not polling yet
       $command = 'sleep 65 && wp-restart-nginx > /data/log/nginx-restart-test.log';
-      $pid = Shell::backround_command($command);
+      $pid = Shell::background_command($command);
       if ( $pid === false ) {
         return Ajax\AjaxResponse::exception_response();
       }

--- a/src/modules/pages/upkeep.php
+++ b/src/modules/pages/upkeep.php
@@ -464,7 +464,7 @@ class Upkeep extends Toolpage {
 
     if ( $polling === false ) {
       $command = 'wp-php-compatibility-check';
-      $pid = Shell::backround_command($command);
+      $pid = Shell::background_command($command);
 
       if ( $pid === false ) {
         return Ajax\AjaxResponse::exception_response();
@@ -513,7 +513,7 @@ class Upkeep extends Toolpage {
         \exec('echo "--> Setting to mode ' . $php_version_array[$php_version] . '" >> /data/log/php-version-change.log');
         //exec('wp-restart-nginx >> /data/log/php-version-change.log 2>&1 &');
         $restart_nginx = 'wp-restart-nginx >> /data/log/php-version-change.log 2>&1 &';
-        $pid = Shell::backround_command($restart_nginx);
+        $pid = Shell::background_command($restart_nginx);
 
         if ( $pid === false ) {
           return Ajax\AjaxResponse::exception_response();


### PR DESCRIPTION
#### What are the main changes in this PR?

The old design ran 'du /data' every time the 15min/60min transient expired.
The command can take up to a minute causing a page to load really slow.

New design stores the last known disk size in a non-expiring transient.
When the main transient expires, it takes the last know size and
runs a background command to update the non-expiring transient from disk.

##### Why are we doing this? Any context or related work?
Found on a production site.