### PR TITLE
Make it possible to disable the plugin using a constant or an environment variable

### DIFF
--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -80,6 +80,15 @@ class Loader {
   private static $domain = 'seravo';
 
   public function __construct() {
+
+    if ( defined('SERAVO_PLUGIN_DISABLED') && SERAVO_PLUGIN_DISABLED === true ) {
+      return;
+    }
+
+    if ( getenv('SERAVO_PLUGIN_DISABLED') !== false && filter_var(getenv('SERAVO_PLUGIN_DISABLED'), FILTER_VALIDATE_BOOLEAN) === true ) {
+      return;
+    }
+
     if ( isset(self::$_single) ) {
       return;
     }


### PR DESCRIPTION
Running the Seravo MU Plugin in a local development environment can cause various issues since the plugin will try to write log files into a location that might not exist in the development environment.

This PR introduces a PHP constant and an environment variable called SERAVO_PLUGIN_DISABLED which can be used to conditionally disable the plugins in environments where it's not desirable to have the plugin enabled.

This means you can add the following to your `wp-config.php` to disable the plugin:

```php
define('SERAVO_PLUGIN_DISABLED', true);
```

You can also define the same as environment variable for the same effect

```env
SERAVO_PLUGIN_DISABLED='true'
```