### PR TITLE
Implement PHP version change with Container API

### DIFF
--- a/src/lib/api/container.php
+++ b/src/lib/api/container.php
@@ -15,6 +15,10 @@ class Container {
     return self::post('/wordpress/php-compatibility-check/', $data);
   }
 
+  public static function php_version_set( $version ) {
+    return self::post('/wordpress/php-version-set/', ['php' => $version]);
+  }
+
   public static function backup_status() {
     return self::post('/wordpress/backup-status/', []);
   }


### PR DESCRIPTION
#### What are the main changes in this PR?

Use Container API to run the `wp-php-set-version` in the background instead of Seravo Plugin running internal poller and `exec`.

Note: The old method used to print to a `php-version-change.log` log file and commit the changes to nginx configs. If these are still needed, they should be implemented in `wp-php-set-version`.
d to this PR, please link it here for context.

#### Manual testing steps?

- Navigate to wp-admin > tools > upkeep.
- See PHP version change work fine.
