### PR TITLE
Add WP Corporate to site plans in Site Status

### DIFF
--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -763,6 +763,7 @@ class SiteStatus extends Toolpage {
       'mini'       => __('WP Mini', 'seravo'),
       'pro'        => __('WP Pro', 'seravo'),
       'business'   => __('WP Business', 'seravo'),
+      'corporate'  => __('WP Corporate', 'seravo'),
       'enterprise' => __('WP Enterprise', 'seravo'),
     );
     $countries = array(


### PR DESCRIPTION
WP Corporate was not included in the plans array here:

https://github.com/Seravo/seravo-plugin/blob/42ecb9274e0699d099216878441784a59a3113e3/src/modules/pages/sitestatus.php#L761-L766

Closes: #659