### PR TITLE
Fix 'Call to undefined function Seravo\rmdir_recursive()' error

### DIFF
--- a/src/lib/cruftremover.php
+++ b/src/lib/cruftremover.php
@@ -526,7 +526,7 @@ class CruftRemover {
       if ( \in_array($file, $legit_cruft_files, true) ) {
         // prevent directory traversal in case of links
         if ( is_dir($file) && !is_link($file) ) {
-          $unlink_result = rmdir_recursive($file, 0);
+          $unlink_result = self::rmdir_recursive($file, 0);
         }
         else {
           $unlink_result = unlink($file);


### PR DESCRIPTION
Add missing `self::` to rmdir_recursive() call.