### PR TITLE
Add PHPCS ruleset and GitHub workflow

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -1,0 +1,23 @@
+---
+name: 'Lint PHP code'
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  phpcs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repository
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: cs2pr, phpcs
+
+      - name: Run PHP CodeSniffer
+        run: phpcs -q --standard=tools/PHPCodeSniffer/Standard/ruleset.xml --report=checkstyle | cs2pr

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,8 @@
     "allow-plugins": {
       "composer/installers": true
     }
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.7"
   }
 }

--- a/src/test.php
+++ b/src/test.php
@@ -1,0 +1,3 @@
+<?php
+
+die('Access denied!');

--- a/tools/PHPCodeSniffer/Standard/ruleset.xml
+++ b/tools/PHPCodeSniffer/Standard/ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="Seravo Coding Standard" namespace="SeravoPlugin\Dev\PHPCodeSniffer\Standard">
+    <description>A custom coding standard for Seravo Plugin.</description>
+
+    <!-- Increase process memory limit to 64M. -->
+    <ini name="memory_limit" value="64M"/>
+
+    <!-- The list of files to check. -->
+    <file>../../../src/test.php</file>
+
+    <!-- Include PSR-1 and PSR-12 coding standards. -->
+    <rule ref="PSR1"/>
+    <rule ref="PSR12"/>
+</ruleset>


### PR DESCRIPTION
#### What are the main changes in this PR?
Adds our new coding standard ruleset and GitHub Action workflow for testing it.

The coding standard is currently only following the [PSR-12](https://www.php-fig.org/psr/psr-12/) standard by PHP-FIG and will be extended in the future to check for PHP compatibility, correct WordPress function usage, phpdoc comments etc.

Our code is currently ready for none of those checks so the GitHub workflow doesn't actually scan any files yet. That's why I've temporarily added the `test.php` file.
