### PR TITLE
Implement php-compat-check with Container API

### DIFF
--- a/src/lib/api/container.php
+++ b/src/lib/api/container.php
@@ -10,6 +10,11 @@ class Container {
     return self::post("/wordpress/shadow-reset/$shadow");
   }
 
+  public static function php_compatibility_check( $version = null ) {
+    $data = $version === null ? [] : ['php' => $version];
+    return self::post('/wordpress/php-compatibility-check/', $data);
+  }
+
   public static function task_status( $id ) {
     return self::get("/tasks/$id");
   }


### PR DESCRIPTION
#### What are the main changes in this PR?

Use Container API to run the `php-compatibility-check` in the background instead of Seravo Plugin built-in poller. Functions exactly the same way expect it now doesn't allow to run multiple checks at once accidentally and the background task in more robust.

Still doesn't allow for live output or checking compatibility for a specific PHP version.

Depends on https://github.com/Seravo/seravo-plugin/pull/686, that's why there's an extra commit included.

#### Where should a reviewer start?
The `php-compatibility-check` feature is on the upkeep page with the PHP version changer.