### PR TITLE
Fix XML-RPC blocking

### DIFF
--- a/src/lib/security-restrictions.php
+++ b/src/lib/security-restrictions.php
@@ -20,7 +20,9 @@ class SecurityRestrictions {
       \add_filter('xmlrpc_enabled', '__return_false');
       \add_filter('xmlrpc_methods', array( __CLASS__, 'remove_xmlrpc_methods' ));
 
-      if ( isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI']) && \strpos($_SERVER['REQUEST_URI'], 'xml-rpc.php') !== false ) {
+      if ( isset($_SERVER['HTTP_HOST']) && isset($_SERVER['REQUEST_URI']) && \strpos($_SERVER['REQUEST_URI'], 'xmlrpc.php') !== false ) {
+        header('Status: 403 Forbidden');
+        header('HTTP/1.1 403 Forbidden');
         \wp_die('XML-RPC blocked.');
       }
     } elseif ( \get_option('seravo-disable-xml-rpc') === 'on' ) {


### PR DESCRIPTION
#### What are the main changes in this PR?

The complete blocking of `xmlrpc.php` seems to have been broken since it was implemented in https://github.com/Seravo/seravo-plugin/commit/23f2199f9df2f284a296f0ece196509991285112.

XML-RPC has never worked (when the full XML-RPC blocking was enabled) even though the `xmlrpc.php` file itself hasn't been blocked because Seravo Plugin has always removed all the XML-RPC endpoints.

In addition of fixing the blocking of `xmlrpc.php`, I changed it to respond with HTTP 403 instead of 200 so the blocking can be seen in access logs.