### PR TITLE
Add workflow for scanning for bugs and quality issues

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,0 +1,44 @@
+---
+name: 'Quality Assurance'
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  phpstan:
+    name: 'PHPStan'
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository
+      - name: Setup repository
+        uses: actions/checkout@v3
+
+      # Install PHP and tools necessary
+      - name: Setup PHP
+        uses: seravo/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: cs2pr, composer
+
+      # Install development dependencies
+      - name: Install development dependencies
+        run: composer install --no-interaction --no-progress
+
+      # Print PHP_CodeSniffer version
+      - run: vendor/bin/phpstan --version
+
+      # Lint PHP code style
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyze
+          --no-progress
+          -c tools/phpstan.neon
+          --error-format=checkstyle
+          --memory-limit=1G | cs2pr

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpcompatibility/php-compatibility": "^9.3",
     "slevomat/coding-standard": "^8.12",
-    "squizlabs/php_codesniffer": "^3.7"
+    "squizlabs/php_codesniffer": "^3.7",
+    "szepeviktor/phpstan-wordpress": "^1.3"
   },
   "config": {
     "sort-packages": true,

--- a/seravo-plugin.php
+++ b/seravo-plugin.php
@@ -18,9 +18,6 @@ if ( ! \defined('ABSPATH') ) {
   die('Access denied!');
 }
 
-// Use debug mode only in development
-\define('SERAVO_PLUGIN_DEBUG', false);
-
 if ( \defined('SERAVO_PLUGIN_DEBUG') && SERAVO_PLUGIN_DEBUG ) {
   \nocache_headers();
 }

--- a/tools/phpstan.neon
+++ b/tools/phpstan.neon
@@ -1,0 +1,8 @@
+parameters:
+  level: 9
+  paths:
+    - ../seravo-plugin.php
+  scanDirectories:
+    - ../src
+includes:
+  - ../vendor/szepeviktor/phpstan-wordpress/extension.neon


### PR DESCRIPTION
#### What are the main changes in this PR?
Adds workflow for running PHPStan. This workflow can later be used to run other QA tools too.

PHPStan currently only scans `seravo-plugin.php` for issues.

#### Where should a reviewer start?
No code changes. Everything should be ok if the new workflow passes in https://github.com/Seravo/seravo-plugin/actions.