### PR TITLE
Remove old PHPCS rules, improve coding standard and fix syntax workflows

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -43,18 +43,24 @@ jobs:
 
       # Install development dependencies
       - name: Install development dependencies
-        run: composer install --no-interaction --no-progress
+        run: composer install --no-interaction --no-progress --ignore-platform-reqs
 
       # Print Parallel Lint version
       - run: vendor/bin/parallel-lint --version
 
       # Lint PHP code syntax
       - name: Run PHP Parallel Lint
-        run: vendor/bin/parallel-lint --show-deprecated --checkstyle *.php src | cs2pr
+        run: vendor/bin/parallel-lint
+          --show-deprecated
+          --checkstyle
+          --exclude src/vendor
+          seravo-plugin.php src | cs2pr
 
       # Print PHP_CodeSniffer version
       - run: vendor/bin/phpcs --version
 
       # Lint PHP code style
       - name: Run PHP CodeSniffer
-        run: vendor/bin/phpcs -q --standard=tools/PHPCodeSniffer/Standard --report=checkstyle | cs2pr
+        run: vendor/bin/phpcs -q
+          --standard=tools/PHPCodeSniffer/Standard
+          --report=checkstyle | cs2pr

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -12,9 +12,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint-php:
-    name: 'Lint syntax and style'
+  lint-php-syntax:
+    name: 'Lint syntax'
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +56,29 @@ jobs:
           --checkstyle
           --exclude src/vendor
           seravo-plugin.php src | cs2pr
+
+  lint-php-style:
+    name: 'Lint style'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Setup repository
+        uses: actions/checkout@v3
+
+      # Install PHP and tools necessary
+      - name: Setup PHP
+        uses: seravo/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: cs2pr, composer
+
+      # Print Composer version
+      - run: composer --version
+
+      # Install development dependencies
+      - name: Install development dependencies
+        run: composer install --no-interaction --no-progress
 
       # Print PHP_CodeSniffer version
       - run: vendor/bin/phpcs --version

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   "require-dev": {
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpcompatibility/php-compatibility": "^9.3",
+    "slevomat/coding-standard": "^8.12",
     "squizlabs/php_codesniffer": "^3.7"
   },
   "config": {
@@ -30,6 +31,9 @@
     "platform-check": false,
     "preferred-install": {
       "*": "dist"
+    },
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   }
 }

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName
+<?php
 /**
  * Plugin Name: Seravo Plugin
  * Version: 1.9.43

--- a/src/lib/domains-ajax.php
+++ b/src/lib/domains-ajax.php
@@ -20,7 +20,6 @@ function seravo_respond_error_json( $reason = '' ) {
 
 function seravo_get_domains_table() {
   if ( Domains::$domains_table === null ) {
-    // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
     Domains::$domains_table = new Seravo_Domains_List_Table();
   }
 
@@ -31,7 +30,6 @@ function seravo_get_domains_table() {
 
 function seravo_get_forwards_table() {
   if ( Domains::$mails_table === null ) {
-    // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
     Domains::$mails_table = new Seravo_Mails_Forward_Table();
   }
 

--- a/src/lib/list-table.php
+++ b/src/lib/list-table.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 
 namespace Seravo;
 
@@ -447,7 +446,7 @@ class WP_List_Table {
 			 *
 			 * @param string[] $actions An array of the available bulk actions.
 			 */
-			$this->_actions = apply_filters( "bulk_actions-{$this->screen->id}", $this->_actions ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			$this->_actions = apply_filters( "bulk_actions-{$this->screen->id}", $this->_actions );
 			$two            = '';
 		} else {
 			$two = '2';

--- a/src/loader.php
+++ b/src/loader.php
@@ -52,7 +52,6 @@ class Loader {
     // If a real file path was given, send out MIME type and file size headers
     if ( \file_exists($file) ) {
       \header('Content-Type: ' . \mime_content_type($file));
-      // phpcs:ignore Security.BadFunctions.FilesystemFunctions.WarnFilesystem
       \header('Content-Length: ' . \filesize($file));
     }
 
@@ -84,7 +83,6 @@ class Loader {
     global $pagenow;
 
     // This check fires on every page load, so keep the scope small
-    // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
     if ( $pagenow === 'tools.php' && isset($_GET['x-accel-redirect']) ) {
 
       // This URL uses authentication, thus don't cache anything from it
@@ -98,10 +96,8 @@ class Loader {
       }
 
       // Filename must be of correct form, e.g. 2016-09.html or home.png
-      // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
       if ( isset($_GET['report']) && \preg_match('/^\d{4}-\d{2}\.html$/', $_GET['report'], $matches) === 1 ) {
         self::x_accel_redirect('/data/slog/html/goaccess-' . $matches[0]);
-        // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
       } elseif ( isset($_GET['screenshot']) && \preg_match('/^[a-z-.]+\.png$/', $_GET['screenshot'], $matches) === 1 ) {
         self::x_accel_redirect('/data/reports/tests/debug/' . $matches[0]);
       } else {

--- a/src/test.php
+++ b/src/test.php
@@ -1,1 +1,3 @@
 <?php
+
+declare(strict_types = 1);

--- a/src/vendor/ezyang/htmlpurifier/library/HTMLPurifier.autoload.php
+++ b/src/vendor/ezyang/htmlpurifier/library/HTMLPurifier.autoload.php
@@ -17,7 +17,6 @@ if (function_exists('spl_autoload_register') && function_exists('spl_autoload_un
     require dirname(__FILE__) . '/HTMLPurifier.autoload-legacy.php';
 }
 
-// phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.zend_ze1_compatibility_modeRemoved
 if (ini_get('zend.ze1_compatibility_mode')) {
     trigger_error("HTML Purifier is not compatible with zend.ze1_compatibility_mode; please turn it off", E_USER_ERROR);
 }

--- a/tools/PHPCodeSniffer/Standard/ruleset.xml
+++ b/tools/PHPCodeSniffer/Standard/ruleset.xml
@@ -6,35 +6,155 @@
     <file>../../../src/test.php</file>
 
     <!-- Specify the command line arguments. -->
+    <arg name="encoding" value="utf-8"/>
     <arg name="extensions" value="php"/>
-    <arg name="report" value="full,summary"/>
     <arg name="tab-width" value="2"/>
+    <arg name="report" value="full"/>
     <arg name="colors"/>
     <arg value="sp"/>
 
-    <!-- Increase process memory limit to 128MB. -->
+    <!-- Specify php.ini settings. -->
     <ini name="memory_limit" value="128M"/>
 
-    <!-- Minimum PHP version to check compatibility for. -->
+    <!-- Specify configuration options. -->
     <config name="testVersion" value="7.0-"/>
-
-    <!-- Specify paths for the external standards. -->
-    <config name="installed_paths" value="../../../vendor/phpcompatibility/php-compatibility/PHPCompatibility"/>
 
     <!-- Include PHPCompatibility coding standard. -->
     <rule ref="PHPCompatibility"/>
 
     <!-- Include PSR-12 coding standard. -->
     <rule ref="PSR12">
-        <!-- Allow opening brace on function declaration line. -->
+        <!-- Allow opening brace on the function declaration line. -->
         <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+
+        <!-- Allow spaces after control structure opening brace. -->
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+        <!-- Allow spaces before control structure closing brace. -->
+        <exclude name="PSR12.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace"/>
+
+        <!-- Allow spaces before and after equals sign in declare statement. -->
+        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundAfterDirective"/>
+        <exclude name="PSR12.Files.DeclareStatement.SpaceFoundBeforeDirectiveValue"/>
+
+        <!-- Allow empty line after class declaration. -->
+        <exclude name="PSR12.Classes.OpeningBraceSpace.Found"/>
+        <!-- Allow empty line before class closing brace. -->
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
+        <!-- Allow opening brace to be on the class declaration line. -->
+        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
     </rule>
 
-    <!-- Opening brace should be on the same line as the function declaration. -->
+    <!-- Include Slevomat coding standard. -->
+    <rule ref="SlevomatCodingStandard">
+        <!-- Allow arbitrary spacing in comments. -->
+        <exclude name="SlevomatCodingStandard.Commenting.DocCommentSpacing"/>
+
+        <!-- Don't enforce rules requiring PHP 7.1 or newer. -->
+        <exclude name="SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
+
+        <!-- Don't require Yoda condition. -->
+        <exclude name="SlevomatCodingStandard.ControlStructures.RequireYodaComparison.RequiredYodaComparison"/>
+
+        <!-- Allow multiline comment with one line of content. -->
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLineDocComment.MultiLineDocComment"/>
+        <exclude name="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment.MultiLinePropertyComment"/>
+
+        <!-- Allow useless annotations. -->
+        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.UselessAnnotation"/>
+    </rule>
+
+    <!-- Enforce CamelCaps for variables names. -->
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+
+    <!-- Specify directories for namespaces. -->
+    <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+        <properties>
+            <property name="rootNamespaces" type="array">
+                <element key="plugin/lib" value="SeravoPlugin"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Allow importing of specific namespaces only. -->
+    <rule ref="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces">
+        <properties>
+            <property name="allowUseFromRootNamespace" value="true"/>
+            <property name="namespacesRequiredToUse" type="array">
+                <element value="SeravoPlugin"/>
+                <element value="PSR"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Limit line length to 100 characters. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="100"/>
+            <property name="absoluteLineLimit" value="100"/>
+        </properties>
+    </rule>
+
+    <!-- Enforce scope indentation with 2 spaces. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="indent" value="2" />
+            <property name="exact" value="true" />
+        </properties>
+    </rule>
+
+    <!-- Enforce multiline array indentation with 2 spaces. -->
+    <rule ref="Generic.Arrays.ArrayIndent">
+        <properties>
+            <property name="tabIndent" value="false" />
+            <property name="indent" value="2" />
+        </properties>
+    </rule>
+
+    <!-- Enforce switch terminating case statement indentation with 2 spaces. -->
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration">
+        <properties>
+            <property name="indent" value="2" />
+        </properties>
+    </rule>
+
+    <!-- Enforce opening brace on the function declaration line. -->
     <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie">
         <properties>
             <property name="checkFunctions" value="true" />
             <property name="checkClosures" value="true" />
+        </properties>
+    </rule>
+
+    <!-- Enforce spacing inside control structure brackets. -->
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing">
+        <properties>
+            <!-- Require 1 space after opening bracket. -->
+            <property name="requiredSpacesAfterOpen" value="1" />
+            <!-- Require 1 space before closing bracket. -->
+            <property name="requiredSpacesBeforeClose" value="1" />
+        </properties>
+    </rule>
+
+    <!-- Enforce spacing inside function declaration brackets. -->
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1" />
+            <property name="requiredSpacesAfterOpen" value="1" />
+            <property name="requiredSpacesBeforeClose" value="1" />
+        </properties>
+    </rule>
+
+    <!-- Exempt the plugin file from declaring strict_types. -->
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <exclude-pattern>seravo-plugin.php</exclude-pattern>
+    </rule>
+
+    <!-- Allow arbitrary number of spaces in comments. -->
+    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces">
+        <properties>
+            <property name="ignoreSpacesInComment" value="true"/>
         </properties>
     </rule>
 


### PR DESCRIPTION
#### What are the main changes in this PR?
- Removes legacy PHPCS rule exclusion comments. These are no longer needed with the new coding standard (909d4b4f528a1a55d4172ce28c2532c1b511816c).
- Updates the coding standard to be stricter by including new rules from the Slevomat coding standard (1af7527243af6817c497cbbb047cbb4672461e95).
- Fixes PHP syntax linting workflow by excluding the new `src/vendor` directory from being linted (46f38516ebe2af85e25d2caaa53e5198fdc9ccd9).
- Split PHP style linting to a separate workflow job so it's not ran with the full PHP version matrix (84333a06f4ac7f6a18a093272d7bb3cde5f054df).

#### Where should a reviewer start?
No changes to actual code was made. If the GitHub action tests pass, everything should be ok.