### PR TITLE
Add WP Start to site plans in Site Status

### DIFF
--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -768,6 +768,7 @@ class SiteStatus extends Toolpage {
     $plans = array(
       'demo'       => __('Demo', 'seravo'),
       'mini'       => __('WP Mini', 'seravo'),
+      'start'      => __('WP Start', 'seravo'),
       'pro'        => __('WP Pro', 'seravo'),
       'business'   => __('WP Business', 'seravo'),
       'corporate'  => __('WP Corporate', 'seravo'),


### PR DESCRIPTION
This modifies the array of site plans used on Site Status page to include the new WP Start plan.
