### PR TITLE
Fix validating emails with long TLD

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -28,7 +28,7 @@ var seravo = {
    * @returns Whether the address is valid or not.
    */
   is_email_valid: function(email) {
-    var regex = /^([ÆØÅæøåõäöüa-zA-Z0-9_.+-])+@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})$/;
+    var regex = /^([ÆØÅæøåõäöüa-zA-Z0-9_.+-])+@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,24})$/;
     return regex.test(email);
   },
 


### PR DESCRIPTION
Increases max TLD length from 4 to 6 so special domains are also accepted.

#### Manual testing steps?
On upkeep page email form, try to input an email with longer TLD eg. `myemail@mydomain.agency`. 