### PR TITLE
Allow restricting login to specific countries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
       "src/lib/shadow.php",
       "src/lib/geoip.php",
       "src/modules/pages",
+      "src/modules/geologin.php",
       "src/modules/check-site-health.php",
       "src/modules/dashboard-widgets.php",
       "src/modules/fixes.php",

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
       "src/lib/logs.php",
       "src/lib/compatibility.php",
       "src/lib/shadow.php",
+      "src/lib/geoip.php",
       "src/modules/pages",
       "src/modules/check-site-health.php",
       "src/modules/dashboard-widgets.php",

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -36,7 +36,7 @@ if ( ! \defined('SERAVO_PLUGIN_SRC') ) {
 }
 
 // Use Postbox::class for now to see if autoload needs to be required
-if ( ! \class_exists(\Seravo\Postbox\Postbox::class) ) {
+if ( ! \class_exists(\Seravo\Postbox\Postbox::class, false) ) {
   require_once SERAVO_PLUGIN_DIR . 'vendor/autoload.php';
 }
 
@@ -221,6 +221,10 @@ class Loader {
      * Helpers for fixing issues with third-party code (plugins etc.)
      */
     Module\ThirdPartyFixes::load();
+    /*
+     * Add country restrictions to admin login
+     */
+    Module\GeoLogin::load();
     /*
      * Add a cache purge button to the WP adminbar
      */

--- a/src/lib/geoip.php
+++ b/src/lib/geoip.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Seravo;
+
+/**
+ * Class GeoIP
+ *
+ * Class for country code and location based login restriction related functions.
+ */
+class GeoIP {
+
+  /**
+   * Convert a two-letter country code in to the full country name.
+   *
+   * @param string $country_code The two-letter country code.
+   * @return false|string        The full country name or false on failure (invalid code).
+   */
+  public static function country_code_to_name( $country_code ) {
+    $country_code = \strtoupper($country_code);
+
+    // Country code is always two letters
+    if ( \strlen($country_code) !== 2 ) {
+      return false;
+    }
+
+    // Get the full English name
+    $country_name = \Locale::getDisplayRegion('-' . \strtoupper($country_code), 'en');
+
+    // If the name is false, empty or just the country code, the code was invalid
+    if ( $country_name === '' || $country_name === $country_code ) {
+      return false;
+    }
+
+    return $country_name;
+  }
+
+  /**
+   * Check whether geologin is enabled. Geologin is enabled if there's at
+   * least one country on the list of countries from which login is allowed.
+   *
+   * @return bool Whether geologin is enabled.
+   */
+  public static function is_geologin_enabled() {
+    // There's at least one allowed country on the blog's list
+    if ( get_option('seravo-allow-login-countries', array()) !== array() ) {
+      return true;
+    }
+
+    // There's at least one allowed country on the network-wide list
+    if ( is_multisite() && get_site_option('seravo-allow-login-countries', array()) !== array() ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Check whether login is allowed from a country.
+   *
+   * @param string $country_code The two-letter code of the country.
+   * @return bool                Whether login is allowed.
+   */
+  public static function is_login_allowed( $country_code ) {
+    $country_code = \strtoupper($country_code);
+
+    // Check the current blog's list
+    if ( in_array($country_code, get_option('seravo-allow-login-countries', array()), true) ) {
+      return true;
+    }
+
+    // Check the network-wide list
+    if ( is_multisite() ) {
+      if ( in_array($country_code, get_site_option('seravo-allow-login-countries', array()), true) ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Add country to the list of countries from which login is allowed.
+   *
+   * @param string $country_code The two-letter country code.
+   * @param bool   $network      Whether to allow network-wide.
+   * @return bool                True on success and false if the code was invalid
+   *                             or the country was already on the list.
+   */
+  public static function allow_geologin( $country_code, $network ) {
+    $country_code = \strtoupper($country_code);
+
+    // Get the old list of allowed countries
+    if ( $network && is_multisite() ) {
+      $allowed_countries = get_site_option('seravo-allow-login-countries', array());
+    } else {
+      $allowed_countries = get_option('seravo-allow-login-countries', array());
+    }
+
+    // Check if the country has already been allowed
+    if ( in_array($country_code, $allowed_countries, true) ) {
+      return false;
+    }
+
+    // Append the code to the list of allowed countries
+    $allowed_countries[] = $country_code;
+    sort($allowed_countries);
+
+    if ( $network && is_multisite() ) {
+      update_site_option('seravo-allow-login-countries', $allowed_countries);
+    } else {
+      update_option('seravo-allow-login-countries', $allowed_countries);
+    }
+
+    return true;
+  }
+
+  /**
+   * Remove a country from the list of countries from which login is allowed.
+   *
+   * @param string $country_code The two-letter country code.
+   * @param bool   $network      Whether to remove from the network-wide list.
+   * @return bool                Whether the country was removed or not.
+   */
+  public static function disallow_geologin( $country_code, $network ) {
+    $country_code = \strtoupper($country_code);
+
+    // Get the old list of allowed countries
+    if ( $network && is_multisite() ) {
+      $allowed_countries = get_site_option('seravo-allow-login-countries', array());
+    } else {
+      $allowed_countries = get_option('seravo-allow-login-countries', array());
+    }
+
+    $index = array_search($country_code, $allowed_countries, true);
+    if ( $index === false ) {
+      // The country wasn't allowed, can't disallow
+      return false;
+    }
+
+    // Disallow the country
+    unset($allowed_countries[$index]);
+
+    if ( $network && is_multisite() ) {
+      update_site_option('seravo-allow-login-countries', $allowed_countries);
+    } else {
+      update_option('seravo-allow-login-countries', $allowed_countries);
+    }
+
+    return true;
+  }
+
+}

--- a/src/lib/helpers.php
+++ b/src/lib/helpers.php
@@ -171,4 +171,23 @@ class Helpers {
     return \esc_url(\get_site_url(null, '.seravo/adminer'));
   }
 
+  /**
+   * Get the current network blog name.
+   * @return false|string Current blog name or false on non-multisite.
+   */
+  public static function get_blog_name() {
+    global $blog_id;
+
+    if ( ! is_multisite() ) {
+      return false;
+    }
+
+    $current_blog_details = get_blog_details(array( 'blog_id' => $blog_id ));
+    if ( $current_blog_details === false ) {
+      return false;
+    }
+
+    return $current_blog_details->blogname;
   }
+
+}

--- a/src/modules/geologin.php
+++ b/src/modules/geologin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Seravo\Module;
+
+use \Seravo\GeoIP;
+
+/**
+ * Class GeoLogin
+ *
+ * Allows logging in to dashboard only from specified countries.
+ */
+final class GeoLogin {
+  use Module;
+
+  /**
+   * Initialize the module. Filters and hooks should be added here.
+   * @return void
+   */
+  protected function init() {
+    // Verify the login country with priority 99, so it can
+    // hide other errors (like invalid pass, user not found, etc.)
+    add_filter('authenticate', array( __CLASS__, 'verify_login_country' ), 99);
+    add_filter('wp_authenticate_user', array( __CLASS__, 'verify_login_country' ), 99);
+  }
+
+  /**
+   * Check whether the user trying to log in from a country that's
+   * in the list of countries from which login is allowed.
+   *
+   * @param \WP_User|\WP_Error|null $user User object or WP error from previous callbacks.
+   * @return \WP_User|\WP_Error|null User object on success and WP error on failure.
+   */
+  public static function verify_login_country( $user ) {
+    // Check whether the login is geo restricted
+    if ( ! GeoIP::is_geologin_enabled() ) {
+      return $user;
+    }
+
+    // Get the country found by GeoIP
+    if ( isset($_SERVER['HTTP_X_SERAVO_GEO_COUNTRY_CODE']) ) {
+      if ( GeoIP::is_login_allowed($_SERVER['HTTP_X_SERAVO_GEO_COUNTRY_CODE']) ) {
+        // Login is restricted to specific countries only but the user is in one of them.
+        // Login OK!
+        return $user;
+      }
+    }
+
+    // The user is not in a country from which login is allowed
+    $message = __('<strong>Error</strong>: Your connection is from a country from which login on this site is not allowed.', 'seravo');
+    return new \WP_Error('seravo_geologin_failure', $message);
+  }
+
+}

--- a/src/modules/seravo-cli.php
+++ b/src/modules/seravo-cli.php
@@ -4,6 +4,7 @@ namespace Seravo\Module;
 
 use \Seravo\API;
 use \Seravo\Helpers;
+use \Seravo\GeoIP;
 
 /**
  * Class SeravoCLI
@@ -27,6 +28,9 @@ final class SeravoCLI extends \WP_CLI_Command {
    */
   protected function init() {
     \WP_CLI::add_command('seravo updates', array( __CLASS__, 'updates' ));
+    \WP_CLI::add_command('seravo geologin list', array( __CLASS__, 'geologin_list' ));
+    \WP_CLI::add_command('seravo geologin allow', array( __CLASS__, 'geologin_allow' ));
+    \WP_CLI::add_command('seravo geologin disallow', array( __CLASS__, 'geologin_disallow' ));
   }
 
   /**
@@ -60,4 +64,221 @@ final class SeravoCLI extends \WP_CLI_Command {
     }
   }
 
+  /**
+   * List the countries from which login is allowed.
+   *
+   * Check whether log in is restricted to specific countries only
+   * and list the countries.
+   *
+   * Note that on multisites, the first list is the current blog only.
+   * You can see the other blogs with WP CLI's `--url` parameter.
+   *
+   * To manage the lists, see the other `wp seravo geologin` subcommands.
+   *
+   * ## OPTIONS
+   *
+   * No options.
+   *
+   * ## EXAMPLES
+   *
+   *     wp seravo geologin list
+   *
+   * @param string[] $args       Arguments for the command.
+   * @param string[] $assoc_args Associated arguments for the command.
+   * @return void
+   */
+  public function geologin_list( $args, $assoc_args ) {
+    $blog = Helpers::get_blog_name();
+
+    // Get the countries allowed to login from
+    $allow_countries = get_option('seravo-allow-login-countries', array());
+    $allow_countries_network = array();
+    if ( is_multisite() ) {
+      $allow_countries_network = get_site_option('seravo-allow-login-countries', array());
+    }
+
+    if ( ! GeoIP::is_geologin_enabled() ) {
+      \WP_CLI::log('Restricted login: ' . \WP_CLI::colorize('%RDisabled%n') . "\n");
+      \WP_CLI::log('Add some countries to the list of countries from which login is allowed');
+      \WP_CLI::log("to begin restricting login. See `wp seravo geologin allow --help` for help.\n");
+      return;
+    }
+
+    // Geologin is enabled
+    \WP_CLI::log('Restricted login: ' . \WP_CLI::colorize('%GEnabled%n') . "\n");
+
+    if ( is_multisite() ) {
+      \WP_CLI::log("Allow login on blog '${blog}' from:\n");
+      foreach ( get_option('seravo-allow-login-countries', array()) as $country_code ) {
+        $country = GeoIP::country_code_to_name($country_code);
+        \WP_CLI::log("    - ${country} (${country_code})");
+      }
+      \WP_CLI::log("\nAllow login network-wide (all blogs) from:\n");
+      foreach ( get_site_option('seravo-allow-login-countries', array()) as $country_code ) {
+        $country = GeoIP::country_code_to_name($country_code);
+        \WP_CLI::log("    - ${country} (${country_code})");
+      }
+    } else {
+      \WP_CLI::log("Allow login from:\n");
+      foreach ( get_option('seravo-allow-login-countries', array()) as $country_code ) {
+        $country = GeoIP::country_code_to_name($country_code);
+        \WP_CLI::log("    - ${country} (${country_code})");
+      }
+    }
+
+    \WP_CLI::log('');
+  }
+
+  /**
+   * Add country to the list of countries from which login is allowed.
+   *
+   * On a multisite, all blogs have a list of their own. You can allow a country
+   * network-wide with the --network option.
+   *
+   * See the list and geologin status with `wp seravo geologin list`.
+   *
+   * ## OPTIONS
+   *
+   * <name>
+   * : The two-letter code of the country from which to allow login.
+   *
+   * [--network]
+   * : Add the country to the network-wide list of countries from
+   * which login is allowed. Applies to multisites only.
+   *
+   * ## EXAMPLES
+   *
+   *   # Allow login from Finland
+   *   $ wp seravo geologin allow fi
+   *   Success: Login from 'Finland' is now allowed on blog 'Joosuakoskinen'.
+   *
+   *   # Allow login from Sweden network-wide (all blogs)
+   *   $ wp seravo geologin allow se --network
+   *   Success: Login from 'Sweden' is now allowed on all blogs.
+   *
+   * @param string[] $args       Arguments for the command.
+   * @param string[] $assoc_args Associated arguments for the command.
+   * @return void
+   */
+  public function geologin_allow( $args, $assoc_args ) {
+    $country_code = $args[0];
+    $country_name = GeoIP::country_code_to_name($args[0]);
+    $blog = Helpers::get_blog_name();
+
+    if ( $country_name === false ) {
+      \WP_CLI::error("${country_code}' is not a valid two-letter country code.");
+    }
+
+    // Check if the country should be added network-wide
+    $network = isset($assoc_args['network']) && $assoc_args['network'] == true && is_multisite();
+
+    if ( GeoIP::allow_geologin($country_code, $network) ) {
+      // Added to the list
+      if ( $network ) {
+        \WP_CLI::success("Login from '${country_name}' is now allowed on all blogs.");
+      } else if ( is_multisite() ) {
+        \WP_CLI::success("Login from '${country_name}' is now allowed on blog '${blog}'.");
+      } else {
+        \WP_CLI::success("Login from '${country_name}' is now allowed.");
+      }
+    } else {
+      // Was already on the list
+      if ( $network ) {
+        \WP_CLI::success("Login from '${country_name}' was already allowed on all blogs.");
+      } else if ( is_multisite() ) {
+        \WP_CLI::success("Login from '${country_name}' was already allowed on blog '${blog}'.");
+      } else {
+        \WP_CLI::success("Login from '${country_name}' was already allowed.");
+      }
+    }
+  }
+
+  /**
+   * Remove a country from the list of countries from which login is allowed.
+   *
+   * This specifically removes a country from the list of allowed countries.
+   * A country can't be disallowed unless it's allowed first.
+   *
+   * On a multisite, all blogs have a list of their own. You can remove a country
+   * from the network-wide list with the --network option.
+   *
+   * See the list and geologin status with `wp seravo geologin list`.
+   *
+   * ## OPTIONS
+   *
+   * <name>
+   * : The two-letter code of the country from which to disallow login.
+   *
+   * [--network]
+   * : Remove the country from the network-wide list of countries from
+   * which login is allowed. Applies to multisites only.
+   *
+   * ## EXAMPLES
+   *
+   *   # Remove Finland from the list of countries from which login is allowed
+   *   $ wp seravo geologin disallow fi
+   *   Success: 'Finland' is no longer on the list of allowed countries for blog 'Joosuakoskinen'.
+   *
+   * @param string[] $args       Arguments for the command.
+   * @param string[] $assoc_args Associated arguments for the command.
+   * @return void
+   */
+  public function geologin_disallow( $args, $assoc_args ) {
+    $country_code = $args[0];
+    $country_name = GeoIP::country_code_to_name($args[0]);
+    $blog = Helpers::get_blog_name();
+
+    if ( $country_name === false ) {
+      \WP_CLI::error("'${country_code}' is not a valid two-letter country code.");
+    }
+
+    // Check if the country should be added network-wide
+    $network = isset($assoc_args['network']) && $assoc_args['network'] == true && is_multisite();
+
+    // Try to remove the country from the list
+    $removed = GeoIP::disallow_geologin($country_code, $network);
+
+    if ( ! $removed ) {
+      // The country wasn't removed from the list
+      if ( $network ) {
+        \WP_CLI::warning("Login from '${country_name}' can't be disallowed network-wide.");
+        \WP_CLI::log("         It isn't on the network-wide list of countries from which login is allowed.");
+      } else if ( is_multisite() ) {
+        \WP_CLI::warning("Login from '${country_name}' can't be disallowed on blog '${blog}'.");
+        \WP_CLI::log("         It isn't on the blog's list of countries from which login is allowed.");
+      } else {
+        \WP_CLI::warning("Login from '${country_name}' can't be disallowed.");
+        \WP_CLI::log("         It isn't on the list of countries from which login is allowed.");
+      }
+    }
+
+    if ( $removed ) {
+      // The country was removed from the list
+      if ( $network ) {
+        \WP_CLI::success("'${country_name}' is no longer on the network-wide list of allowed countries.");
+      } else {
+        if ( is_multisite() && GeoIP::is_login_allowed($country_code) ) {
+          \WP_CLI::warning("'${country_name}' is no longer on the list of allowed countries for blog '${blog}'");
+          \WP_CLI::log("         but it's still on the network-wide list so login from there is still allowed.");
+        } else {
+          if ( is_multisite() ) {
+            \WP_CLI::success("'${country_name}' is no longer on the list of allowed countries for blog '${blog}'.");
+          } else {
+            \WP_CLI::success("'${country_name}' is no longer on the list of allowed countries.");
+          }
+        }
+      }
+    }
+
+    if ( ! GeoIP::is_geologin_enabled() ) {
+      if ( is_multisite() ) {
+        \WP_CLI::warning("The list of allowed countries on blog '${blog}' is empty.");
+      } else {
+        \WP_CLI::warning('The list of allowed countries is empty.');
+      }
+      \WP_CLI::log('         Geologin is now disabled and login is allowed from anywhere.');
+    }
+  }
+
 }
+

--- a/vendor/composer/ClassLoader.php
+++ b/vendor/composer/ClassLoader.php
@@ -42,30 +42,75 @@ namespace Composer\Autoload;
  */
 class ClassLoader
 {
+    /** @var ?string */
     private $vendorDir;
 
     // PSR-4
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<string, int>>
+     */
     private $prefixLengthsPsr4 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<int, string>>
+     */
     private $prefixDirsPsr4 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, string>
+     */
     private $fallbackDirsPsr4 = array();
 
     // PSR-0
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<string, string[]>>
+     */
     private $prefixesPsr0 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, string>
+     */
     private $fallbackDirsPsr0 = array();
 
+    /** @var bool */
     private $useIncludePath = false;
+
+    /**
+     * @var string[]
+     * @psalm-var array<string, string>
+     */
     private $classMap = array();
+
+    /** @var bool */
     private $classMapAuthoritative = false;
+
+    /**
+     * @var bool[]
+     * @psalm-var array<string, bool>
+     */
     private $missingClasses = array();
+
+    /** @var ?string */
     private $apcuPrefix;
 
+    /**
+     * @var self[]
+     */
     private static $registeredLoaders = array();
 
+    /**
+     * @param ?string $vendorDir
+     */
     public function __construct($vendorDir = null)
     {
         $this->vendorDir = $vendorDir;
     }
 
+    /**
+     * @return string[]
+     */
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
@@ -75,28 +120,47 @@ class ClassLoader
         return array();
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, array<int, string>>
+     */
     public function getPrefixesPsr4()
     {
         return $this->prefixDirsPsr4;
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, string>
+     */
     public function getFallbackDirs()
     {
         return $this->fallbackDirsPsr0;
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, string>
+     */
     public function getFallbackDirsPsr4()
     {
         return $this->fallbackDirsPsr4;
     }
 
+    /**
+     * @return string[] Array of classname => path
+     * @psalm-var array<string, string>
+     */
     public function getClassMap()
     {
         return $this->classMap;
     }
 
     /**
-     * @param array $classMap Class to filename map
+     * @param string[] $classMap Class to filename map
+     * @psalm-param array<string, string> $classMap
+     *
+     * @return void
      */
     public function addClassMap(array $classMap)
     {
@@ -111,9 +175,11 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix, either
      * appending or prepending to the ones previously set for this prefix.
      *
-     * @param string       $prefix  The prefix
-     * @param array|string $paths   The PSR-0 root directories
-     * @param bool         $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix
+     * @param string[]|string $paths   The PSR-0 root directories
+     * @param bool            $prepend Whether to prepend the directories
+     *
+     * @return void
      */
     public function add($prefix, $paths, $prepend = false)
     {
@@ -156,11 +222,13 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace, either
      * appending or prepending to the ones previously set for this namespace.
      *
-     * @param string       $prefix  The prefix/namespace, with trailing '\\'
-     * @param array|string $paths   The PSR-4 base directories
-     * @param bool         $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths   The PSR-4 base directories
+     * @param bool            $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException
+     *
+     * @return void
      */
     public function addPsr4($prefix, $paths, $prepend = false)
     {
@@ -204,8 +272,10 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix,
      * replacing any others previously set for this prefix.
      *
-     * @param string       $prefix The prefix
-     * @param array|string $paths  The PSR-0 base directories
+     * @param string          $prefix The prefix
+     * @param string[]|string $paths  The PSR-0 base directories
+     *
+     * @return void
      */
     public function set($prefix, $paths)
     {
@@ -220,10 +290,12 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace,
      * replacing any others previously set for this namespace.
      *
-     * @param string       $prefix The prefix/namespace, with trailing '\\'
-     * @param array|string $paths  The PSR-4 base directories
+     * @param string          $prefix The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths  The PSR-4 base directories
      *
      * @throws \InvalidArgumentException
+     *
+     * @return void
      */
     public function setPsr4($prefix, $paths)
     {
@@ -243,6 +315,8 @@ class ClassLoader
      * Turns on searching the include path for class files.
      *
      * @param bool $useIncludePath
+     *
+     * @return void
      */
     public function setUseIncludePath($useIncludePath)
     {
@@ -265,6 +339,8 @@ class ClassLoader
      * that have not been registered with the class map.
      *
      * @param bool $classMapAuthoritative
+     *
+     * @return void
      */
     public function setClassMapAuthoritative($classMapAuthoritative)
     {
@@ -285,6 +361,8 @@ class ClassLoader
      * APCu prefix to use to cache found/not-found classes, if the extension is enabled.
      *
      * @param string|null $apcuPrefix
+     *
+     * @return void
      */
     public function setApcuPrefix($apcuPrefix)
     {
@@ -305,6 +383,8 @@ class ClassLoader
      * Registers this instance as an autoloader.
      *
      * @param bool $prepend Whether to prepend the autoloader or not
+     *
+     * @return void
      */
     public function register($prepend = false)
     {
@@ -324,6 +404,8 @@ class ClassLoader
 
     /**
      * Unregisters this instance as an autoloader.
+     *
+     * @return void
      */
     public function unregister()
     {
@@ -403,6 +485,11 @@ class ClassLoader
         return self::$registeredLoaders;
     }
 
+    /**
+     * @param  string       $class
+     * @param  string       $ext
+     * @return string|false
+     */
     private function findFileWithExtension($class, $ext)
     {
         // PSR-4 lookup
@@ -474,6 +561,10 @@ class ClassLoader
  * Scope isolated include.
  *
  * Prevents access to $this/self from included files.
+ *
+ * @param  string $file
+ * @return void
+ * @private
  */
 function includeFile($file)
 {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -126,6 +126,7 @@ return array(
     'Seravo\\Logs' => $baseDir . '/src/lib/logs.php',
     'Seravo\\Module\\AdminChecks' => $baseDir . '/src/modules/admin-checks.php',
     'Seravo\\Module\\Fixes' => $baseDir . '/src/modules/fixes.php',
+    'Seravo\\Module\\GeoLogin' => $baseDir . '/src/modules/geologin.php',
     'Seravo\\Module\\HideUsers' => $baseDir . '/src/modules/hide-users.php',
     'Seravo\\Module\\ImageUpload' => $baseDir . '/src/modules/image-upload.php',
     'Seravo\\Module\\InstanceSwitcher' => $baseDir . '/src/modules/instance-switcher.php',

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -121,6 +121,7 @@ return array(
     'Seravo\\CruftRemover' => $baseDir . '/src/lib/cruftremover.php',
     'Seravo\\DashboardWidgets' => $baseDir . '/src/modules/dashboard-widgets.php',
     'Seravo\\Domains' => $baseDir . '/src/modules/pages/domains.php',
+    'Seravo\\GeoIP' => $baseDir . '/src/lib/geoip.php',
     'Seravo\\Helpers' => $baseDir . '/src/lib/helpers.php',
     'Seravo\\Logs' => $baseDir . '/src/lib/logs.php',
     'Seravo\\Module\\AdminChecks' => $baseDir . '/src/modules/admin-checks.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -156,6 +156,7 @@ class ComposerStaticInit816aadb5ea01182af5842468019f4c6c
         'Seravo\\CruftRemover' => __DIR__ . '/../..' . '/src/lib/cruftremover.php',
         'Seravo\\DashboardWidgets' => __DIR__ . '/../..' . '/src/modules/dashboard-widgets.php',
         'Seravo\\Domains' => __DIR__ . '/../..' . '/src/modules/pages/domains.php',
+        'Seravo\\GeoIP' => __DIR__ . '/../..' . '/src/lib/geoip.php',
         'Seravo\\Helpers' => __DIR__ . '/../..' . '/src/lib/helpers.php',
         'Seravo\\Logs' => __DIR__ . '/../..' . '/src/lib/logs.php',
         'Seravo\\Module\\AdminChecks' => __DIR__ . '/../..' . '/src/modules/admin-checks.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -161,6 +161,7 @@ class ComposerStaticInit816aadb5ea01182af5842468019f4c6c
         'Seravo\\Logs' => __DIR__ . '/../..' . '/src/lib/logs.php',
         'Seravo\\Module\\AdminChecks' => __DIR__ . '/../..' . '/src/modules/admin-checks.php',
         'Seravo\\Module\\Fixes' => __DIR__ . '/../..' . '/src/modules/fixes.php',
+        'Seravo\\Module\\GeoLogin' => __DIR__ . '/../..' . '/src/modules/geologin.php',
         'Seravo\\Module\\HideUsers' => __DIR__ . '/../..' . '/src/modules/hide-users.php',
         'Seravo\\Module\\ImageUpload' => __DIR__ . '/../..' . '/src/modules/image-upload.php',
         'Seravo\\Module\\InstanceSwitcher' => __DIR__ . '/../..' . '/src/modules/instance-switcher.php',


### PR DESCRIPTION
#### What are the main changes in this PR?

Adds GeoIP based login restricting. If the user tries to login from a country that's not in the list of countries from which login is allowed, error is shown on login (see screenshots).

Restrictions are only in use when there's at least on country on the list. So no restrictions enabled by default but if you were to add `Finland` to the list, you could only login from Finland from there on.

Adds WP-CLI commands to manage the restrictions:
```
PRODUCTION [@joosuakoskinen-4a5d38:~] $ wp seravo geologin
usage: wp seravo geologin allow <name> [--network]
   or: wp seravo geologin disallow <name> [--network]
   or: wp seravo geologin list 
```

The `geologin allow` adds a country to the allowed countries list. The `geologin disallow` removes entries from the allowed countries list. The `geologin list` tells whether the restrictions are enabled, what countries are allowed on the current blog and what countries are allowed on the whole multisite.

On multisites, the sites all have their own list and also the common network-wide list. For example below we have `geologin list` for a single blog "JoosuaKoskinen" in a multisite on which you could login from Finland, Norway and United Kingdom.
```
PRODUCTION [@joosuakoskinen-4a5d38:~] $ wp seravo geologin list
Restricted login: Enabled

Allow login on blog 'Joosuakoskinen' from:

    - Finland (FI)
    - Norway (NO)

Allow login network-wide (all blogs) from:

    - United Kingdom (UK)
```

#### Manual testing steps?

CLI needs to be tested on a regular and a multisite. Especially regular site as this was mainly developed on a multisite. The login blocking hasn't been tested much, I did a few tests with a VPN and seemed to work great.

#### Screenshot
![geologin](https://user-images.githubusercontent.com/42264063/140796780-ba5a29dd-c4d7-42d3-bb36-e880a8efdcdf.png)
