### PR TITLE
Reset shadows using the Container API

### DIFF
--- a/js/lib/ajax/seravo-ajax.js
+++ b/js/lib/ajax/seravo-ajax.js
@@ -23,11 +23,13 @@ function seravo_ajax_request(method, postbox_id, section, on_success, on_error, 
         response = jQuery.parseJSON(response);
 
         if (response !== null && 'success' in response && response['success'] === true) {
-          if ('poller_id' in response) {
+          if ('poller_id' in response && 'poller_type' in response) {
             // Polling requested
             setTimeout(
               function () {
-                seravo_poller(method, postbox_id, section, on_success, on_error, response['poller_id']);
+                let poller_id = response['poller_id'];
+                let poller_type = response['poller_type'];
+                seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, poller_type);
               },
               5000
             );
@@ -68,7 +70,7 @@ function seravo_ajax_request(method, postbox_id, section, on_success, on_error, 
   );
 }
 
-function seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, retry = 0) {
+function seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, poller_type, retry = 0) {
   if (retry == 10) {
     on_error(seravo_ajax_l10n.server_timeout);
     return;
@@ -83,6 +85,7 @@ function seravo_poller(method, postbox_id, section, on_success, on_error, poller
         'section': section,
         'nonce': SERAVO_AJAX_NONCE,
         'poller_id': poller_id,
+        'poller_type': poller_type,
       },
     },
   ).done(
@@ -94,7 +97,7 @@ function seravo_poller(method, postbox_id, section, on_success, on_error, poller
           // Poll again
           setTimeout(
             function () {
-              seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, 0)
+              seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, poller_type,0)
             },
             2000
           );
@@ -124,7 +127,7 @@ function seravo_poller(method, postbox_id, section, on_success, on_error, poller
       // Poll again
       setTimeout(
         function () {
-          seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, retry + 1)
+          seravo_poller(method, postbox_id, section, on_success, on_error, poller_id, poller_type, retry + 1)
         },
         3000
       );

--- a/src/lib/ajax/response.php
+++ b/src/lib/ajax/response.php
@@ -177,15 +177,17 @@ class AjaxResponse {
 
   /**
    * Get response for requesting polling.
-   * @param string $pid Pid of the program to poll.
+   * @param string $id ID of the program to poll.
+   * @param string $type ID type, either 'pid' or 'task'.
    * @return \Seravo\Ajax\AjaxResponse Polling response.
    */
-  public static function require_polling_response( $pid ) {
+  public static function require_polling_response( $id, $type = 'pid' ) {
     $response = new AjaxResponse();
     $response->is_success(true);
     $response->set_data(
       array(
-        'poller_id' => \base64_encode($pid),
+        'poller_id' => \base64_encode($id),
+        'poller_type' => $type,
       )
     );
     return $response;

--- a/src/lib/api/container.php
+++ b/src/lib/api/container.php
@@ -2,79 +2,32 @@
 
 namespace Seravo\API;
 
-class SWD {
+class Container {
 
-  const API_URL = "http://localhost:8888/v2/site";
+  const API_URL = "http://localhost:8080/v2";
 
-  public static function get_site_info() {
-    return self::get('/');
+  public static function reset_shadow( $shadow ) {
+    return self::post("/wordpress/shadow-reset/$shadow");
   }
 
-  public static function update_site_info( $updates, $contacts, $webhooks ) {
-    $data = [
-      'seravo_updates' => $updates,
-      'contact_emails' => $contacts,
-      'notification_webhooks_json' => $webhooks,
-    ];
-
-    return self::put('/', $data);;
-  }
-
-  public static function get_site_shadows() {
-    return self::get('/shadows/');
-  }
-
-  public static function get_site_shadow( $shadow ) {
-    return self::get("/shadows/$shadow");
-  }
-
-  public static function get_site_domains() {
-    return self::get('/domains/');
-  }
-
-  public static function set_primary_domain( $domain ) {
-    return self::post("/domains/$domain/primary", []);
-  }
-
-  public static function get_domain_zone( $domain ) {
-    return self::get("/domains/$domain/zone");
-  }
-
-  public static function sniff_domain_zone( $domain ) {
-    return self::get("/domains/$domain/sniff");
-  }
-
-  public static function update_domain_zone( $domain, $records ) {
-    return self::put("/domains/$domain/zone", ['items' => $records]);
-  }
-
-  public static function get_domain_mailforwards( $domain ) {
-    return self::get("/domains/$domain/mailforwards/");
-  }
-
-  public static function update_domain_mailforwards( $domain, $forwards ) {
-    return self::post("/domains/$domain/mailforwards/", $forwards);
-  }
-
-  public static function publish_domain( $domain ) {
-    return self::post("/domains/$domain/publish" );
+  public static function task_status( $id ) {
+    return self::get("/tasks/$id");
   }
 
   private static function get( $query ) {
-    return self::request('GET', $query);
+    return self::request('get', $query);
   }
 
   private static function put( $query, $data = null ) {
-    return self::request('PUT', $query, $data);
+    return self::request('put', $query, $data);
   }
 
   private static function post( $query, $data = null ) {
-    return self::request('POST', $query, $data);
+    return self::request('post', $query, $data);
   }
 
   private static function request( $method, $path, $data = null ) {
     $url = self::API_URL . $path;
-    $user = \wp_get_current_user();
     $headers = [];
 
     // Initialize a new cURL session handle.
@@ -83,12 +36,6 @@ class SWD {
     if ( $handle === false ) {
       // cURL failed to initialize.
       return self::error($method, $path, 'cURL session initialization failure');
-    }
-
-    if ( $user instanceof \WP_User ) {
-      // If logged in, include the username in headers for logs.
-      $auth = \base64_encode($user->user_login . ':xxx');
-      $headers[] = "Authorization: Basic $auth";
     }
 
     // Set the HTTP method.
@@ -136,9 +83,8 @@ class SWD {
   }
 
   private static function error($method, $path, $message) {
-    $code = "seravo-swd-$method-error";
-    $error = "SWD API error on $method to '$path' failed: $message";
-
+    $code = "seravo-container-$method-error";
+    $error = "Container API error on $method to '$path' failed: $message";
     return new \WP_Error($code, $error);
   }
 

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -238,6 +238,7 @@ return array(
     'HTMLPurifier_VarParser_Flexible' => $vendorDir . '/ezyang/htmlpurifier/library/HTMLPurifier/VarParser/Flexible.php',
     'HTMLPurifier_VarParser_Native' => $vendorDir . '/ezyang/htmlpurifier/library/HTMLPurifier/VarParser/Native.php',
     'HTMLPurifier_Zipper' => $vendorDir . '/ezyang/htmlpurifier/library/HTMLPurifier/Zipper.php',
+    'Seravo\\API\\Container' => $baseDir . '/src/lib/api/container.php',
     'Seravo\\API\\SWD' => $baseDir . '/src/lib/api/swd.php',
     'Seravo\\Ajax\\AjaxHandler' => $baseDir . '/src/lib/ajax/handler.php',
     'Seravo\\Ajax\\AjaxResponse' => $baseDir . '/src/lib/ajax/response.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -267,6 +267,7 @@ class ComposerStaticInit7fbd458cfab372eb173c9554bbea50d5
         'HTMLPurifier_VarParser_Flexible' => __DIR__ . '/..' . '/ezyang/htmlpurifier/library/HTMLPurifier/VarParser/Flexible.php',
         'HTMLPurifier_VarParser_Native' => __DIR__ . '/..' . '/ezyang/htmlpurifier/library/HTMLPurifier/VarParser/Native.php',
         'HTMLPurifier_Zipper' => __DIR__ . '/..' . '/ezyang/htmlpurifier/library/HTMLPurifier/Zipper.php',
+        'Seravo\\API\\Container' => __DIR__ . '/../..' . '/src/lib/api/container.php',
         'Seravo\\API\\SWD' => __DIR__ . '/../..' . '/src/lib/api/swd.php',
         'Seravo\\Ajax\\AjaxHandler' => __DIR__ . '/../..' . '/src/lib/ajax/handler.php',
         'Seravo\\Ajax\\AjaxResponse' => __DIR__ . '/../..' . '/src/lib/ajax/response.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'seravo/seravo-plugin',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '5086818070e674c03e9b98a59fcd7015dfb6aea1',
+        'reference' => '85dc11329d0ccd15d15de8b7b7bb7279b73e5eac',
         'type' => 'wordpress-muplugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -31,7 +31,7 @@
         'seravo/seravo-plugin' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '5086818070e674c03e9b98a59fcd7015dfb6aea1',
+            'reference' => '85dc11329d0ccd15d15de8b7b7bb7279b73e5eac',
             'type' => 'wordpress-muplugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
#### What are the main changes in this PR?
Instead of the Seravo Plugin's built-in poller, use Container API's `/task/` and `/shadow-reset/` endpoints to do it.

To be fixed at later time:
- Trying to reset an shadow (eg. from an other browser tab) while another shadow reset is in progress, will show a very generic error message to the user.
- The `SWD` and `Container` API classes are ugly, will replace the with some common `HTTPClient` system later.

#### Manual testing steps?
- Have a site running with a Container API and at least one shadow site.
- Try breaking the "Shadows" (Varjot) feature on the site status (Sivuston tila) page. 