### PR TITLE
Implement backup-status with Container API

### DIFF
--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -14,6 +14,8 @@
 namespace Seravo;
 
 // Deny direct access to this file
+use Seravo\API\Container;
+
 if ( ! \defined('ABSPATH') ) {
   die('Access denied!');
 }

--- a/src/lib/api/container.php
+++ b/src/lib/api/container.php
@@ -15,6 +15,10 @@ class Container {
     return self::post('/wordpress/php-compatibility-check/', $data);
   }
 
+  public static function backup_status() {
+    return self::post('/wordpress/backup-status/', []);
+  }
+
   public static function task_status( $id ) {
     return self::get("/tasks/$id");
   }


### PR DESCRIPTION
#### What are the main changes in this PR?

Use Container API to run the wp-backup-status in the background instead of Seravo Plugin running `exec`.

Note: This temporarily makes some extra API requests.

#### Manual testing steps?
- Navigate to wp-admin > tools > backups.
- See backups status load fine.