### PR TITLE
Fix autoloading on sites using global autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,40 +45,5 @@
       "composer rector:check",
       "composer phpcs:check"
     ]
-  },
-  "autoload": {
-    "classmap": [
-      "src/lib/module",
-      "src/lib/postbox",
-      "src/lib/ajax",
-      "src/lib/api/swd.php",
-      "src/lib/helpers.php",
-      "src/lib/cruftremover.php",
-      "src/lib/list-table.php",
-      "src/lib/shell.php",
-      "src/lib/security-restrictions.php",
-      "src/lib/logs.php",
-      "src/lib/compatibility.php",
-      "src/lib/shadow.php",
-      "src/lib/geoip.php",
-      "src/modules/pages",
-      "src/modules/geologin.php",
-      "src/modules/check-site-health.php",
-      "src/modules/dashboard-widgets.php",
-      "src/modules/fixes.php",
-      "src/modules/hide-users.php",
-      "src/modules/instance-switcher.php",
-      "src/modules/noindex-domain-alias.php",
-      "src/modules/passwords.php",
-      "src/modules/purge-cache.php",
-      "src/modules/seravotest-auth-bypass.php",
-      "src/modules/speed-test.php",
-      "src/modules/thirdparty-fixes.php",
-      "src/modules/wp-login-log.php",
-      "src/modules/wp-plugin-log.php",
-      "src/modules/wp-user-log.php",
-      "src/modules/admin-checks.php",
-      "src/modules/image-upload.php"
-    ]
   }
 }

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -36,7 +36,8 @@ if ( ! \defined('SERAVO_PLUGIN_SRC') ) {
 }
 
 // Use Postbox::class for now to see if autoload needs to be required
-if ( ! \class_exists(\Seravo\Postbox\Postbox::class) ) {
+// NOTICE: Do not remove the 'false' parameter before no sites autoload the plugin.
+if ( ! \class_exists(\Seravo\Postbox\Postbox::class, false) ) {
   require_once SERAVO_PLUGIN_DIR . 'vendor/autoload.php';
 }
 


### PR DESCRIPTION
#### What are the main changes in this PR?

- Makes sure Seravo Plugin autoloader is loaded even if the site's global autoloader loads Seravo Plugin.
- Prevents new sites generating global autoloader for Seravo Plugin on deploy.

#### Manual testing steps?
- Load a site and see no fatal errors. 