### PR TITLE
Add missing plans to Site Status

### DIFF
--- a/.github/workflows/gnitpick.yml
+++ b/.github/workflows/gnitpick.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
@@ -24,7 +24,7 @@ jobs:
         run: curl -O https://raw.githubusercontent.com/Seravo/gnitpick/master/gnitpick.py
 
       - name: Set up python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install PHP and tools necessary
       - name: Setup PHP
@@ -64,7 +64,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install PHP and tools necessary
       - name: Setup PHP

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # Checkout the repository
       - name: Setup repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install PHP and tools necessary
       - name: Setup PHP

--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -768,6 +768,7 @@ class SiteStatus extends Toolpage {
     $plans = array(
       'demo'       => __('Demo', 'seravo'),
       'mini'       => __('WP Mini', 'seravo'),
+      'start'      => __('WP Start', 'seravo'),
       'pro'        => __('WP Pro', 'seravo'),
       'business'   => __('WP Business', 'seravo'),
       'corporate'  => __('WP Corporate', 'seravo'),

--- a/src/modules/pages/sitestatus.php
+++ b/src/modules/pages/sitestatus.php
@@ -767,6 +767,7 @@ class SiteStatus extends Toolpage {
 
     $plans = array(
       'demo'       => __('Demo', 'seravo'),
+      'dev'       => __('WP Dev', 'seravo'),
       'mini'       => __('WP Mini', 'seravo'),
       'start'      => __('WP Start', 'seravo'),
       'pro'        => __('WP Pro', 'seravo'),

--- a/tools/PHPCodeSniffer/Standard/ruleset.xml
+++ b/tools/PHPCodeSniffer/Standard/ruleset.xml
@@ -107,7 +107,6 @@
     <!-- Enforce multiline array indentation with 2 spaces. -->
     <rule ref="Generic.Arrays.ArrayIndent">
         <properties>
-            <property name="tabIndent" value="false" />
             <property name="indent" value="2" />
         </properties>
     </rule>


### PR DESCRIPTION
#### What are the main changes in this PR?
- Add missing plan names to site status array

##### Why are we doing this? Any context or related work?
Start and dev plans show an empty string in the site status page.

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
