### PR TITLE
Replace 'wp_date' with PHP built-in 'date'

### DIFF
--- a/src/modules/pages/upkeep.php
+++ b/src/modules/pages/upkeep.php
@@ -428,7 +428,8 @@ class Upkeep extends Toolpage {
     $options = [];
     foreach ( $version_info['PHP_SUPPORTED_VERSIONS'] as $version ) {
       $in_use = $current_version === $version;
-      $eol_time = $version_info['PHP_EOL'][$version];
+      $eol_offset = get_option('gmt_offset') * HOUR_IN_SECONDS;
+      $eol_time = $version_info['PHP_EOL'][$version] + $eol_offset;
 
       $options[$version] = array(
         'value' => $version,
@@ -438,7 +439,7 @@ class Upkeep extends Toolpage {
 
       // Show EOL time if EOL is in less than 12 months
       if ( $eol_time - $current_time < 12 * MONTH_IN_SECONDS ) {
-        $options[$version]['name'] .= ' (EOL ' . \wp_date('M j, Y', $eol_time) . ')';
+        $options[$version]['name'] .= ' (EOL ' . \date_i18n('M j, Y', $eol_time, false) . ')';
       }
     }
 


### PR DESCRIPTION
#### What are the main changes in this PR?

Replaces `wp_date` with PHP built-in function (since PHP 4) `date` because `wp_date` was introduced to WP core in version 5.3 and Seravo Plugin needs to support WP core 4.9.

##### Why are we doing this? Any context or related work?

Customer site had issues with older WP core.

#### Manual testing steps?

1. Go to upkeep page and find PHP version postbox.
2. Make sure the PHP EOL dates are the same before and after this change.