### PR TITLE
Check the type of MainWP options before access

### DIFF
--- a/src/modules/thirdparty-fixes.php
+++ b/src/modules/thirdparty-fixes.php
@@ -46,7 +46,9 @@ final class ThirdPartyFixes {
    * MainWP by default keep README.html
    */
   public static function mainwp_readme( $value, $option ) {
-    $value['readme'] = false;
+    if ( is_array($value) && in_array('readme', $value)) {
+      $value['readme'] = false;
+    }
     return $value;
   }
 


### PR DESCRIPTION
It was noticed that the format of MainWP options was changed in newer versions of MainWP plugin. This caused issues when SP tried to override the value for README file removal, as config value was no longer treated as array.

Closes: SP-13

#### What are the main changes in this PR?

##### Why are we doing this? Any context or related work?
If there is an issue related to this PR, please link it here for context.

#### Where should a reviewer start?

#### Manual testing steps?

#### Screenshots
