### PR TITLE
Fix contact email button width

### DIFF
--- a/style/common.css
+++ b/style/common.css
@@ -190,17 +190,16 @@ table.widefat {
 /* Email list */
 
 .email-button {
-  width: 200px;
   height: 20px;
   padding-left: 0 !important;
 }
 
 .email-button-content {
-  width: 85%;
   overflow: hidden;
   display: inline-block;
   text-overflow: ellipsis;
   font-size: 13px !important;
+  padding: 0 5px 0 10px;
 }
 
 .email-button .dashicons  {


### PR DESCRIPTION
#### What are the main changes in this PR?
Fixes long email addresses not being fully visible.

#### Manual testing steps?
1. Make sure to clear browser cache (eg. `ctrl+f5`).
2. On upkeep page, add contact emails of different lengths.

#### Screenshots
![image](https://user-images.githubusercontent.com/42264063/236398901-84839619-31f6-41b6-a273-68c5feec4de6.png)
